### PR TITLE
Ensure that prettier and eslint run before commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,17 +175,17 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: echo "$(date +'%Y-%m-%dT%H:%M:%S')" >> build_dev_timestamp
 
+      - name: Linting and prettier
+        run: |
+          yarn format
+          yarn lint-fix
+
       - name: Commit latest build info
         if: github.ref == 'refs/heads/master'
         run: |
           git add .
           git diff-index --quiet HEAD || git commit -m "GitHub actions build (ci_skip) (trigger_template_deploy_dev)"
           git status
-
-      - name: Linting and prettier
-        run: |
-          yarn format
-          yarn lint-fix
 
       - name: Push changes
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
For #107, there is still a prettier warning after checking out the project. This was caused by Prettier and ESLint being run after the commit of changes made during the build process.