### PR TITLE
Issue 23 use aws cli image

### DIFF
--- a/workspaces/templates-lib/packages/utils-aws-cli/src/utilsAwsCli.ts
+++ b/workspaces/templates-lib/packages/utils-aws-cli/src/utilsAwsCli.ts
@@ -57,7 +57,6 @@ export const execWithDocker = (params: AWSExecParams): string => {
     'Cannot execute AWS cli command since working directory does not exist: aws ' +
       params.command
   );
-  console.log('exec aws cli');
   return exec(
     'docker run --rm ' +
       awsUserConfig +

--- a/workspaces/templates-lib/packages/utils-aws-cli/src/utilsAwsCli.ts
+++ b/workspaces/templates-lib/packages/utils-aws-cli/src/utilsAwsCli.ts
@@ -12,6 +12,7 @@ import {
   imageGoldstackBuild,
   hasDocker,
   assertDocker,
+  imageAWSCli,
 } from '@goldstack/utils-docker';
 
 export const assertAwsCli = (): void => {
@@ -56,11 +57,13 @@ export const execWithDocker = (params: AWSExecParams): string => {
     'Cannot execute AWS cli command since working directory does not exist: aws ' +
       params.command
   );
+  console.log('exec aws cli');
   return exec(
     'docker run --rm ' +
       awsUserConfig +
       `-v "${mountDir}":/app ` +
-      ` ${imageGoldstackBuild()} aws ${params.command}`,
+      '-w /app ' +
+      ` ${imageAWSCli()} ${params.command}`,
     params.options
   );
 };

--- a/workspaces/templates-lib/packages/utils-docker/src/utilsDocker.ts
+++ b/workspaces/templates-lib/packages/utils-docker/src/utilsDocker.ts
@@ -148,3 +148,5 @@ export const imageGoldstackBuild = (): string =>
   'goldstack/goldstack-docker-build:0.1.3';
 
 export const imageTerraform = (): string => 'hashicorp/terraform:0.12.26';
+
+export const imageAWSCli = (): string => 'amazon/aws-cli:2.4.6';


### PR DESCRIPTION
For #23, use the [AWS CLI Docker Image](https://hub.docker.com/r/amazon/aws-cli) instead of the [Goldstack Docker Build](https://hub.docker.com/r/goldstack/goldstack-docker-build) image, to reduce size of images that needs to be downloaded.

