### PR TITLE
Fix redirect not optional for Next.js template

### DIFF
--- a/workspaces/templates/packages/app-nextjs/goldstack.json
+++ b/workspaces/templates/packages/app-nextjs/goldstack.json
@@ -12,7 +12,6 @@
       "configuration": {
         "hostedZoneDomain": "dev.goldstack.party",
         "websiteDomain": "app-nextjs.templates.dev.goldstack.party",
-        "websiteDomainRedirect": "www.app-nextjs.templates.dev.goldstack.party",
         "defaultCacheDuration": 10
       },
       "tfStateKey": "app-nextjs-prod-bfe30e556c467437d714.tfstate",

--- a/workspaces/templates/packages/app-nextjs/infra/aws/redirect.tf
+++ b/workspaces/templates/packages/app-nextjs/infra/aws/redirect.tf
@@ -123,6 +123,8 @@ resource "aws_cloudfront_distribution" "website_cdn_redirect" {
 
 # Creates record to point to redirect CloudFront distribution
 resource "aws_route53_record" "website_cdn_redirect_record" {
+  count  = var.website_domain_redirect != null ? 1 : 0
+
   zone_id = data.aws_route53_zone.main.zone_id
   name    = var.website_domain_redirect
   type    = "A"


### PR DESCRIPTION
For #173

Ensuring that Route53 records are not created for redirect website if it is not provided