### PR TITLE
Fix Getting Started guides in templates

### DIFF
--- a/workspaces/docs/docs/templates/app-nextjs/getting-started-development.md
+++ b/workspaces/docs/docs/templates/app-nextjs/getting-started-development.md
@@ -1,3 +1,3 @@
-### Development
+### 4. Development
 
 Goldstack's Next.js template is a simple wrapper around a standard Next.js project. Please see the [Next.js documentation](https://nextjs.org/docs/basic-features/pages) for details on how to develop a Next.js application. Generally, the folder `src/pages` is a good starting point.

--- a/workspaces/docs/docs/templates/email-send/getting-started.md
+++ b/workspaces/docs/docs/templates/email-send/getting-started.md
@@ -1,6 +1,8 @@
+[!embed](./../shared/getting-started-project.md)
+
 [!embed](./../shared/getting-started-infrastructure.md)
 
-### Development
+### 3. Development
 
 See below how this template can be used by other packages (for instance within an [Express Server](./../modules/lambda-express)).
 

--- a/workspaces/docs/docs/templates/lambda-express/getting-started.md
+++ b/workspaces/docs/docs/templates/lambda-express/getting-started.md
@@ -1,3 +1,5 @@
+[!embed](./../shared/getting-started-project.md)
+
 [!embed](./../shared/getting-started-infrastructure.md)
 
 Note that your API will not work yet. It first needs to be deployed as per instructions below.

--- a/workspaces/docs/docs/templates/lambda-go-gin/index.md
+++ b/workspaces/docs/docs/templates/lambda-go-gin/index.md
@@ -21,6 +21,8 @@ This template will only work when the [Go](https://golang.org) executable is ins
 
 Note that for automating the build and rolling out the infrastructure, this template will use [Yarn](https://yarnpkg.com/).
 
+[!embed](./../shared/getting-started-project.md)
+
 [!embed](./../shared/getting-started-infrastructure.md)
 
 [!embed](./../shared/getting-started-deployment.md)

--- a/workspaces/docs/docs/templates/s3/getting-started.md
+++ b/workspaces/docs/docs/templates/s3/getting-started.md
@@ -1,6 +1,8 @@
+[!embed](./../shared/getting-started-project.md)
+
 [!embed](./../shared/getting-started-infrastructure.md)
 
-### Development
+### 3. Development
 
 This is how an the S3 package can be used from another package:
 

--- a/workspaces/docs/docs/templates/serverless-api/getting-started.md
+++ b/workspaces/docs/docs/templates/serverless-api/getting-started.md
@@ -1,3 +1,6 @@
+
+[!embed](./../shared/getting-started-project.md)
+
 [!embed](./../shared/getting-started-infrastructure.md)
 
 Note that your API will not work yet. It first needs to be deployed as per instructions below.


### PR DESCRIPTION
For #145 

- Fixing that project getting started guides were missing in documentation for a number of templates