### PR TITLE
Add body to request and headers to response

### DIFF
--- a/workspaces/templates-lib/packages/utils-aws-http-api-local/src/expressRequestToHttpApiGatewayEvent.ts
+++ b/workspaces/templates-lib/packages/utils-aws-http-api-local/src/expressRequestToHttpApiGatewayEvent.ts
@@ -145,6 +145,7 @@ export const convertToGatewayEvent = (
       timeEpoch: new Date().getTime(),
     },
     isBase64Encoded: false,
+    body: JSON.stringify(params.req.body),
   };
 };
 
@@ -190,11 +191,9 @@ export const injectGatewayResultIntoResponse = (
     const structuredResult: APIGatewayProxyStructuredResultV2 = result as APIGatewayProxyStructuredResultV2;
     resp.status(structuredResult.statusCode || 200);
     if (structuredResult.headers) {
-      resp.contentType(
-        (structuredResult.headers['content-type'] as string) ||
-          'application/json'
-      );
-    } else {
+      resp.set(structuredResult.headers);
+    }
+    if (!structuredResult.headers?.['content-type']) {
       resp.contentType('application/json');
     }
     if (structuredResult.cookies) {

--- a/workspaces/templates-lib/packages/utils-aws-http-api-local/src/utilsAwsHttpApiLocal.spec.ts
+++ b/workspaces/templates-lib/packages/utils-aws-http-api-local/src/utilsAwsHttpApiLocal.spec.ts
@@ -72,6 +72,20 @@ describe('Should create API', () => {
     expect(response.message).toContain('Unknown endpoint');
   });
 
+  test('Should pass request body', async () => {
+    const res = await fetch(`http://localhost:${port}/echoBody`, {
+      method: 'post',
+      body: JSON.stringify({ message: 'The body.' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(await res.text()).toContain('The body.');
+  });
+
+  test('Should return headers', async () => {
+    const res = await fetch(`http://localhost:${port}/echoBody`);
+    expect(await res.headers.get('location')).toContain('/echoBody');
+  });
+
   afterAll(async () => {
     if (server) {
       await server.shutdown();

--- a/workspaces/templates-lib/packages/utils-aws-http-api-local/testData/routes/echoBody.ts
+++ b/workspaces/templates-lib/packages/utils-aws-http-api-local/testData/routes/echoBody.ts
@@ -1,0 +1,21 @@
+import {
+  Handler,
+  APIGatewayProxyEventV2,
+  APIGatewayProxyResultV2,
+} from 'aws-lambda';
+
+type ProxyHandler = Handler<APIGatewayProxyEventV2, APIGatewayProxyResultV2>;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const handler: ProxyHandler = async (event, context) => {
+  const message =
+    (event.body && JSON.parse(event.body).message) ?? 'no message';
+
+  return {
+    statusCode: 201,
+    body: JSON.stringify({
+      message: `${message}`,
+    }),
+    headers: { location: '/echoBody' },
+  };
+};


### PR DESCRIPTION
Resolves #178 No event body in serverless-api when running locally
Resolves #179 No headers in serverless-api response when running locally

The local express emulator package does not currently put the request body into the AWS request event and it does not copy all response headers from the response to the AWS response event. This PR fixes both of those issues.

The fix was tested locally in my generated project, in addition to in the unit tests.