### PR TITLE
Defining module interface for serverless API for consumption in other modules

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2134,6 +2134,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [\
             ["@goldstack/lambda-express", "workspace:workspaces/templates/packages/lambda-express"],\
             ["@goldstack/template-lambda-express", "workspace:workspaces/templates-lib/packages/template-lambda-express"],\
+            ["@goldstack/utils-esbuild", "workspace:workspaces/templates-lib/packages/utils-esbuild"],\
             ["@jest-mock/express", "npm:1.4.5"],\
             ["@types/aws-serverless-express", "npm:3.3.3"],\
             ["@types/express", "npm:4.17.13"],\
@@ -2490,6 +2491,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@goldstack/serverless-api", "workspace:workspaces/templates/packages/serverless-api"],\
             ["@goldstack/template-lambda-api-cli", "workspace:workspaces/templates-lib/packages/template-lambda-api-cli"],\
             ["@goldstack/utils-aws-http-api-local", "workspace:workspaces/templates-lib/packages/utils-aws-http-api-local"],\
+            ["@goldstack/utils-esbuild", "workspace:workspaces/templates-lib/packages/utils-esbuild"],\
             ["@jest-mock/express", "npm:1.4.5"],\
             ["@types/aws-lambda", "npm:8.10.88"],\
             ["@types/aws-serverless-express", "npm:3.3.3"],\

--- a/.pnp.loader.mjs
+++ b/.pnp.loader.mjs
@@ -4,10 +4,10 @@ import path from 'path';
 import moduleExports, { Module } from 'module';
 
 var PathType;
-(function (PathType2) {
-  PathType2[(PathType2['File'] = 0)] = 'File';
-  PathType2[(PathType2['Portable'] = 1)] = 'Portable';
-  PathType2[(PathType2['Native'] = 2)] = 'Native';
+(function(PathType2) {
+  PathType2[PathType2["File"] = 0] = "File";
+  PathType2[PathType2["Portable"] = 1] = "Portable";
+  PathType2[PathType2["Native"] = 2] = "Native";
 })(PathType || (PathType = {}));
 const npath = Object.create(path);
 const ppath = Object.create(path.posix);
@@ -20,11 +20,13 @@ ppath.resolve = (...segments) => {
     return path.posix.resolve(ppath.cwd(), ...segments);
   }
 };
-const contains = function (pathUtils, from, to) {
+const contains = function(pathUtils, from, to) {
   from = pathUtils.normalize(from);
   to = pathUtils.normalize(to);
-  if (from === to) return `.`;
-  if (!from.endsWith(pathUtils.sep)) from = from + pathUtils.sep;
+  if (from === to)
+    return `.`;
+  if (!from.endsWith(pathUtils.sep))
+    from = from + pathUtils.sep;
   if (to.startsWith(from)) {
     return to.slice(from.length);
   } else {
@@ -40,45 +42,44 @@ const UNC_WINDOWS_PATH_REGEXP = /^\/\/(\.\/)?(.*)$/;
 const PORTABLE_PATH_REGEXP = /^\/([a-zA-Z]:.*)$/;
 const UNC_PORTABLE_PATH_REGEXP = /^\/unc\/(\.dot\/)?(.*)$/;
 function fromPortablePath(p) {
-  if (process.platform !== `win32`) return p;
+  if (process.platform !== `win32`)
+    return p;
   let portablePathMatch, uncPortablePathMatch;
-  if ((portablePathMatch = p.match(PORTABLE_PATH_REGEXP)))
+  if (portablePathMatch = p.match(PORTABLE_PATH_REGEXP))
     p = portablePathMatch[1];
-  else if ((uncPortablePathMatch = p.match(UNC_PORTABLE_PATH_REGEXP)))
+  else if (uncPortablePathMatch = p.match(UNC_PORTABLE_PATH_REGEXP))
     p = `\\\\${uncPortablePathMatch[1] ? `.\\` : ``}${uncPortablePathMatch[2]}`;
-  else return p;
+  else
+    return p;
   return p.replace(/\//g, `\\`);
 }
 function toPortablePath(p) {
-  if (process.platform !== `win32`) return p;
+  if (process.platform !== `win32`)
+    return p;
   p = p.replace(/\\/g, `/`);
   let windowsPathMatch, uncWindowsPathMatch;
-  if ((windowsPathMatch = p.match(WINDOWS_PATH_REGEXP)))
+  if (windowsPathMatch = p.match(WINDOWS_PATH_REGEXP))
     p = `/${windowsPathMatch[1]}`;
-  else if ((uncWindowsPathMatch = p.match(UNC_WINDOWS_PATH_REGEXP)))
-    p = `/unc/${uncWindowsPathMatch[1] ? `.dot/` : ``}${
-      uncWindowsPathMatch[2]
-    }`;
+  else if (uncWindowsPathMatch = p.match(UNC_WINDOWS_PATH_REGEXP))
+    p = `/unc/${uncWindowsPathMatch[1] ? `.dot/` : ``}${uncWindowsPathMatch[2]}`;
   return p;
 }
 
-const builtinModules = new Set(
-  Module.builtinModules || Object.keys(process.binding(`natives`))
-);
-const isBuiltinModule = (request) =>
-  request.startsWith(`node:`) || builtinModules.has(request);
+const builtinModules = new Set(Module.builtinModules || Object.keys(process.binding(`natives`)));
+const isBuiltinModule = (request) => request.startsWith(`node:`) || builtinModules.has(request);
 function readPackageScope(checkPath) {
   const rootSeparatorIndex = checkPath.indexOf(npath.sep);
   let separatorIndex;
   do {
     separatorIndex = checkPath.lastIndexOf(npath.sep);
     checkPath = checkPath.slice(0, separatorIndex);
-    if (checkPath.endsWith(`${npath.sep}node_modules`)) return false;
+    if (checkPath.endsWith(`${npath.sep}node_modules`))
+      return false;
     const pjson = readPackage(checkPath + npath.sep);
     if (pjson) {
       return {
         data: pjson,
-        path: checkPath,
+        path: checkPath
       };
     }
   } while (separatorIndex > rootSeparatorIndex);
@@ -86,7 +87,8 @@ function readPackageScope(checkPath) {
 }
 function readPackage(requestPath) {
   const jsonPath = npath.resolve(requestPath, `package.json`);
-  if (!fs.existsSync(jsonPath)) return null;
+  if (!fs.existsSync(jsonPath))
+    return null;
   return JSON.parse(fs.readFileSync(jsonPath, `utf8`));
 }
 
@@ -94,7 +96,8 @@ async function tryReadFile(path2) {
   try {
     return await fs.promises.readFile(path2, `utf8`);
   } catch (error) {
-    if (error.code === `ENOENT`) return null;
+    if (error.code === `ENOENT`)
+      return null;
     throw error;
   }
 }
@@ -127,14 +130,18 @@ function getFileFormat(filepath) {
     }
     case `.js`: {
       const pkg = readPackageScope(filepath);
-      if (!pkg) return `commonjs`;
+      if (!pkg)
+        return `commonjs`;
       return (_a = pkg.data.type) != null ? _a : `commonjs`;
     }
     default: {
-      if (entrypointPath !== filepath) return null;
+      if (entrypointPath !== filepath)
+        return null;
       const pkg = readPackageScope(filepath);
-      if (!pkg) return `commonjs`;
-      if (pkg.data.type === `module`) return null;
+      if (!pkg)
+        return `commonjs`;
+      if (pkg.data.type === `module`)
+        return null;
       return (_b = pkg.data.type) != null ? _b : `commonjs`;
     }
   }
@@ -147,7 +154,7 @@ async function getFormat$1(resolved, context, defaultGetFormat) {
   const format = getFileFormat(fileURLToPath(url));
   if (format) {
     return {
-      format,
+      format
     };
   }
   return defaultGetFormat(resolved, context, defaultGetFormat);
@@ -158,7 +165,7 @@ async function getSource$1(urlString, context, defaultGetSource) {
   if ((url == null ? void 0 : url.protocol) !== `file:`)
     return defaultGetSource(urlString, context, defaultGetSource);
   return {
-    source: await fs.promises.readFile(fileURLToPath(url), `utf8`),
+    source: await fs.promises.readFile(fileURLToPath(url), `utf8`)
   };
 }
 
@@ -168,10 +175,11 @@ async function load$1(urlString, context, defaultLoad) {
     return defaultLoad(urlString, context, defaultLoad);
   const filePath = fileURLToPath(url);
   const format = getFileFormat(filePath);
-  if (!format) return defaultLoad(urlString, context, defaultLoad);
+  if (!format)
+    return defaultLoad(urlString, context, defaultLoad);
   return {
     format,
-    source: await fs.promises.readFile(filePath, `utf8`),
+    source: await fs.promises.readFile(filePath, `utf8`)
   };
 }
 
@@ -179,23 +187,19 @@ const pathRegExp = /^(?![a-zA-Z]:[\\/]|\\\\|\.{0,2}(?:\/|$))((?:node:)?(?:@[^/]+
 const isRelativeRegexp = /^\.{0,2}\//;
 async function resolve$1(originalSpecifier, context, defaultResolver) {
   var _a;
-  const { findPnpApi } = moduleExports;
+  const {findPnpApi} = moduleExports;
   if (!findPnpApi || isBuiltinModule(originalSpecifier))
     return defaultResolver(originalSpecifier, context, defaultResolver);
   let specifier = originalSpecifier;
-  const url = tryParseURL(
-    specifier,
-    isRelativeRegexp.test(specifier) ? context.parentURL : void 0
-  );
+  const url = tryParseURL(specifier, isRelativeRegexp.test(specifier) ? context.parentURL : void 0);
   if (url) {
     if (url.protocol !== `file:`)
       return defaultResolver(originalSpecifier, context, defaultResolver);
     specifier = fileURLToPath(url);
   }
-  const { parentURL, conditions = [] } = context;
+  const {parentURL, conditions = []} = context;
   const issuer = parentURL ? fileURLToPath(parentURL) : process.cwd();
-  const pnpapi =
-    (_a = findPnpApi(issuer)) != null ? _a : url ? findPnpApi(specifier) : null;
+  const pnpapi = (_a = findPnpApi(issuer)) != null ? _a : url ? findPnpApi(specifier) : null;
   if (!pnpapi)
     return defaultResolver(originalSpecifier, context, defaultResolver);
   const dependencyNameMatch = specifier.match(pathRegExp);
@@ -203,10 +207,7 @@ async function resolve$1(originalSpecifier, context, defaultResolver) {
   if (dependencyNameMatch) {
     const [, dependencyName, subPath] = dependencyNameMatch;
     if (subPath === ``) {
-      const resolved = pnpapi.resolveToUnqualified(
-        `${dependencyName}/package.json`,
-        issuer
-      );
+      const resolved = pnpapi.resolveToUnqualified(`${dependencyName}/package.json`, issuer);
       if (resolved) {
         const content = await tryReadFile(resolved);
         if (content) {
@@ -218,7 +219,7 @@ async function resolve$1(originalSpecifier, context, defaultResolver) {
   }
   const result = pnpapi.resolveRequest(specifier, issuer, {
     conditions: new Set(conditions),
-    extensions: allowLegacyResolve ? void 0 : [],
+    extensions: allowLegacyResolve ? void 0 : []
   });
   if (!result)
     throw new Error(`Resolving '${specifier}' from '${issuer}' failed`);
@@ -227,16 +228,17 @@ async function resolve$1(originalSpecifier, context, defaultResolver) {
     resultURL.search = url.search;
     resultURL.hash = url.hash;
   }
-  if (!parentURL) setEntrypointPath(fileURLToPath(resultURL));
+  if (!parentURL)
+    setEntrypointPath(fileURLToPath(resultURL));
   return {
-    url: resultURL.href,
+    url: resultURL.href
   };
 }
 
 const binding = process.binding(`fs`);
 const originalfstat = binding.fstat;
 const ZIP_FD = 2147483648;
-binding.fstat = function (...args) {
+binding.fstat = function(...args) {
   const [fd, useBigint, req] = args;
   if ((fd & ZIP_FD) !== 0 && useBigint === false && req === void 0) {
     try {
@@ -251,17 +253,16 @@ binding.fstat = function (...args) {
         stats.blksize,
         stats.ino,
         stats.size,
-        stats.blocks,
+        stats.blocks
       ]);
-    } catch {}
+    } catch {
+    }
   }
   return originalfstat.apply(this, args);
 };
 
-const [major, minor] = process.versions.node
-  .split(`.`)
-  .map((value) => parseInt(value, 10));
-const hasConsolidatedHooks = major > 16 || (major === 16 && minor >= 12);
+const [major, minor] = process.versions.node.split(`.`).map((value) => parseInt(value, 10));
+const hasConsolidatedHooks = major > 16 || major === 16 && minor >= 12;
 const resolve = resolve$1;
 const getFormat = hasConsolidatedHooks ? void 0 : getFormat$1;
 const getSource = hasConsolidatedHooks ? void 0 : getSource$1;

--- a/workspaces/templates/packages/lambda-express/package.json
+++ b/workspaces/templates/packages/lambda-express/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@goldstack/template-lambda-express": "0.3.116",
+    "@goldstack/utils-esbuild": "0.4.2",
     "aws-serverless-express": "^3.3.8",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/workspaces/templates/packages/lambda-express/src/module.ts
+++ b/workspaces/templates/packages/lambda-express/src/module.ts
@@ -1,5 +1,7 @@
 import goldstackConfig from './../goldstack.json';
 
+import { excludeInBundle } from '@goldstack/utils-esbuild';
+
 let testServerPort: null | number = null;
 
 let testServer: any = null;
@@ -9,10 +11,9 @@ if (process.env.TEST_SERVER_PORT) {
 }
 
 export const startTestServer = async (port: number): Promise<void> => {
-  // The below is preventing webpack from bundling up the server - it is only required for local tests.
-  testServer = await eval(
-    `var server = require('./server.ts'); var promise = server.start(${port}); promise;`
-  );
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const server = require(excludeInBundle('./server.ts'));
+  testServer = await server.start(port);
   testServerPort = port;
 };
 

--- a/workspaces/templates/packages/serverless-api/package.json
+++ b/workspaces/templates/packages/serverless-api/package.json
@@ -24,6 +24,7 @@
     "watch": "PORT=5054 CORS=http://localhost:3000 GOLDSTACK_DEPLOYMENT=local ts-node-dev --respawn ./scripts/start.ts"
   },
   "dependencies": {
+    "@goldstack/utils-esbuild": "0.4.2",
     "date-fns": "^2.28.0",
     "source-map-support": "^0.5.21"
   },

--- a/workspaces/templates/packages/serverless-api/src/api.spec.ts
+++ b/workspaces/templates/packages/serverless-api/src/api.spec.ts
@@ -1,15 +1,12 @@
 import getPort from 'find-free-port';
 import fetch from 'node-fetch';
-import {
-  startServer,
-  StartServerResult,
-} from '@goldstack/utils-aws-http-api-local';
+
+import { startTestServer, stopTestServer, getEndpoint } from './module';
 
 jest.setTimeout(120000);
 
 describe('Should create API', () => {
   let port: undefined | number = undefined;
-  let server: undefined | StartServerResult = undefined;
 
   beforeAll(async () => {
     port = await new Promise<number>((resolve, reject) => {
@@ -24,21 +21,16 @@ describe('Should create API', () => {
         }
       );
     });
-    server = await startServer({
-      port: `${port}`,
-      routesDir: './src/routes',
-    });
+    await startTestServer(port);
   });
 
   test('Should receive response and support parameters', async () => {
-    const res = await fetch(`http://localhost:${port}/echo?message=abc`);
+    const res = await fetch(`${getEndpoint()}/echo?message=abc`);
     const response = await res.json();
     expect(response.message).toContain('abc');
   });
 
   afterAll(async () => {
-    if (server) {
-      await server.shutdown();
-    }
+    await stopTestServer();
   });
 });

--- a/workspaces/templates/packages/serverless-api/src/module.ts
+++ b/workspaces/templates/packages/serverless-api/src/module.ts
@@ -1,0 +1,50 @@
+import goldstackConfig from './../goldstack.json';
+
+import { excludeInBundle } from '@goldstack/utils-esbuild';
+
+const cors = process.env.CORS;
+
+let testServerPort: null | number = null;
+
+let testServer: any = null;
+
+if (process.env.TEST_SERVER_PORT) {
+  testServerPort = parseInt(process.env.TEST_SERVER_PORT);
+}
+
+export const startTestServer = async (port?: number): Promise<any> => {
+  port = port || 3047;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { startServer } = require(excludeInBundle(
+    '@goldstack/utils-aws-http-api-local'
+  ));
+  testServer = await startServer({
+    port: port,
+    routesDir: './src/routes',
+    cors,
+  });
+  testServerPort = port;
+  return testServer;
+};
+
+export const stopTestServer = async (): Promise<void> => {
+  return testServer.shutdown();
+};
+
+export const getEndpoint = (deploymentName?: string): string => {
+  if (!deploymentName) {
+    deploymentName = process.env.GOLDSTACK_DEPLOYMENT;
+  }
+  if (deploymentName === 'local') {
+    const port = testServerPort || 3047;
+
+    return `http://localhost:${port}`;
+  }
+  const deployment = goldstackConfig.deployments.find(
+    (deployment) => (deployment as any).name === deploymentName
+  );
+  if (!deployment) {
+    throw new Error(`Cannot find deployment with name ${deploymentName}`);
+  }
+  return 'https://' + (deployment as any).configuration.apiDomain;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,6 +1257,7 @@ __metadata:
   resolution: "@goldstack/lambda-express@workspace:workspaces/templates/packages/lambda-express"
   dependencies:
     "@goldstack/template-lambda-express": 0.3.116
+    "@goldstack/utils-esbuild": 0.4.2
     "@jest-mock/express": ^1.4.5
     "@types/aws-serverless-express": ^3.3.3
     "@types/express": ^4.17.13
@@ -1585,6 +1586,7 @@ __metadata:
   dependencies:
     "@goldstack/template-lambda-api-cli": 0.4.10
     "@goldstack/utils-aws-http-api-local": 0.1.33
+    "@goldstack/utils-esbuild": 0.4.2
     "@jest-mock/express": ^1.4.5
     "@types/aws-lambda": ^8.10.88
     "@types/aws-serverless-express": ^3.3.3


### PR DESCRIPTION
For #209 

Creating a `module.ts` that can be imported in other modules, e.g. Next.js based frontends.