### PR TITLE
Allow GitHub actions workflow to run on PRs

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,4 +1,4 @@
-name: Branch & PR build 
+name: Branch & PR build
 
 on: [push, pull_request]
 
@@ -28,7 +28,6 @@ jobs:
         run: |
           yarn npm audit --all
 
-
       - name: Compile all
         run: |
           yarn compile
@@ -44,7 +43,7 @@ jobs:
           cd workspaces/templates-management
           yarn test-ci
           cd ../..
-      
+
       - name: Generate schemas
         run: |
           yarn generate-schema

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,7 +1,6 @@
 name: Branch build 
 
-on: 
-  push 
+on: [push, pull_request]
 
 jobs:
   build:
@@ -12,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
+
       - name: Install Yarn
         run: npm install -g yarn@1.22.11
 

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,0 +1,54 @@
+name: Branch build 
+
+on: 
+  push 
+
+jobs:
+  build:
+    name: 'Build and Test'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Install Yarn
+        run: npm install -g yarn@1.22.11
+
+      - name: Install
+        run: |
+          yarn install
+
+      - name: Linting and formatting
+        run: |
+          yarn format-check
+          yarn lint
+
+      - name: NPM Audit
+        run: |
+          yarn npm audit --all
+
+
+      - name: Compile all
+        run: |
+          yarn compile
+
+      - name: Test libraries
+        run: |
+          cd workspaces/templates-lib
+          yarn test-ci
+          cd ../..
+
+      - name: Test template management
+        run: |
+          cd workspaces/templates-management
+          yarn test-ci
+          cd ../..
+      
+      - name: Generate schemas
+        run: |
+          yarn generate-schema
+
+      - name: Generate docs
+        run: |
+          yarn generate-docs

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,4 +1,4 @@
-name: Branch build 
+name: Branch & PR build 
 
 on: [push, pull_request]
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: 'CodeQL'
 
 on:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{secrets.BUILD_TOKEN}}
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14'
           registry-url: https://registry.npmjs.org
       - name: Configure git
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,9 +1,9 @@
 name: Build, Test and Library Publish
 
-on: 
-  push: 
+on:
+  push:
     branches:
-        - master
+      - master
 
 jobs:
   build:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,6 +1,9 @@
 name: Build, Test and Library Publish
 
-on: [push, pull_request]
+on: 
+  push: 
+    branches:
+        - master
 
 jobs:
   build:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,28 +4,28 @@ npmPublishAccess: public
 
 npmRegistries:
   //registry.npmjs.org:
-    npmAuthToken: ""
+    npmAuthToken: ''
 
 packageExtensions:
   css@*:
     dependencies:
-      fs: "*"
+      fs: '*'
   debug@*:
     dependencies:
-      supports-color: "*"
+      supports-color: '*'
   webpack@*:
     peerDependencies:
-      webpack-cli: "*"
+      webpack-cli: '*'
     peerDependenciesMeta:
       webpack-cli:
         optional: true
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
-    spec: "@yarnpkg/plugin-workspace-tools"
+    spec: '@yarnpkg/plugin-workspace-tools'
   - path: .yarn/plugins/@yarnpkg/plugin-version.cjs
-    spec: "@yarnpkg/plugin-version"
+    spec: '@yarnpkg/plugin-version'
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
-    spec: "@yarnpkg/plugin-typescript"
+    spec: '@yarnpkg/plugin-typescript'
 
 yarnPath: .yarn/releases/yarn-3.0.2.cjs

--- a/workspaces/templates-lib/packages/utils-typescript-references/README.md
+++ b/workspaces/templates-lib/packages/utils-typescript-references/README.md
@@ -70,10 +70,10 @@ Will skip updating the `references` in the `tsconfig.json` file for the project 
 `utils-typescript-references --tsConfigName tsconfig.build.json`
 
 Will update and reference `tsconfig.build.json` files only; `tsconfig.json` files are ignored, and packages
-with only `tsconfig.json` and not `tsconfig.build.json` will not have references inserted.  This is intended
+with only `tsconfig.json` and not `tsconfig.build.json` will not have references inserted. This is intended
 for monorepos where the `tsconfig.build.json` builds the modules that are exported from the package, and thus
-should be run when you are building using `tsc -b`.  In this case the `tsconfig.json` can be set up to type
-check only (no emit) and have a manually inserted reference to `tsconfig.build.json` for running `tsc -b`. 
+should be run when you are building using `tsc -b`. In this case the `tsconfig.json` can be set up to type
+check only (no emit) and have a manually inserted reference to `tsconfig.build.json` for running `tsc -b`.
 
 `utils-typescript-references --tsConfigName tsconfig.build.json --tsConfigName tsconfig.json`
 
@@ -84,8 +84,6 @@ where `tsconfig.build.json` is not present (maybe it's not needed as there are n
 
 Prefer to reference and update `tsconfig.json` inside a `src` subfolder rather than at the top
 of the package / project.
-
-
 
 ## Limitations
 


### PR DESCRIPTION
Closes #138 - currently all PRs for forks will fail since the default workflow used [GitHub tokens](https://github.com/actions/checkout/issues/298).

This PR introduces a new workflow that runs for all pushes to branches as well as PRs and does not use the GitHub token.