### PR TITLE
Adding support specific Terraform Version per Template

### DIFF
--- a/workspaces/templates-lib/packages/template-docker-image-aws/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-docker-image-aws/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -70,6 +73,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-docker-image-aws/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-docker-image-aws/schemas/deployment.schema.json
@@ -78,7 +78,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-docker-image-aws/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-docker-image-aws/schemas/package.schema.json
@@ -151,7 +151,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-docker-image-aws/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-docker-image-aws/schemas/package.schema.json
@@ -90,6 +90,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -143,6 +146,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-email-send/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-email-send/schemas/deployment.schema.json
@@ -90,7 +90,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-email-send/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-email-send/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -82,6 +85,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-email-send/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-email-send/schemas/package.schema.json
@@ -154,7 +154,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-email-send/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-email-send/schemas/package.schema.json
@@ -81,6 +81,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -146,6 +149,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-lambda-api/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-lambda-api/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -122,6 +125,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-lambda-api/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-lambda-api/schemas/deployment.schema.json
@@ -130,7 +130,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-lambda-api/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-lambda-api/schemas/package.schema.json
@@ -85,6 +85,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -190,6 +193,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-lambda-api/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-lambda-api/schemas/package.schema.json
@@ -198,7 +198,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-lambda-express/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-lambda-express/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -97,6 +100,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-lambda-express/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-lambda-express/schemas/deployment.schema.json
@@ -105,7 +105,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-lambda-express/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-lambda-express/schemas/package.schema.json
@@ -173,7 +173,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-lambda-express/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-lambda-express/schemas/package.schema.json
@@ -85,6 +85,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -165,6 +168,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-nextjs/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-nextjs/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -133,6 +136,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-nextjs/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-nextjs/schemas/deployment.schema.json
@@ -141,7 +141,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-nextjs/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-nextjs/schemas/package.schema.json
@@ -81,6 +81,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -197,6 +200,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-nextjs/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-nextjs/schemas/package.schema.json
@@ -205,7 +205,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-s3/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-s3/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -68,6 +71,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-s3/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-s3/schemas/deployment.schema.json
@@ -76,7 +76,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-s3/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-s3/schemas/package.schema.json
@@ -140,7 +140,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-s3/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-s3/schemas/package.schema.json
@@ -81,6 +81,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -132,6 +135,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-static-website-aws/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-static-website-aws/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -103,6 +106,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/template-static-website-aws/schemas/deployment.schema.json
+++ b/workspaces/templates-lib/packages/template-static-website-aws/schemas/deployment.schema.json
@@ -111,7 +111,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-static-website-aws/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-static-website-aws/schemas/package.schema.json
@@ -170,7 +170,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-lib/packages/template-static-website-aws/schemas/package.schema.json
+++ b/workspaces/templates-lib/packages/template-static-website-aws/schemas/package.schema.json
@@ -76,6 +76,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -162,6 +165,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-lib/packages/utils-docker/src/utilsDocker.ts
+++ b/workspaces/templates-lib/packages/utils-docker/src/utilsDocker.ts
@@ -155,6 +155,21 @@ export const imageTerraform = (version?: string): string => {
     return 'hashicorp/terraform:0.13.7';
   }
 
+  if (version === '0.14') {
+    return 'hashicorp/terraform:0.14.11';
+  }
+
+  if (version === '0.15') {
+    return 'hashicorp/terraform:0.15.5';
+  }
+
+  if (version === '1.0') {
+    return 'hashicorp/terraform:1.0.10';
+  }
+
+  if (version === '1.1') {
+    return 'hashicorp/terraform:1.1.3';
+  }
   throw new Error('Unknown Terraform version ' + version);
 };
 

--- a/workspaces/templates-lib/packages/utils-docker/src/utilsDocker.ts
+++ b/workspaces/templates-lib/packages/utils-docker/src/utilsDocker.ts
@@ -146,6 +146,16 @@ export const renderHostEnvironmentVariables = (): string => {
 
 export const imageNodeYarn = (): string => 'node:12.22-alpine';
 
-export const imageTerraform = (): string => 'hashicorp/terraform:0.12.26';
+export const imageTerraform = (version?: string): string => {
+  if (!version || version === '0.12') {
+    return 'hashicorp/terraform:0.12.26';
+  }
+
+  if (version === '0.13') {
+    return 'hashicorp/terraform:0.13.7';
+  }
+
+  throw new Error('Unknown Terraform version ' + version);
+};
 
 export const imageAWSCli = (): string => 'amazon/aws-cli:2.4.6';

--- a/workspaces/templates-lib/packages/utils-terraform/src/schemas/configSchema.json
+++ b/workspaces/templates-lib/packages/utils-terraform/src/schemas/configSchema.json
@@ -60,7 +60,11 @@
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "type": "string"
     }

