### PR TITLE
Enable email send deploy set

### DIFF
--- a/.github/workflows/template_deploy_dev.yml
+++ b/.github/workflows/template_deploy_dev.yml
@@ -15,6 +15,7 @@ jobs:
             'backend-nodejs-express',
             'nextjs-bootstrap',
             'no-infra',
+            'email-send',
             'static-website',
           ]
     if: "contains(github.event.head_commit.message, 'trigger_template_deploy_dev') && github.ref == 'refs/heads/master'"

--- a/.github/workflows/template_deploy_prod.yml
+++ b/.github/workflows/template_deploy_prod.yml
@@ -14,6 +14,7 @@ jobs:
             'backend-lambda-api',
             'backend-nodejs-express',
             'no-infra',
+            'email-send',
             'static-website',
           ]
     if: "contains(github.event.head_commit.message, 'trigger_template_deploy_prod') && github.ref == 'refs/heads/master'"


### PR DESCRIPTION
Enabling the deploy set introduced in https://github.com/goldstack/goldstack/pull/157

This will ensure the [boilerplate repo](https://github.com/goldstack/ses-terraform-typescript-boilerplate) is updated and the template is deployed to the template repository.