### PR TITLE
Ensuring format-check works successfully for newly generated projects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,6 +182,11 @@ jobs:
           git diff-index --quiet HEAD || git commit -m "GitHub actions build (ci_skip) (trigger_template_deploy_dev)"
           git status
 
+      - name: Linting and prettier
+        run: |
+          yarn format
+          yarn lint-fix
+
       - name: Push changes
         if: github.ref == 'refs/heads/master'
         uses: ad-m/github-push-action@65392840bda2e774394d5cd38ca33e5918aec2d3

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,5 +10,6 @@ node_modules/
 *.tfstate
 *.tfstate.backup
 .pnp.js
+.pnp.cjs
 *.json
 .yarn/


### PR DESCRIPTION
For #107 

- adding `.pnp.cjs` to files to ignore for prettier (since it is a generated file)
- Ensuring that prettier runs before files are pushed from the build