--- a/workspaces/templates-lib/packages/utils-terraform/src/schemas/configSchema.json
+++ b/workspaces/templates-lib/packages/utils-terraform/src/schemas/configSchema.json
@@ -26,6 +26,9 @@
         },
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
+        },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
         }
       },
       "required": [
@@ -51,6 +54,15 @@
       },
       "title": "Terraform Variables",
       "type": "array"
+    },
+    "TerraformVersion": {
+      "default": "0.12",
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "type": "string"
     }
   }
 }

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformBuild.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformBuild.ts
@@ -4,6 +4,7 @@ import { tf } from './terraformCli';
 import {
   TerraformDeployment,
   TerraformVariables,
+  TerraformVersion,
 } from './types/utilsTerraformConfig';
 import { CloudProvider } from './cloudProvider';
 import { cd, read, pwd } from '@goldstack/utils-sh';
@@ -337,20 +338,65 @@ export class TerraformBuild {
     cd('../..');
   };
 
+  private performUpgrade = (
+    deploymentName: string,
+    targetVersion: TerraformVersion
+  ) => {
+    const provider = this.provider;
+    if (targetVersion === '0.13') {
+      cd('./infra/aws');
+      const upgradeRes = tf(`${targetVersion}upgrade`, {
+        version: targetVersion,
+        provider,
+        options: ['-yes'],
+      });
+      if (upgradeRes.indexOf('Upgrade complete!') === -1) {
+        throw new Error('Upgrade of Terraform version not successful.');
+      }
+      cd('../..');
+    }
+    const packageConfig = readPackageConfig();
+    const deploymentInConfig = packageConfig.deployments.find(
+      (e) => e.name === deploymentName
+    );
+    assert(deploymentInConfig);
+    deploymentInConfig.tfVersion = targetVersion;
+    writePackageConfig(packageConfig);
+    this.init([deploymentName]);
+    console.log(
+      `Version upgraded to ${targetVersion}. Please run deployment to upgrade remote state before further upgrades.`
+    );
+  };
+
   upgrade = (args: string[]): void => {
     const deployment = getDeployment(args);
     const version = deployment.tfVersion || '0.12';
-    const newVersion = args[0];
-    const provider = this.provider;
+    const newVersion = args[1];
     if (version === newVersion) {
       console.log('Already on version', newVersion);
       return;
     }
     if (version === '0.12' && newVersion === '0.13') {
-      tf('0.12upgrade', { version: '0.13', provider });
+      this.performUpgrade(args[0], '0.13');
       return;
     }
 
+    if (version === '0.13' && newVersion === '0.14') {
+      this.performUpgrade(args[0], '0.14');
+      return;
+    }
+    if (version === '0.14' && newVersion === '0.15') {
+      this.performUpgrade(args[0], '0.15');
+      return;
+    }
+    if (version === '0.15' && newVersion === '1.0') {
+      this.performUpgrade(args[0], '1.0');
+      return;
+    }
+    if (version === '1.0' && newVersion === '1.1') {
+      this.performUpgrade(args[0], '1.1');
+      return;
+    }
     throw new Error(
       `Version upgrade not supported: from [${version}] to [${newVersion}]. Currently only 0.12 -> 0.13 is supported.`
     );

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.spec.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.spec.ts
@@ -5,11 +5,21 @@ import MockCloudProvider from './MockCloudProvider';
 import path from 'path';
 
 describe('Terraform CLI', () => {
-  it('Should accept folder with spaces', async () => {
-    const testDir = './goldstackLocal/cli-folder-w-space/My Dir';
+  it('Should accept folder with spaces (v0.12)', async () => {
+    const testDir = './goldstackLocal/cli-folder-w-space/0.12/My Dir';
     mkdir('-p', testDir);
     tf('init', {
       dir: path.resolve(testDir),
+      version: '0.12',
+      provider: new MockCloudProvider(),
+    });
+  });
+  it('Should accept folder with spaces (v0.13', async () => {
+    const testDir = './goldstackLocal/cli-folder-w-space/0.13/My Dir';
+    mkdir('-p', testDir);
+    tf('init', {
+      dir: path.resolve(testDir),
+      version: '0.13',
       provider: new MockCloudProvider(),
     });
   });

--- a/workspaces/templates-lib/packages/utils-terraform/src/types/utilsTerraformConfig.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/types/utilsTerraformConfig.ts
@@ -18,6 +18,15 @@ export type TerraformVariable = string;
 export type TerraformStateKey = string;
 
 /**
+ * Version of Terraform that the remote state for this deployment was created with.
+ *
+ * Go to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.
+ *
+ * @default '0.12'
+ */
+export type TerraformVersion = '0.12' | '0.13';
+
+/**
  * Define which of the deployment variables will be made available for terraform.
  *
  * @title Terraform Variables
@@ -27,4 +36,5 @@ export type TerraformVariables = TerraformVariable[];
 export interface TerraformDeployment extends Deployment {
   terraformVariables?: TerraformVariables;
   tfStateKey?: TerraformStateKey;
+  tfVersion?: TerraformVersion;
 }

--- a/workspaces/templates-lib/packages/utils-terraform/src/types/utilsTerraformConfig.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/types/utilsTerraformConfig.ts
@@ -24,7 +24,13 @@ export type TerraformStateKey = string;
  *
  * @default '0.12'
  */
-export type TerraformVersion = '0.12' | '0.13';
+export type TerraformVersion =
+  | '0.12'
+  | '0.13'
+  | '0.14'
+  | '0.15'
+  | '1.0'
+  | '1.1';
 
 /**
  * Define which of the deployment variables will be made available for terraform.

--- a/workspaces/templates-lib/packages/utils-terraform/src/utilsTerraform.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/utilsTerraform.ts
@@ -58,6 +58,18 @@ export const infraCommands = (): any => {
             type: 'boolean',
           });
         }
+      )
+      .command(
+        'upgrade <deployment> <targetVersion>',
+        'Upgrades Terraform version to a new target version (experimental)',
+        (yargs) => {
+          return deploymentPositional(yargs).positional('targetVersion', {
+            type: 'string',
+            description:
+              'DANGER: If provided, confirmation for deleting infrastructure resources will be skipped.',
+            demandOption: true,
+          });
+        }
       );
   };
 };
@@ -92,6 +104,11 @@ export const terraformCli = (
 
   if (operation === 'destroy') {
     build.destroy(opArgs);
+    return;
+  }
+
+  if (operation === 'upgrade') {
+    build.upgrade(opArgs);
     return;
   }
 

--- a/workspaces/templates-management/packages/project-repository-bucket/schemas/deployment.schema.json
+++ b/workspaces/templates-management/packages/project-repository-bucket/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -68,6 +71,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-management/packages/project-repository-bucket/schemas/deployment.schema.json
+++ b/workspaces/templates-management/packages/project-repository-bucket/schemas/deployment.schema.json
@@ -76,7 +76,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-management/packages/project-repository-bucket/schemas/package.schema.json
+++ b/workspaces/templates-management/packages/project-repository-bucket/schemas/package.schema.json
@@ -140,7 +140,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-management/packages/project-repository-bucket/schemas/package.schema.json
+++ b/workspaces/templates-management/packages/project-repository-bucket/schemas/package.schema.json
@@ -81,6 +81,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -132,6 +135,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-management/packages/template-repository-bucket/schemas/deployment.schema.json
+++ b/workspaces/templates-management/packages/template-repository-bucket/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -68,6 +71,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates-management/packages/template-repository-bucket/schemas/deployment.schema.json
+++ b/workspaces/templates-management/packages/template-repository-bucket/schemas/deployment.schema.json
@@ -76,7 +76,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-management/packages/template-repository-bucket/schemas/package.schema.json
+++ b/workspaces/templates-management/packages/template-repository-bucket/schemas/package.schema.json
@@ -140,7 +140,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates-management/packages/template-repository-bucket/schemas/package.schema.json
+++ b/workspaces/templates-management/packages/template-repository-bucket/schemas/package.schema.json
@@ -81,6 +81,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -132,6 +135,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/app-nextjs-bootstrap/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -133,6 +136,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/app-nextjs-bootstrap/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/schemas/deployment.schema.json
@@ -141,7 +141,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/app-nextjs-bootstrap/schemas/package.schema.json
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/schemas/package.schema.json
@@ -81,6 +81,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -197,6 +200,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/app-nextjs-bootstrap/schemas/package.schema.json
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/schemas/package.schema.json
@@ -205,7 +205,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/app-nextjs/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/app-nextjs/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -133,6 +136,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/app-nextjs/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/app-nextjs/schemas/deployment.schema.json
@@ -141,7 +141,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/app-nextjs/schemas/package.schema.json
+++ b/workspaces/templates/packages/app-nextjs/schemas/package.schema.json
@@ -81,6 +81,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -197,6 +200,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/app-nextjs/schemas/package.schema.json
+++ b/workspaces/templates/packages/app-nextjs/schemas/package.schema.json
@@ -205,7 +205,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/docker-image-aws/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/docker-image-aws/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -70,6 +73,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/docker-image-aws/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/docker-image-aws/schemas/deployment.schema.json
@@ -78,7 +78,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/docker-image-aws/schemas/package.schema.json
+++ b/workspaces/templates/packages/docker-image-aws/schemas/package.schema.json
@@ -151,7 +151,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/docker-image-aws/schemas/package.schema.json
+++ b/workspaces/templates/packages/docker-image-aws/schemas/package.schema.json
@@ -90,6 +90,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -143,6 +146,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/email-send/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/email-send/schemas/deployment.schema.json
@@ -90,7 +90,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/email-send/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/email-send/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -82,6 +85,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/email-send/schemas/package.schema.json
+++ b/workspaces/templates/packages/email-send/schemas/package.schema.json
@@ -154,7 +154,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/email-send/schemas/package.schema.json
+++ b/workspaces/templates/packages/email-send/schemas/package.schema.json
@@ -81,6 +81,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -146,6 +149,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/lambda-api/goldstack.json
+++ b/workspaces/templates/packages/lambda-api/goldstack.json
@@ -45,7 +45,8 @@
           }
         }
       },
-      "tfStateKey": "lambda-api-template-prod-fbec3992bfc4f00aa381.tfstate"
+      "tfStateKey": "lambda-api-template-prod-fbec3992bfc4f00aa381.tfstate",
+      "tfVersion": "1.1"
     }
   ]
 }

--- a/workspaces/templates/packages/lambda-api/infra/aws/.terraform.lock.hcl
+++ b/workspaces/templates/packages/lambda-api/infra/aws/.terraform.lock.hcl
@@ -1,0 +1,58 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.1.0"
+  constraints = "2.1.0"
+  hashes = [
+    "h1:f3WXKM/FBu5EMY6j2BGt982hzVMNicrxTyEAz5EsrOU=",
+    "zh:033279ecbf60f565303222e9a6d26b50fdebe43aa1c6e8f565f09bb64d67c3fd",
+    "zh:0af998e42eb421c92e87202df5bfee436b3cfe553214394f08d786c72a9e3f70",
+    "zh:1183b661c692f38409a61eefb5d412167c246fcd9e49d4d61d6d910012d206ba",
+    "zh:5febb66f4a8207117f71dcd460fb9c81d3afb7b600b5e598cf517cf6e27cf4b2",
+    "zh:66135ce46d29d0ccf0e3b6a119423754ca334dbf4266bc989cce5b0b667b5fde",
+    "zh:6b9dc1a4f0a680bb650a7191784927f99675a8c8dd3c155ba821185f630db604",
+    "zh:91e249482c016ecf6bf8b83849964005cd2d0b4396688419cd1752809b46b23e",
+    "zh:a6a2e5f2f010c511e66174cb84ea18899e8bcfc1354c4b9fed972fdb131ffffc",
+    "zh:bb1f6abc76552a883732caff897ff7b07a91977a9b4bb97915f6aac54116bb65",
+    "zh:f05a9a63607f85719fde705f58d82ee16fa67f9158a5c3424c0216507631eddf",
+    "zh:fc603a05a06814387ffa4a054d1baee8ea6b5ab32c53cb73e90a5bf9a2616777",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.71.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:wnTd0krep3mqRz650U7TSv/tCkA0LoXKe0QFlnsg/7Q=",
+    "zh:173134d8861a33ed60a48942ad2b96b9d06e85c506d7f927bead47a28f4ebdd2",
+    "zh:2996c8e96930f526f1761e99d14c0b18d83e287b1362aa2fa1444cf848ece613",
+    "zh:43903da1e0a809a1fb5832e957dbe2321b86630d6bfdd8b47728647a72fd912d",
+    "zh:43e71fd8924e7f7b56a0b2a82e29edf07c53c2b41ee7bb442a2f1c27e03e86ae",
+    "zh:4f4c73711f64a3ff85f88bf6b2594e5431d996b7a59041ff6cbc352f069fc122",
+    "zh:5045241b8695ffbd0730bdcd91393b10ffd0cfbeaad6254036e42ead6687d8fd",
+    "zh:6a8811a0fb1035c09aebf1f9b15295523a9a7a2627fd783f50c6168a82e192dd",
+    "zh:8d273c04d7a8c36d4366329adf041c480a0f1be10a7269269c88413300aebdb8",
+    "zh:b90505897ae4943a74de2b88b6a9e7d97bf6dc325a0222235996580edff28656",
+    "zh:ea5e422942ac6fc958229d27d4381c89d21d70c5c2c67a6c06ff357bcded76f6",
+    "zh:f1536d7ff2d3bfd668e3ac33d8956b4f988f87fdfdcc371c7d94b98d5dba53e2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/workspaces/templates/packages/lambda-api/infra/aws/providers.tf
+++ b/workspaces/templates/packages/lambda-api/infra/aws/providers.tf
@@ -1,10 +1,25 @@
+terraform {
+  required_providers {
+    archive = {
+      source = "hashicorp/archive"
+      version = "2.1.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
 provider "aws" {
-  version                 = "3.37.0"
   region                  = var.aws_region
 }
 
 provider "archive" {
-  version = "2.1.0"
 }
 
 terraform {

--- a/workspaces/templates/packages/lambda-api/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/lambda-api/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -122,6 +125,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/lambda-api/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/lambda-api/schemas/deployment.schema.json
@@ -130,7 +130,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/lambda-api/schemas/package.schema.json
+++ b/workspaces/templates/packages/lambda-api/schemas/package.schema.json
@@ -85,6 +85,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -190,6 +193,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/lambda-api/schemas/package.schema.json
+++ b/workspaces/templates/packages/lambda-api/schemas/package.schema.json
@@ -198,7 +198,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/lambda-express/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/lambda-express/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -97,6 +100,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/lambda-express/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/lambda-express/schemas/deployment.schema.json
@@ -105,7 +105,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/lambda-express/schemas/package.schema.json
+++ b/workspaces/templates/packages/lambda-express/schemas/package.schema.json
@@ -173,7 +173,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/lambda-express/schemas/package.schema.json
+++ b/workspaces/templates/packages/lambda-express/schemas/package.schema.json
@@ -85,6 +85,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -165,6 +168,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/s3/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/s3/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -68,6 +71,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/s3/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/s3/schemas/deployment.schema.json
@@ -76,7 +76,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/s3/schemas/package.schema.json
+++ b/workspaces/templates/packages/s3/schemas/package.schema.json
@@ -140,7 +140,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/s3/schemas/package.schema.json
+++ b/workspaces/templates/packages/s3/schemas/package.schema.json
@@ -81,6 +81,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -132,6 +135,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/static-website-aws/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/static-website-aws/schemas/deployment.schema.json
@@ -17,6 +17,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -103,6 +106,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",

--- a/workspaces/templates/packages/static-website-aws/schemas/deployment.schema.json
+++ b/workspaces/templates/packages/static-website-aws/schemas/deployment.schema.json
@@ -111,7 +111,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/static-website-aws/schemas/package.schema.json
+++ b/workspaces/templates/packages/static-website-aws/schemas/package.schema.json
@@ -170,7 +170,11 @@
       "type": "string",
       "enum": [
         "0.12",
-        "0.13"
+        "0.13",
+        "0.14",
+        "0.15",
+        "1.0",
+        "1.1"
       ],
       "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
       "default": "0.12"

--- a/workspaces/templates/packages/static-website-aws/schemas/package.schema.json
+++ b/workspaces/templates/packages/static-website-aws/schemas/package.schema.json
@@ -76,6 +76,9 @@
         "tfStateKey": {
           "$ref": "#/definitions/TerraformStateKey"
         },
+        "tfVersion": {
+          "$ref": "#/definitions/TerraformVersion"
+        },
         "awsRegion": {
           "$ref": "#/definitions/AWSDeploymentRegion"
         },
@@ -162,6 +165,15 @@
       "type": "string",
       "description": "Key used for Terraform state persisted in Terraform state bucket.\n\nWill be auto-generated upon first deployment if not provided.",
       "title": "Terraform State Key"
+    },
+    "TerraformVersion": {
+      "type": "string",
+      "enum": [
+        "0.12",
+        "0.13"
+      ],
+      "description": "Version of Terraform that the remote state for this deployment was created with.\n\nGo to the next version using `yarn infra upgrade [deploymentName] [targetVersion]`. Note that Terraform versions should only be increased one at a time, so for instance you can go from v0.12 to v0.13 but not from v0.12 to v0.14.",
+      "default": "0.12"
     },
     "AWSDeploymentRegion": {
       "type": "string",


### PR DESCRIPTION
Since there are frequent updates to Terraform it is not feasiable to keep all tempaltes aligned to the same version. Thus Goldstack can now support different Terraform versions for different templates. Currently all versions from 0.13 to 1.1 are supported.

Upgrade between versions can be performed with the `yarn infra upgrade [deployment] [targetVersion]` command. Upgrades should be performed manually and only one upgrade at a time to ensure remote state remains compatible.