### PR TITLE
Fixing API gateway response parsing in local Express

### DIFF
--- a/workspaces/templates-lib/packages/utils-aws-http-api-local/src/expressRequestToHttpApiGatewayEvent.ts
+++ b/workspaces/templates-lib/packages/utils-aws-http-api-local/src/expressRequestToHttpApiGatewayEvent.ts
@@ -186,7 +186,7 @@ export const injectGatewayResultIntoResponse = (
   }
 
   // 2: structured output
-  if (result.body) {
+  if (result.statusCode) {
     const structuredResult: APIGatewayProxyStructuredResultV2 = result as APIGatewayProxyStructuredResultV2;
     resp.status(structuredResult.statusCode || 200);
     if (structuredResult.headers) {
@@ -205,7 +205,9 @@ export const injectGatewayResultIntoResponse = (
         });
       });
     }
-    resp.json(JSON.parse(structuredResult.body || '"parsing error"'));
+    if (structuredResult.body || structuredResult.body !== '') {
+      resp.json(JSON.parse(structuredResult.body || ''));
+    }
     return;
   }
 

--- a/workspaces/templates-lib/packages/utils-aws-http-api-local/src/expressRequestToHttpApiGatewayEvent.ts
+++ b/workspaces/templates-lib/packages/utils-aws-http-api-local/src/expressRequestToHttpApiGatewayEvent.ts
@@ -205,8 +205,10 @@ export const injectGatewayResultIntoResponse = (
         });
       });
     }
-    if (structuredResult.body || structuredResult.body !== '') {
+    if (structuredResult.body) {
       resp.json(JSON.parse(structuredResult.body || ''));
+    } else {
+      resp.end();
     }
     return;
   }

--- a/workspaces/templates-lib/packages/utils-aws-http-api-local/src/utilsAwsHttpApiLocal.spec.ts
+++ b/workspaces/templates-lib/packages/utils-aws-http-api-local/src/utilsAwsHttpApiLocal.spec.ts
@@ -27,6 +27,12 @@ describe('Should create API', () => {
     expect(await res.text()).toContain('abc');
   });
 
+  test.only('Should support non-success status codes and empty body', async () => {
+    const res = await fetch(`http://localhost:${port}/keepOut`);
+    expect(res.status).toEqual(401);
+    expect(res.bodyUsed).toBeFalsy();
+  });
+
   test('Should support fallback', async () => {
     const res = await fetch(`http://localhost:${port}/unknownEndpoint`);
     expect(await res.text()).toContain('Unknown endpoint');

--- a/workspaces/templates-lib/packages/utils-aws-http-api-local/testData/routes/keepOut.ts
+++ b/workspaces/templates-lib/packages/utils-aws-http-api-local/testData/routes/keepOut.ts
@@ -8,12 +8,7 @@ type ProxyHandler = Handler<APIGatewayProxyEventV2, APIGatewayProxyResultV2>;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const handler: ProxyHandler = async (event, context) => {
-  const message = event.queryStringParameters?.message || 'no message';
-
   return {
-    statusCode: 201,
-    body: JSON.stringify({
-      message: `${message}`,
-    }),
+    statusCode: 401,
   };
 };


### PR DESCRIPTION
For #175 to improve [AWS HTTP API Gateway Local Local Mock](https://github.com/goldstack/goldstack/tree/master/workspaces/templates-lib/packages/utils-aws-http-api-local)

- Ensures that a custom response is only built when the `statusCode` property is defined