### PR TITLE
Ensure build command only cleans and compiles

### DIFF
--- a/workspaces/templates/packages/serverless-api/package.json
+++ b/workspaces/templates/packages/serverless-api/package.json
@@ -24,7 +24,6 @@
     "watch": "PORT=5054 CORS=http://localhost:3000 GOLDSTACK_DEPLOYMENT=local ts-node-dev --respawn ./scripts/start.ts"
   },
   "dependencies": {
-    "@goldstack/s3": "workspace:^",
     "date-fns": "^2.28.0",
     "source-map-support": "^0.5.21"
   },

--- a/workspaces/templates/packages/serverless-api/package.json
+++ b/workspaces/templates/packages/serverless-api/package.json
@@ -7,13 +7,14 @@
   "sideEffects": false,
   "main": "src/module.ts",
   "scripts": {
-    "build": "template build",
-    "build-ts": "yarn template-ts build",
-    "clean": "rimraf ./dist && rimraf distLambda",
+    "build": "yarn clean && yarn compile",
+    "build-lambda": "template build",
+    "build-lambda-ts": "yarn template-ts build",
+    "clean": "rimraf ./dist && rimraf ./distLambda",
     "compile": "tsc --build",
     "coverage": "jest --collect-coverage --passWithNoTests --config=./jest.config.js --runInBand",
-    "deploy": "yarn build \"$@\" && template deploy \"$@\"",
-    "deploy-ts": "yarn build-ts \"$@\" && yarn template-ts deploy \"$@\"",
+    "deploy": "yarn build-lambda \"$@\" && template deploy \"$@\"",
+    "deploy-ts": "yarn build-lambda-ts \"$@\" && yarn template-ts deploy \"$@\"",
     "infra": "template infra \"$@\"",
     "start": "PORT=5054 CORS=http://localhost:3000 GOLDSTACK_DEPLOYMENT=local ts-node scripts/start.ts",
     "template": "template",
@@ -23,6 +24,7 @@
     "watch": "PORT=5054 CORS=http://localhost:3000 GOLDSTACK_DEPLOYMENT=local ts-node-dev --respawn ./scripts/start.ts"
   },
   "dependencies": {
+    "@goldstack/s3": "workspace:^",
     "date-fns": "^2.28.0",
     "source-map-support": "^0.5.21"
   },


### PR DESCRIPTION
Building the lambda requires providing the deployment, which is not available during a whole project build.