### PR TITLE
Implementing `yarn infra terraform` command and adding documentation

### DIFF
--- a/workspaces/docs/docs/templates/shared/infrastructure.md
+++ b/workspaces/docs/docs/templates/shared/infrastructure.md
@@ -33,6 +33,8 @@ Infrastructure commands for this template can be run using `yarn`. There are fou
 - `yarn infra plan`: For running [Terraform plan](https://www.terraform.io/docs/commands/plan.html).
 - `yarn infra apply`: For running [Terraform apply](https://www.terraform.io/docs/commands/apply.html).
 - `yarn infra destroy`: For destroying all infrastructure using [Terraform destroy](https://www.terraform.io/docs/commands/destroy.html).
+- `yarn infra upgrade`: For upgrading the Terraform versions (supported by the template). To upgrade to an arbitrary version, use `yarn infra terraform`.
+- `yarn infra terraform`: For running arbitrary [Terraform commands](https://www.terraform.io/cli/commands).
 
 For each command, the deployment they should be applied to must be specified.
 
@@ -47,6 +49,25 @@ yarn infra up dev
 ```
 
 Generally you will only need to run `yarn infra up`. However, if you are familiar with Terraform and want more fine-grained control over the deployment of your infrastructure, you can also use the other commands as required.
+
+Note that for running `yarn infra terraform`, you will need to specify which command line arguments you want to provide to Terraform. By default, no extra arguments are provided:
+
+```bash
+yarn infra terraform [deployment] plan
+```
+
+If extra arguments are needed, such as variables, you can use the `--inject-variables` option, such as for running `terraform plan`:
+
+```bash
+yarn infra terraform [deployment] --inject-variables plan
+```
+
+If you want to interact with the remote backend, you can also provide the `--inject-backend-config` option, such as for running `terraform init`:
+
+```bash
+yarn infra terraform [deployment] --inject-backend-config init
+```
+
 
 ### Customizing Terraform
 

--- a/workspaces/templates-lib/packages/template-docker-image-aws/src/infraAwsDockerImage.ts
+++ b/workspaces/templates-lib/packages/template-docker-image-aws/src/infraAwsDockerImage.ts
@@ -103,7 +103,7 @@ export const infraAwsDockerImageCli = async (
 ): Promise<void> => {
   if (args.length < 1) {
     throw new Error(
-      'Please provide the operation in the arguments: "init", "plan", "apply", "deploy", "destroy".'
+      'Please provide the operation in the arguments: "up", "init", "plan", "apply", "deploy", "destroy", "upgrade", "terraform".'
     );
   }
   const [operation] = args;

--- a/workspaces/templates-lib/packages/template-static-website-aws/src/infraAwsStaticWebsite.ts
+++ b/workspaces/templates-lib/packages/template-static-website-aws/src/infraAwsStaticWebsite.ts
@@ -52,7 +52,7 @@ export const infraAwsStaticWebsiteCli = async (
 ): Promise<void> => {
   if (args.length < 1) {
     fatal(
-      'Please provide the operation in the arguments: "init", "plan", "apply", "deploy", "destroy".'
+      'Please provide the operation in the arguments: "up", "init", "plan", "apply", "deploy", "destroy", "upgrade", "terraform".'
     );
     throw new Error();
   }

--- a/workspaces/templates-lib/packages/utils-package/src/utilsPackage.ts
+++ b/workspaces/templates-lib/packages/utils-package/src/utilsPackage.ts
@@ -58,7 +58,7 @@ export const buildCli = (params: BuildCliParams): Argv<any> => {
     .scriptName('template')
     .usage('$0 <infra|deploy>')
     .command(
-      'infra <up|down|init|plan|apply|destroy> <deployment>',
+      'infra <up|down|init|plan|apply|destroy|upgrade|terraform> <deployment>',
       'Manage infrastructure for deployment',
       params.infraCommands
     )

--- a/workspaces/templates-lib/packages/utils-sh/src/utilsSh.ts
+++ b/workspaces/templates-lib/packages/utils-sh/src/utilsSh.ts
@@ -1,4 +1,4 @@
-import { execSync, exec as processAsync } from 'child_process';
+import { execSync, execFileSync, exec as processAsync } from 'child_process';
 import fs from 'fs';
 import ncp from 'ncp';
 
@@ -262,6 +262,29 @@ const exec = (cmd: string, params?: ExecParams): string => {
   }
 };
 
+const execSafe = (
+  file: string,
+  args: string[],
+  params?: ExecParams
+): string => {
+  try {
+    const res = execFileSync(file, args);
+    if (!params?.silent) {
+      console.log(res.toString());
+    }
+    return res.toString();
+  } catch (e) {
+    console.error('Command failed:', file, args);
+    if (e.stderr) {
+      console.error(e.stderr.toString());
+    }
+    if (e.stdout) {
+      console.log(e.stdout.toString());
+    }
+    throw e;
+  }
+};
+
 export const execAsync = async (
   cmd: string,
   params?: ExecParams
@@ -303,4 +326,4 @@ const commandExists = (command: string): boolean => {
   return res !== null;
 };
 
-export { exec, pwd, read, write, cd, globSync, commandExists };
+export { exec, execSafe, pwd, read, write, cd, globSync, commandExists };

--- a/workspaces/templates-lib/packages/utils-terraform/src/utilsTerraform.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/utilsTerraform.ts
@@ -70,6 +70,26 @@ export const infraCommands = (): any => {
             demandOption: true,
           });
         }
+      )
+      .command(
+        'terraform <deployment> [command..]',
+        'Runs an arbitrary Terraform CLI command',
+        (yargs) => {
+          return deploymentPositional(yargs)
+            .option('inject-variables', {
+              description: 'Injects variables into the Terraform CLI command.',
+              default: false,
+              type: 'boolean',
+              demandOption: false,
+            })
+            .option('inject-backend-config', {
+              description:
+                'Injects backend config into the Terraform CLI command.',
+              default: false,
+              type: 'boolean',
+              demandOption: false,
+            });
+        }
       );
   };
 };
@@ -109,6 +129,10 @@ export const terraformCli = (
 
   if (operation === 'upgrade') {
     build.upgrade(opArgs);
+    return;
+  }
+  if (operation === 'terraform') {
+    build.terraform(opArgs);
     return;
   }
 


### PR DESCRIPTION
Implemented first version for #101 

- Can run arbitrary Terraform commands through the command `yarn infra terraform <deployment> ...command`
- Can inject variables and backend configuration
- Provided basic configuration