### PR TITLE
Enhancements to utils-typescript-references: Write files only when changed and ignore non-TypeScript packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "compile-watch": "tsc -b -w",
     "ensure-local-packages": "ts-node scripts/ensureLocalPackages.ts",
     "eslint": "eslint",
-    "fix-project-references": "utils-typescript-references",
+    "fix-project-references": "ts-node scripts/fixProjectReferences.ts",
     "format": "prettier --loglevel log --config .prettierrc.json --write .",
     "format-check": "prettier --loglevel log --config .prettierrc.json --check .",
     "generate-docs": "yarn workspace templates-lib generate-docs && yarn workspace docs generate-docs && yarn workspace apps generate-docs",

--- a/scripts/fixProjectReferences.ts
+++ b/scripts/fixProjectReferences.ts
@@ -1,0 +1,3 @@
+import { run } from '@goldstack/utils-typescript-references';
+
+run(process.argv);

--- a/workspaces/templates-lib/packages/utils-typescript-references/README.md
+++ b/workspaces/templates-lib/packages/utils-typescript-references/README.md
@@ -25,8 +25,6 @@ Running this script will:
 
 2. Update all the `"references"` in the `tsconfig.json` for all packages in the workspace so that it includes all the packages that it declares as a dependency in `package.json`.
 
-This package uses [@monorepo-utils/workspaces-to-typescript-project-references](https://github.com/azu/monorepo-utils/tree/master/packages/@monorepo-utils/workspaces-to-typescript-project-references#readme).
-
 ## Usage
 
 Install as development dependency using

--- a/workspaces/templates-lib/packages/utils-typescript-references/package.json
+++ b/workspaces/templates-lib/packages/utils-typescript-references/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@goldstack/utils-typescript-references",
   "version": "0.1.6",
-  "description": "Utility for keeping TypeScript references in sync in the monorepo",
+  "description": "Utility for keeping TypeScript references in sync in a Yarn monorepo",
   "keywords": [
     "goldstack",
     "utility",

--- a/workspaces/templates-lib/packages/utils-typescript-references/package.json
+++ b/workspaces/templates-lib/packages/utils-typescript-references/package.json
@@ -35,7 +35,6 @@
     "version:apply:force": "yarn version $@ && yarn version apply"
   },
   "dependencies": {
-    "@monorepo-utils/workspaces-to-typescript-project-references": "^2.6.2",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {

--- a/workspaces/templates-lib/packages/utils-typescript-references/src/sharedUtils.ts
+++ b/workspaces/templates-lib/packages/utils-typescript-references/src/sharedUtils.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 export interface PackageData {
   path: string;
   name: string;
@@ -15,6 +17,14 @@ export function getPackages(cmdRes: string): PackageData[] {
       }
       const packageData = JSON.parse(line);
       if (packageData.location === '.') {
+        return {
+          path: undefined,
+          name: undefined,
+        };
+      }
+      // ignore packages without TypeScript configuration
+      if (!fs.existsSync(`${packageData.location}/tsconfig.json`)) {
+        console.log('skipping package', packageData.location);
         return {
           path: undefined,
           name: undefined,

--- a/workspaces/templates-lib/packages/utils-typescript-references/src/updatePackageProjectReferences.ts
+++ b/workspaces/templates-lib/packages/utils-typescript-references/src/updatePackageProjectReferences.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import { execSync } from 'child_process';
 import { getPackages, PackageData } from './sharedUtils';
 import path from 'path';
-import { Z_FIXED } from 'zlib';
 
 export const updatePackageProjectReferences = (): void => {
   const cmdRes = execSync('yarn workspaces list --json').toString();

--- a/workspaces/templates-lib/packages/utils-typescript-references/src/updatePackageProjectReferences.ts
+++ b/workspaces/templates-lib/packages/utils-typescript-references/src/updatePackageProjectReferences.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import { execSync } from 'child_process';
 import { getPackages, PackageData } from './sharedUtils';
 import path from 'path';
+import { Z_FIXED } from 'zlib';
 
 export const updatePackageProjectReferences = (): void => {
   const cmdRes = execSync('yarn workspaces list --json').toString();
@@ -24,7 +25,6 @@ function processPackage(
   allPackages: PackageData[],
   packageData: PackageData
 ) {
-  console.log(`Processing package ${packageDir}`);
   const packageJson = fs
     .readFileSync(path.resolve(packageDir, './package.json'))
     .toString();
@@ -58,12 +58,17 @@ function processPackage(
       };
     });
 
-  console.log(
-    'Setting project references:\n' +
-      tsConfigData.references.map((refData) => refData.path).join('\n ')
-  );
-  fs.writeFileSync(
-    path.resolve(packageDir, './tsconfig.json'),
-    JSON.stringify(tsConfigData, null, 2)
-  );
+  const tsConfigPath = path.resolve(packageDir, './tsconfig.json');
+  const newData = JSON.stringify(tsConfigData, null, 2);
+  // only update the config file when it has changed
+  if (
+    !fs.existsSync(tsConfigPath) ||
+    fs.readFileSync(tsConfigPath).toString() !== newData
+  ) {
+    console.log(
+      `Updating project references in ${tsConfigPath} to:\n` +
+        tsConfigData.references.map((refData) => refData.path).join('\n ')
+    );
+    fs.writeFileSync(tsConfigPath, newData);
+  }
 }

--- a/workspaces/templates-lib/packages/utils-typescript-references/src/updateRootProjectReferences.ts
+++ b/workspaces/templates-lib/packages/utils-typescript-references/src/updateRootProjectReferences.ts
@@ -15,5 +15,13 @@ export const updateRootProjectReferences = (): void => {
     (packageData) => packageData.path
   );
 
-  fs.writeFileSync('./tsconfig.json', JSON.stringify(tsConfigData, null, 2));
+  const newContent = JSON.stringify(tsConfigData, null, 2);
+
+  if (newContent !== fs.readFileSync('./tsconfig.json').toString()) {
+    console.log(
+      "Updating project references in './tsconfig.json' to:\n" +
+        tsConfigData.references.map((refData) => refData.path).join('\n ')
+    );
+    fs.writeFileSync('./tsconfig.json', newContent);
+  }
 };

--- a/workspaces/templates-lib/packages/utils-typescript-references/src/utilsTypeScriptReferences.ts
+++ b/workspaces/templates-lib/packages/utils-typescript-references/src/utilsTypeScriptReferences.ts
@@ -1,23 +1,8 @@
-import { toProjectReferences } from '@monorepo-utils/workspaces-to-typescript-project-references';
-import path from 'path';
 import { updatePackageProjectReferences } from './updatePackageProjectReferences';
 import { updateRootProjectReferences } from './updateRootProjectReferences';
 
 export const run = (args: string[]): void => {
-  console.log('run ' + args);
   if (args.indexOf('--skipPackages') === -1) {
-    // const res = toProjectReferences({
-    //   rootDir: path.resolve('./'),
-    //   checkOnly: false,
-    // });
-
-    // if (!res.ok) {
-    //   if (res.aggregateError) {
-    //     console.error(res.aggregateError.message);
-    //   }
-    //   process.exit(1);
-    // }
-    console.log('packages');
     updatePackageProjectReferences();
   }
 


### PR DESCRIPTION
- Writes `tsconfig.json` changes only when they are updated
- Ignores packages that do not have a `tsconfig.json` file
- Removing unused dependency
- Cleaning up log messages

Closes #133 
Closes #134 