### PR TITLE
Ensuring correct TF version linked for templates

### DIFF
--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformBuild.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformBuild.ts
@@ -220,7 +220,7 @@ export class TerraformBuild {
 
   init = (args: string[]): void => {
     const deployment = getDeployment(args);
-    const version = deployment.tfVersion || '0.12';
+    const version = this.getTfVersion(args);
     const backendConfig = this.getTfStateVariables(deployment);
     cd('./infra/aws');
     const provider = this.provider;
@@ -252,7 +252,7 @@ export class TerraformBuild {
 
   plan = (args: string[]): void => {
     const deployment = getDeployment(args);
-    const version = deployment.tfVersion || '0.12';
+    const version = this.getTfVersion(args);
     const backendConfig = this.getTfStateVariables(deployment);
     cd('./infra/aws');
     const provider = this.provider;
@@ -285,7 +285,7 @@ export class TerraformBuild {
 
   apply = (args: string[]): void => {
     const deployment = getDeployment(args);
-    const version = deployment.tfVersion || '0.12';
+    const version = this.getTfVersion(args);
     const backendConfig = this.getTfStateVariables(deployment);
     cd('./infra/aws');
     const provider = this.provider;
@@ -321,7 +321,7 @@ export class TerraformBuild {
 
   destroy = (args: string[]): void => {
     const deployment = getDeployment(args);
-    const version = deployment.tfVersion || '0.12';
+    const version = this.getTfVersion(args);
     const backendConfig = this.getTfStateVariables(deployment);
     cd('./infra/aws');
     const ciConfirmed = args.find((str) => str === '-y');

--- a/workspaces/templates/packages/app-nextjs/build.json
+++ b/workspaces/templates/packages/app-nextjs/build.json
@@ -1,6 +1,6 @@
 {
   "include": [
-    "infra/aws/",
+    "infra/",
     "src/",
     "schemas/",
     "scripts/",

--- a/workspaces/templates/packages/docker-image-aws/build.json
+++ b/workspaces/templates/packages/docker-image-aws/build.json
@@ -1,6 +1,6 @@
 {
   "include": [
-    "infra/aws/",
+    "infra/",
     "src/",
     "schemas/",
     "scripts",

--- a/workspaces/templates/packages/lambda-api/build.json
+++ b/workspaces/templates/packages/lambda-api/build.json
@@ -1,6 +1,6 @@
 {
   "include": [
-    "infra/aws/",
+    "infra/",
     "docs/",
     "scripts/",
     "src/",

--- a/workspaces/templates/packages/lambda-api/goldstack.json
+++ b/workspaces/templates/packages/lambda-api/goldstack.json
@@ -45,7 +45,6 @@
           }
         }
       },
-      "tfVersion": "1.1",
       "tfStateKey": "lambda-api-template-prod-9d3d0e0a2d6a51e5308a.tfstate"
     }
   ]

--- a/workspaces/templates/packages/lambda-express/build.json
+++ b/workspaces/templates/packages/lambda-express/build.json
@@ -1,6 +1,6 @@
 {
   "include": [
-    "infra/aws/",
+    "infra/",
     "docs/",
     "scripts/",
     "src/",

--- a/workspaces/templates/packages/static-website-aws/build.json
+++ b/workspaces/templates/packages/static-website-aws/build.json
@@ -1,6 +1,6 @@
 {
   "include": [
-    "infra/aws/",
+    "infra/",
     "docs/",
     "schemas/",
     "scripts/",


### PR DESCRIPTION
Fixes #54

TF version can now be determined from `./infra/tfVersion.json` file.