### PR TITLE
Allow connectTable to accept DocumentClient - useful for using entities in migrations

### DIFF
--- a/workspaces/templates/packages/dynamodb/src/table.spec.ts
+++ b/workspaces/templates/packages/dynamodb/src/table.spec.ts
@@ -27,6 +27,18 @@ describe('DynamoDB Table', () => {
     assert(dynamoDB2);
   });
 
+  it('Should be able to instantiate Toolbox table', async () => {
+    const dynamoDB = await connect();
+    const table1 = await connectTable({ client: dynamoDB });
+    assert(table1);
+    const table2 = await connectTable({
+      documentClient: new DynamoDB.DocumentClient({ service: dynamoDB }),
+    });
+    assert(table2);
+    const table3 = await connectTable();
+    assert(table3);
+  });
+
   it('Should be able to write and read an entity with native toolbox methods', async () => {
     const table = new Table({
       name: await getTableName(),
@@ -80,6 +92,7 @@ describe('DynamoDB Table', () => {
     expect(user.name).toEqual('Joe');
     expect(user.pk).toEqual('joe@email.com');
   });
+
   afterAll(async () => {
     await stopLocalDynamoDB();
   });

--- a/workspaces/templates/packages/dynamodb/src/table.ts
+++ b/workspaces/templates/packages/dynamodb/src/table.ts
@@ -23,12 +23,20 @@ export const connect = async (deploymentName?: string): Promise<DynamoDB> => {
   });
 };
 
+export interface ConnectTableParams {
+  deploymentName?: string;
+  client?: DynamoDB.DocumentClient;
+}
+
 export const connectTable = async <Name extends string>(
-  deploymentName?: string
+  params?: ConnectTableParams
 ): Promise<Table<Name, 'pk', 'sk'>> => {
-  const tableName = await getTableName(deploymentName);
+  const tableName = await getTableName(params?.deploymentName);
   return createTable(
-    new DynamoDB.DocumentClient({ service: await connect(deploymentName) }),
+    params?.client ||
+      new DynamoDB.DocumentClient({
+        service: await connect(params?.deploymentName),
+      }),
     tableName
   );
 };

--- a/workspaces/templates/packages/dynamodb/src/table.ts
+++ b/workspaces/templates/packages/dynamodb/src/table.ts
@@ -25,7 +25,8 @@ export const connect = async (deploymentName?: string): Promise<DynamoDB> => {
 
 export interface ConnectTableParams {
   deploymentName?: string;
-  client?: DynamoDB.DocumentClient;
+  documentClient?: DynamoDB.DocumentClient;
+  client?: DynamoDB;
 }
 
 export const connectTable = async <Name extends string>(
@@ -33,10 +34,12 @@ export const connectTable = async <Name extends string>(
 ): Promise<Table<Name, 'pk', 'sk'>> => {
   const tableName = await getTableName(params?.deploymentName);
   return createTable(
-    params?.client ||
-      new DynamoDB.DocumentClient({
-        service: await connect(params?.deploymentName),
-      }),
+    params?.documentClient || params?.client
+      ? new DynamoDB.DocumentClient({ service: params.client })
+      : undefined ||
+          new DynamoDB.DocumentClient({
+            service: await connect(params?.deploymentName),
+          }),
     tableName
   );
 };

--- a/workspaces/templates/packages/serverless-api/src/api.spec.ts
+++ b/workspaces/templates/packages/serverless-api/src/api.spec.ts
@@ -5,6 +5,8 @@ import {
   StartServerResult,
 } from '@goldstack/utils-aws-http-api-local';
 
+jest.setTimeout(120000);
+
 describe('Should create API', () => {
   let port: undefined | number = undefined;
   let server: undefined | StartServerResult = undefined;


### PR DESCRIPTION
for #188 