### PR TITLE
Resolving errors with template build; reverting to legacy way of executing command

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -1,6 +1,4 @@
-![Build status](https://img.shields.io/github/workflow/status/goldstack/goldstack/Build,%20Test%20and%20Library%20Publish/master)
-
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/6cc586e39fca47a5b7bd64c5d3e1b563)](https://www.codacy.com/gh/goldstack/goldstack/dashboard?utm_source=github.com&utm_medium=referral&utm_content=goldstack/goldstack&utm_campaign=Badge_Grade)
+![Build status](https://img.shields.io/github/workflow/status/goldstack/goldstack/Build,%20Test%20and%20Library%20Publish/master) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/6cc586e39fca47a5b7bd64c5d3e1b563)](https://www.codacy.com/gh/goldstack/goldstack/dashboard?utm_source=github.com&utm_medium=referral&utm_content=goldstack/goldstack&utm_campaign=Badge_Grade)
 
 # Goldstack - JavaScript Project Builder 💖
 

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -60,24 +60,16 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
   if (options.workspace) {
     workspaceEnvVariable = `-e TF_WORKSPACE=${options.workspace}`;
   }
+  const cmd3 =
+    `docker run --rm -v "${options.dir}":/app ` +
+    ` ${options.provider.generateEnvVariableString()} ${workspaceEnvVariable} ` +
+    '-w /app ' +
+    `${imageTerraform(options.version)} ${cmd} ` +
+    ` ${renderBackendConfig(options.backendConfig || [])} ` +
+    ` ${renderVariables(options.variables || [])} ` +
+    ` ${options.options?.join(' ') || ''} `;
 
-  const args = [
-    'run',
-    '--rm',
-    '-v',
-    `${options.dir}:/app`,
-    ...options.provider.generateEnvVariableString().split(' '),
-    workspaceEnvVariable,
-    '-w',
-    '/app',
-    imageTerraform(options.version),
-    ...cmd.split(' '),
-    renderBackendConfig(options.backendConfig || []),
-    renderVariables(options.variables || []),
-    ...(options.options ?? []),
-  ].filter((o) => o);
-
-  return execSafe('docker', args, { silent: options.silent });
+  return exec(cmd3, { silent: options.silent });
 };
 
 export const assertTerraform = (): void => {


### PR DESCRIPTION
For #101 - reverting back to use the `exec` command. I think the issue here was that not all arguments where passed to Docker in the required way. I tried to split the generated variables to provide each as an individual item in the argument array, but this introduce other issues. 

```
Error: Invalid backend configuration argument

The backend configuration argument "\"bucket" given on the command line is not       
expected for the selected backend type.
```

I think changing to the new `execSafe` command maybe good to do across all templates in line with https://github.com/goldstack/goldstack/issues/56 - since it would probably involve compiling the generate arguments in a different way.

