### PR TITLE
A few utils-typescript-references script improvements

### DIFF
--- a/workspaces/templates-lib/packages/utils-typescript-references/README.md
+++ b/workspaces/templates-lib/packages/utils-typescript-references/README.md
@@ -67,9 +67,28 @@ Will skip updating the `references` in `tsconfig.json` files for all packages in
 
 Will skip updating the `references` in the `tsconfig.json` file for the project root.
 
+`utils-typescript-references --tsConfigName tsconfig.build.json`
+
+Will update and reference `tsconfig.build.json` files only; `tsconfig.json` files are ignored, and packages
+with only `tsconfig.json` and not `tsconfig.build.json` will not have references inserted.  This is intended
+for monorepos where the `tsconfig.build.json` builds the modules that are exported from the package, and thus
+should be run when you are building using `tsc -b`.  In this case the `tsconfig.json` can be set up to type
+check only (no emit) and have a manually inserted reference to `tsconfig.build.json` for running `tsc -b`. 
+
+`utils-typescript-references --tsConfigName tsconfig.build.json --tsConfigName tsconfig.json`
+
+This is similar to the above but allows a fallback to referencing / updating `tsconfig.json` for some packages
+where `tsconfig.build.json` is not present (maybe it's not needed as there are no tests to compile separately).
+
+`utils-typescript-references --tsConfigName src/tsconfig.json --tsConfigName tsconfig.json`
+
+Prefer to reference and update `tsconfig.json` inside a `src` subfolder rather than at the top
+of the package / project.
+
+
+
 ## Limitations
 
-- The root of the project and each workspace must contain a `tsconfig.json`. It is currently not able to specify an alternative file name for `tsconfig.json`.
 - The root `tsconfig.json` file needs to be a vanilla JSON document (so no comments)
 
 If these limitations or anything else are an issues, please [raise a ticket in GitHub for the Goldstack Monorepo](https://github.com/goldstack/goldstack/issues).

--- a/workspaces/templates-lib/packages/utils-typescript-references/package.json
+++ b/workspaces/templates-lib/packages/utils-typescript-references/package.json
@@ -24,7 +24,7 @@
   "bin": "./bin/utils-typescript-references",
   "scripts": {
     "build": "yarn clean && yarn compile",
-    "build:watch": "yarn clean && yarn compile-watch",
+    "build:watch": "yarn clean && yarn compile --watch",
     "clean": "rimraf ./dist",
     "compile": "tsc -p tsconfig.json",
     "coverage": "jest --collect-coverage --passWithNoTests --config=./jest.config.js",

--- a/workspaces/templates-lib/packages/utils-typescript-references/src/updatePackageProjectReferences.ts
+++ b/workspaces/templates-lib/packages/utils-typescript-references/src/updatePackageProjectReferences.ts
@@ -1,9 +1,16 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
-import { getPackages, PackageData } from './sharedUtils';
+import {
+  getPackages,
+  getTsConfigPath,
+  PackageData,
+  makeReferences,
+} from './sharedUtils';
 import path from 'path';
 
-export const updatePackageProjectReferences = (): void => {
+export const updatePackageProjectReferences = (
+  tsConfigNames: string[]
+): void => {
   const cmdRes = execSync('yarn workspaces list --json').toString();
 
   const allPackages = getPackages(cmdRes);
@@ -12,7 +19,7 @@ export const updatePackageProjectReferences = (): void => {
     const packageDir = packageData.path;
 
     if (fs.existsSync(path.resolve(packageDir, './tsconfig.json'))) {
-      processPackage(packageDir, allPackages, packageData);
+      processPackage(packageDir, allPackages, packageData, tsConfigNames);
     } else {
       console.log(`Skipping package ${packageDir}`);
     }
@@ -22,62 +29,61 @@ export const updatePackageProjectReferences = (): void => {
 function processPackage(
   packageDir: string,
   allPackages: PackageData[],
-  packageData: PackageData
+  packageData: PackageData,
+  tsConfigNames: string[]
 ): void {
   const packageJson = fs
     .readFileSync(path.resolve(packageDir, './package.json'))
     .toString();
   const packageJsonData = JSON.parse(packageJson);
-  const tsConfigPath = path.join(packageDir, 'tsconfig.json');
-  const tsConfig = fs.readFileSync(tsConfigPath).toString();
-
-  const tsConfigData = JSON.parse(tsConfig);
-  const oldReferences = tsConfigData.references || [];
-
-  const newReferences = [
-    ...Object.keys(packageJsonData.dependencies || {}),
-    ...Object.keys(packageJsonData.devDependencies || {}),
-  ]
-    // all dependencies that are workspace dependencies and have a tsconfig.json
-    .map((dependencyData) =>
-      allPackages.find((packageData) => packageData.name === dependencyData)
-    )
-    .filter((dependencyPackageData): dependencyPackageData is PackageData => {
-      return (
-        !!dependencyPackageData &&
-        fs.existsSync(path.resolve(dependencyPackageData.path, 'package.json'))
-      );
-    })
-    // for each add a path
-    .map((dependencyPackageData) => {
-      return {
-        path: path.posix.relative(packageData.path, dependencyPackageData.path),
-      };
-    });
-
-  // Exit early if references are unchanged (using JSON for deep comparison)
-  if (JSON.stringify(oldReferences) === JSON.stringify(newReferences)) {
+  const tsConfigPath = getTsConfigPath(packageDir, tsConfigNames);
+  if (!tsConfigPath) {
     return;
   }
+  try {
+    const tsConfig = fs.readFileSync(tsConfigPath).toString();
+    const tsConfigData = JSON.parse(tsConfig);
+    const oldReferences = tsConfigData.references || [];
 
-  const newData = JSON.stringify(
-    {
-      ...tsConfigData,
-      // Override references; or omit them if empty
-      references: newReferences.length ? newReferences : undefined,
-    },
-    null,
-    2
-  );
-
-  // only update the config file when it has changed
-  if (newReferences.length) {
-    console.log(
-      `Updating project references in ${tsConfigPath} to:` +
-        newReferences.map((refData) => `\n  ${refData.path}`).join('')
+    const newReferences = makeReferences(
+      packageDir,
+      [
+        ...Object.keys(packageJsonData.dependencies || {}),
+        ...Object.keys(packageJsonData.devDependencies || {}),
+      ]
+        // all dependencies that are workspace dependencies and have a tsconfig.json
+        .map((dependencyData) =>
+          allPackages.find((packageData) => packageData.name === dependencyData)
+        ),
+      tsConfigNames
     );
-  } else {
-    console.log(`Removing project references in ${tsConfigPath}`);
+
+    // Exit early if references are unchanged (using JSON for deep comparison)
+    if (JSON.stringify(oldReferences) === JSON.stringify(newReferences)) {
+      return;
+    }
+
+    const newData = JSON.stringify(
+      {
+        ...tsConfigData,
+        // Override references; or omit them if empty
+        references: newReferences.length ? newReferences : undefined,
+      },
+      null,
+      2
+    );
+
+    // only update the config file when it has changed
+    if (newReferences.length) {
+      console.log(
+        `Updating project references in ${tsConfigPath} to:` +
+          newReferences.map((refData) => `\n  ${refData.path}`).join('')
+      );
+    } else {
+      console.log(`Removing project references in ${tsConfigPath}`);
+    }
+    fs.writeFileSync(tsConfigPath, newData);
+  } catch (e) {
+    console.error(e, `While processing ${tsConfigPath}`);
   }
-  fs.writeFileSync(tsConfigPath, newData);
 }

--- a/workspaces/templates-lib/packages/utils-typescript-references/src/updateRootProjectReferences.ts
+++ b/workspaces/templates-lib/packages/utils-typescript-references/src/updateRootProjectReferences.ts
@@ -1,43 +1,50 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
-import { getPackages } from './sharedUtils';
+import { getPackages, getTsConfigPath, makeReferences } from './sharedUtils';
 import path from 'path';
 
-export const updateRootProjectReferences = (): void => {
+export const updateRootProjectReferences = (tsConfigNames: string[]): void => {
   const cmdRes = execSync('yarn workspaces list --json').toString();
 
   const allPackages = getPackages(cmdRes);
-
-  const tsConfig = fs.readFileSync('./tsconfig.json').toString();
-
-  const tsConfigData = JSON.parse(tsConfig);
-  const oldReferences = tsConfigData.references;
-  const newReferences = allPackages
-    .map(({ path }) => ({ path }))
-    .filter((ref) => fs.existsSync(path.join(ref.path, 'tsconfig.json')));
-
-  // Don't continue if references are unchanged
-  if (JSON.stringify(newReferences) === JSON.stringify(oldReferences)) {
+  const tsConfigPath = getTsConfigPath('.', tsConfigNames);
+  if (!tsConfigPath) {
+    console.warn('No root-level tsconfig.json found');
     return;
   }
 
-  const newContent = JSON.stringify(
-    {
-      ...tsConfigData,
-      // Override references; or omit them if empty
-      references: newReferences.length ? newReferences : undefined,
-    },
-    null,
-    2
-  );
+  try {
+    const tsConfig = fs.readFileSync(tsConfigPath).toString();
 
-  if (newReferences.length) {
-    console.log(
-      'Updating project references in ./tsconfig.json to:' +
-        newReferences.map((refData) => `\n  ${refData.path}`).join('')
+    const tsConfigData = JSON.parse(tsConfig);
+    const oldReferences = tsConfigData.references;
+    const newReferences = makeReferences('.', allPackages, tsConfigNames);
+
+    // Don't continue if references are unchanged
+    if (JSON.stringify(newReferences) === JSON.stringify(oldReferences)) {
+      return;
+    }
+
+    const newContent = JSON.stringify(
+      {
+        ...tsConfigData,
+        // Override references; or omit them if empty
+        references: newReferences.length ? newReferences : undefined,
+      },
+      null,
+      2
     );
-  } else {
-    console.log('Removing project references in ./tsconfig.json');
+
+    if (newReferences.length) {
+      console.log(
+        `Updating project references in ${tsConfigPath} to:` +
+          newReferences.map((refData) => `\n  ${refData.path}`).join('')
+      );
+    } else {
+      console.log(`Removing project references in ${tsConfigPath}`);
+    }
+    fs.writeFileSync(tsConfigPath, newContent);
+  } catch (e) {
+    console.error(e, `While processing top level config file ${tsConfigPath}`);
   }
-  fs.writeFileSync('./tsconfig.json', newContent);
 };

--- a/workspaces/templates-lib/packages/utils-typescript-references/src/updateRootProjectReferences.ts
+++ b/workspaces/templates-lib/packages/utils-typescript-references/src/updateRootProjectReferences.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
 import { getPackages } from './sharedUtils';
+import path from 'path';
 
 export const updateRootProjectReferences = (): void => {
   const cmdRes = execSync('yarn workspaces list --json').toString();
@@ -10,18 +11,33 @@ export const updateRootProjectReferences = (): void => {
   const tsConfig = fs.readFileSync('./tsconfig.json').toString();
 
   const tsConfigData = JSON.parse(tsConfig);
+  const oldReferences = tsConfigData.references;
+  const newReferences = allPackages
+    .map(({ path }) => ({ path }))
+    .filter((ref) => fs.existsSync(path.join(ref.path, 'tsconfig.json')));
 
-  tsConfigData.references = allPackages.filter(
-    (packageData) => packageData.path
+  // Don't continue if references are unchanged
+  if (JSON.stringify(newReferences) === JSON.stringify(oldReferences)) {
+    return;
+  }
+
+  const newContent = JSON.stringify(
+    {
+      ...tsConfigData,
+      // Override references; or omit them if empty
+      references: newReferences.length ? newReferences : undefined,
+    },
+    null,
+    2
   );
 
-  const newContent = JSON.stringify(tsConfigData, null, 2);
-
-  if (newContent !== fs.readFileSync('./tsconfig.json').toString()) {
+  if (newReferences.length) {
     console.log(
-      "Updating project references in './tsconfig.json' to:\n" +
-        tsConfigData.references.map((refData) => refData.path).join('\n ')
+      'Updating project references in ./tsconfig.json to:' +
+        newReferences.map((refData) => `\n  ${refData.path}`).join('')
     );
-    fs.writeFileSync('./tsconfig.json', newContent);
+  } else {
+    console.log('Removing project references in ./tsconfig.json');
   }
+  fs.writeFileSync('./tsconfig.json', newContent);
 };

--- a/workspaces/templates-lib/packages/utils-typescript-references/src/utilsTypeScriptReferences.ts
+++ b/workspaces/templates-lib/packages/utils-typescript-references/src/utilsTypeScriptReferences.ts
@@ -1,12 +1,47 @@
 import { updatePackageProjectReferences } from './updatePackageProjectReferences';
 import { updateRootProjectReferences } from './updateRootProjectReferences';
 
+interface RunOptions {
+  tsConfigNames: string[];
+  skipPackages: boolean;
+  skipRoot: boolean;
+}
+
 export const run = (args: string[]): void => {
-  if (args.indexOf('--skipPackages') === -1) {
-    updatePackageProjectReferences();
+  const options: RunOptions = {
+    tsConfigNames: [],
+    skipPackages: false,
+    skipRoot: false,
+  };
+  const defaultArgFallback = (arg: string): void => {
+    console.warn(`Unexpected command line argument: ${arg}`);
+  };
+  let argFallback: (arg: string) => void = defaultArgFallback;
+
+  for (const arg of args.slice(2)) {
+    if (arg === '--skipPackages') {
+      options.skipPackages = true;
+    } else if (arg === '--skipRoot') {
+      options.skipRoot = true;
+    } else if (arg === '--tsConfigName') {
+      argFallback = (arg: string): void => {
+        options.tsConfigNames.push(arg);
+        argFallback = defaultArgFallback;
+      };
+    } else {
+      argFallback(arg);
+    }
   }
 
-  if (args.indexOf('--skipRoot') === -1) {
-    updateRootProjectReferences();
+  if (!options.tsConfigNames.length) {
+    options.tsConfigNames.push('tsconfig.json');
+  }
+
+  if (!options.skipPackages) {
+    updatePackageProjectReferences(options.tsConfigNames);
+  }
+
+  if (!options.skipRoot) {
+    updateRootProjectReferences(options.tsConfigNames);
   }
 };


### PR DESCRIPTION
- Compare only references for changing when deciding whether to update the file
- If the list of references is empty, remove it from the config instead of setting an empty array
- Update log message for empty references array
- Skip workspaces without a `tsconfig.json` file when building references list(s)
- Fix build:watch script
- Support specifying the config file name(s) to use to update and reference (https://github.com/goldstack/goldstack/issues/132)

