### PR TITLE
Updating documentation for esbuild and TypeScript utilities

### DIFF
--- a/workspaces/utils/packages/esbuild-css-modules-client-plugin/README.md
+++ b/workspaces/utils/packages/esbuild-css-modules-client-plugin/README.md
@@ -1,3 +1,5 @@
+[![npm version](https://badge.fury.io/js/esbuild-css-modules-client-plugin.svg)](https://badge.fury.io/js/esbuild-css-modules-client-plugin)
+
 # esbuild CSS Modules Plugin (Client)
 
 This [esbuild Plugin](https://esbuild.github.io/plugins/) bundles CSS module files along with client-side JavaScript.
@@ -7,6 +9,8 @@ Thus, import directives such as the following can be used alongside React compon
 ```typescript
 import styles from './Panel.module.css';
 ```
+
+For creating bundles for server-side rendering, see [`esbuild-css-modules-server-plugin`](https://www.npmjs.com/package/esbuild-css-modules-server-plugin)
 
 ## Usage
 
@@ -28,6 +32,20 @@ const res = await build({
 });
 ```
 
+### Options
+
+The plugin supports one option `excludeCSSInject`. This defaults to `false`. When set, no `<script>` tags are injected to be run during script load.
+
+```typescript
+import cssPlugin from 'esbuild-css-modules-client-plugin';
+
+const res = await build({
+  plugins: [cssPlugin({
+    excludeCSSInject: true
+  })],
+});
+```
+
 ## How does it work?
 
 This plugin will transform `.css` files into JavaScript source files that contain:
@@ -36,3 +54,8 @@ This plugin will transform `.css` files into JavaScript source files that contai
 - A default export with a map of original class names to transformed class names
 
 Thus, when the client-side bundle is loaded, all required CSS will be injected into the page and we can use the `styles` object to resolve original class names to the transformed ones.
+
+## See also
+
+- [`esbuild-plugin-css-in-js`](https://github.com/karishmashuklaa/esbuild-plugin-css-in-js): Plugin that includes plain CSS (instead of CSS with transformed classnames according to the CSS modules standard as this plugin does)
+- [`node-css-require`](https://www.npmjs.com/package/node-css-require): Library used for CSS module transformation

--- a/workspaces/utils/packages/esbuild-css-modules-client-plugin/package.json
+++ b/workspaces/utils/packages/esbuild-css-modules-client-plugin/package.json
@@ -9,7 +9,7 @@
     "esbuild",
     "css"
   ],
-  "homepage": "",
+  "homepage": "https://github.com/goldstack/goldstack/tree/master/workspaces/utils/packages/esbuild-css-modules-client-plugin#readme",
   "bugs": {
     "url": "https://github.com/goldstack/goldstack/issues"
   },

--- a/workspaces/utils/packages/esbuild-css-modules-server-plugin/README.md
+++ b/workspaces/utils/packages/esbuild-css-modules-server-plugin/README.md
@@ -1,3 +1,5 @@
+[![npm version](https://badge.fury.io/js/esbuild-css-modules-server-plugin.svg)](https://badge.fury.io/js/esbuild-css-modules-server-plugin)
+
 # esbuild CSS Modules Plugin (Server)
 
 This [esbuild Plugin](https://esbuild.github.io/plugins/) bundles CSS module files for usage in server-side script for server-side rendering.
@@ -7,6 +9,8 @@ Thus, import directives such as the following can be used alongside React compon
 ```typescript
 import styles from './Panel.module.css';
 ```
+
+For creating client-side bundles, see [`esbuild-css-modules-client-plugin`](https://www.npmjs.com/package/esbuild-css-modules-client-plugin)
 
 ## Usage
 
@@ -28,6 +32,26 @@ const res = await build({
 });
 ```
 
+### Options
+
+The plugin supports one option `onCSSGenerated`. This option accepts a callback function that receives one argument `css` that contains snippets of CSS generated.
+
+```typescript
+import cssPlugin from 'esbuild-css-modules-server-plugin';
+
+const generatedCss: string[] = [];
+const res = await build({
+  plugins: [cssPlugin({
+    onCSSGenerated: (css) => {
+      generatedCss.push(css);
+    },
+  })],
+});
+console.log(generatedCss.join('\n'));
+```
+
+This can be useful for creating a CSS bundle that can be shipped with the other files packaged for the server. When generating a client-side bundle using [`esbuild-css-modules-client-plugin`](https://www.npmjs.com/package/esbuild-css-modules-client-plugin), the option `excludeCSSInject` can then be set to true for a better page load experience (no flicker of the page once CSS is injected).
+
 ## How does it work?
 
 This plugin will transform `.css` files into JavaScript source files that contain:
@@ -35,3 +59,8 @@ This plugin will transform `.css` files into JavaScript source files that contai
 - A default export with a map of original class names to transformed class names
 
 Thus, when server-side rendering is performed, class names can be resolved to the transformed counter-parts and the HTML rendered with the correct class names.
+
+## See also
+
+- [`esbuild-plugin-css-in-js`](https://github.com/karishmashuklaa/esbuild-plugin-css-in-js): Plugin that includes plain CSS (instead of CSS with transformed classnames according to the CSS modules standard as this plugin does)
+- [`node-css-require`](https://www.npmjs.com/package/node-css-require): Library used for CSS module transformation

--- a/workspaces/utils/packages/esbuild-css-modules-server-plugin/package.json
+++ b/workspaces/utils/packages/esbuild-css-modules-server-plugin/package.json
@@ -10,7 +10,7 @@
     "esbuild",
     "css"
   ],
-  "homepage": "",
+  "homepage": "https://github.com/goldstack/goldstack/tree/master/workspaces/utils/packages/esbuild-css-modules-server-plugin#readme",
   "bugs": {
     "url": "https://github.com/goldstack/goldstack/issues"
   },

--- a/workspaces/utils/packages/node-css-require/README.md
+++ b/workspaces/utils/packages/node-css-require/README.md
@@ -1,3 +1,5 @@
+[![npm version](https://badge.fury.io/js/node-css-require.svg)](https://badge.fury.io/js/node-css-require)
+
 # Node CSS Require
 
 Sometimes it is required to import CSS files into a Node script:

--- a/workspaces/utils/packages/node-css-require/package.json
+++ b/workspaces/utils/packages/node-css-require/package.json
@@ -7,7 +7,7 @@
     "javascript",
     "css"
   ],
-  "homepage": "",
+  "homepage": "https://github.com/goldstack/goldstack/tree/master/workspaces/utils/packages/node-css-require#readme",
   "bugs": {
     "url": "https://github.com/goldstack/goldstack/issues"
   },


### PR DESCRIPTION
Updating Readmes for three utility libraries:

- [node-css-require]( https://github.com/goldstack/goldstack/tree/master/workspaces/utils/packages/node-css-require#readme)
- [esbuild-css-modules-server-plugin](https://github.com/goldstack/goldstack/tree/master/workspaces/utils/packages/esbuild-css-modules-server-plugin#readme)
- [esbuild-css-modules-client-plugin](https://github.com/goldstack/goldstack/tree/master/workspaces/utils/packages/esbuild-css-modules-client-plugin#readme)