### PR TITLE
Support long domain names for SSR applications

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -3294,6 +3294,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./workspaces/templates-lib/packages/template-ssr-cli/",\
           "packageDependencies": [\
             ["@goldstack/template-ssr-cli", "workspace:workspaces/templates-lib/packages/template-ssr-cli"],\
+            ["@goldstack/infra", "workspace:workspaces/templates-lib/packages/infra"],\
             ["@goldstack/infra-aws", "workspace:workspaces/templates-lib/packages/infra-aws"],\
             ["@goldstack/template-ssr", "workspace:workspaces/templates-lib/packages/template-ssr"],\
             ["@goldstack/template-ssr-server", "workspace:workspaces/templates-lib/packages/template-ssr-server"],\

--- a/workspaces/templates-lib/packages/template-nextjs/src/edgeLambdaDeploy.ts
+++ b/workspaces/templates-lib/packages/template-nextjs/src/edgeLambdaDeploy.ts
@@ -1,14 +1,13 @@
 import { NextjsDeployment } from './types/NextJsPackage';
 import { getAWSUser } from '@goldstack/infra-aws';
 import { readTerraformStateVariable, DeploymentState } from '@goldstack/infra';
-import { zip, cp, write, rmSafe, read, mkdir } from '@goldstack/utils-sh';
+import { cp, write, rmSafe, read, mkdir } from '@goldstack/utils-sh';
 import { awsCli } from '@goldstack/utils-aws-cli';
 import util from 'util';
 import globFunc from 'glob';
 import { packageEdgeLambda } from './edgeLambdaPackage';
 
 import { deployFunction } from '@goldstack/utils-aws-lambda';
-import { version } from 'yargs';
 
 const glob = util.promisify(globFunc);
 

--- a/workspaces/templates-lib/packages/template-ssr-cli/package.json
+++ b/workspaces/templates-lib/packages/template-ssr-cli/package.json
@@ -42,6 +42,7 @@
     "version:apply:force": "yarn version $@ && yarn version apply"
   },
   "dependencies": {
+    "@goldstack/infra": "0.3.38",
     "@goldstack/infra-aws": "0.3.47",
     "@goldstack/template-ssr": "0.1.8",
     "@goldstack/template-ssr-server": "0.1.8",

--- a/workspaces/templates-lib/packages/template-ssr-cli/src/deployToS3.ts
+++ b/workspaces/templates-lib/packages/template-ssr-cli/src/deployToS3.ts
@@ -5,11 +5,13 @@ import type { AWSDeployment } from '@goldstack/infra-aws';
 export interface DeployToS3Params {
   configuration: LambdaApiDeploymentConfiguration;
   deployment: AWSDeployment;
+  staticFilesBucket: string;
+  publicFilesBucket: string;
 }
 export const deployToS3 = async (params: DeployToS3Params): Promise<void> => {
   await Promise.all([
     upload({
-      bucket: `${params.configuration.apiDomain}-public-files`,
+      bucket: params.publicFilesBucket,
       bucketPath: '/',
       localPath: 'public/',
       region: params.deployment.awsRegion,
@@ -18,14 +20,14 @@ export const deployToS3 = async (params: DeployToS3Params): Promise<void> => {
     // uploading files again to allow CloudFront routing both to the root
     // and the subdirectory
     upload({
-      bucket: `${params.configuration.apiDomain}-public-files`,
+      bucket: params.staticFilesBucket,
       bucketPath: '/_goldstack/public',
       localPath: 'public/',
       region: params.deployment.awsRegion,
       userName: params.deployment.awsUser,
     }),
     upload({
-      bucket: `${params.configuration.apiDomain}-static-files`,
+      bucket: params.staticFilesBucket,
       bucketPath: '/_goldstack/static',
       localPath: 'static/',
       region: params.deployment.awsRegion,

--- a/workspaces/templates/packages/server-side-rendering/infra/aws/output.tf
+++ b/workspaces/templates/packages/server-side-rendering/infra/aws/output.tf
@@ -2,3 +2,11 @@
 output "gateway_url" {
   value = aws_apigatewayv2_api.api.api_endpoint
 }
+
+output "static_files_bucket" {
+  value = aws_s3_bucket.static_files.bucket
+}
+
+output "public_files_bucket" {
+  value = aws_s3_bucket.public_files.bucket
+}

--- a/workspaces/templates/packages/server-side-rendering/infra/aws/s3.tf
+++ b/workspaces/templates/packages/server-side-rendering/infra/aws/s3.tf
@@ -1,8 +1,13 @@
 # S3 Buckets for file hosting
 
+# Random id to prevent name collisions when bucket names need to be truncated
+resource "random_id" "bucket_name" {
+	  byte_length = 4
+}
+
 # Creates bucket to store the static website
 resource "aws_s3_bucket" "static_files" {
-  bucket = "${length(var.domain) < 38 ? var.domain : substr(var.domain, 0, 38)}-static-files"
+  bucket = "${length(var.domain) < 38 ? var.domain : substr(var.domain, 0, 38)}-static-files-${random_id.bucket_name.hex}"
 
   acl = "public-read"
 
@@ -25,7 +30,7 @@ resource "aws_s3_bucket" "static_files" {
         "AWS": "*"
       },
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::${length(var.domain) < 38 ? var.domain : substr(var.domain, 0, 38)}-static-files/*"
+      "Resource": "arn:aws:s3:::${length(var.domain) < 38 ? var.domain : substr(var.domain, 0, 38)}-static-files-${random_id.bucket_name.hex}/*"
     }
   ]
 }
@@ -50,7 +55,7 @@ resource "aws_s3_bucket_website_configuration" "static_files_web" {
 }
 
 resource "aws_s3_bucket" "public_files" {
-  bucket = "${length(var.domain) < 38 ? var.domain : substr(var.domain, 0, 38)}-public-files"
+  bucket = "${length(var.domain) < 38 ? var.domain : substr(var.domain, 0, 38)}-public-files-${random_id.bucket_name.hex}"
 
   acl = "public-read"
 
@@ -73,7 +78,7 @@ resource "aws_s3_bucket" "public_files" {
         "AWS": "*"
       },
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::${length(var.domain) < 38 ? var.domain : substr(var.domain, 0, 38)}-public-files/*"
+      "Resource": "arn:aws:s3:::${length(var.domain) < 38 ? var.domain : substr(var.domain, 0, 38)}-public-files-${random_id.bucket_name.hex}/*"
     }
   ]
 }

--- a/workspaces/templates/packages/server-side-rendering/src/state/deployments.json
+++ b/workspaces/templates/packages/server-side-rendering/src/state/deployments.json
@@ -6,6 +6,16 @@
         "sensitive": false,
         "type": "string",
         "value": "https://38xbcaysyl.execute-api.us-west-2.amazonaws.com"
+      },
+      "public_files_bucket": {
+        "sensitive": false,
+        "type": "string",
+        "value": "ssr.examples.templates.dev.goldstack.p-public-files"
+      },
+      "static_files_bucket": {
+        "sensitive": false,
+        "type": "string",
+        "value": "ssr.examples.templates.dev.goldstack.p-static-files"
       }
     }
   }

--- a/workspaces/templates/packages/server-side-rendering/src/state/deployments.json
+++ b/workspaces/templates/packages/server-side-rendering/src/state/deployments.json
@@ -10,12 +10,12 @@
       "public_files_bucket": {
         "sensitive": false,
         "type": "string",
-        "value": "ssr.examples.templates.dev.goldstack.p-public-files"
+        "value": "ssr.examples.templates.dev.goldstack.p-public-files-f3d74658"
       },
       "static_files_bucket": {
         "sensitive": false,
         "type": "string",
-        "value": "ssr.examples.templates.dev.goldstack.p-static-files"
+        "value": "ssr.examples.templates.dev.goldstack.p-static-files-f3d74658"
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2284,6 +2284,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@goldstack/template-ssr-cli@workspace:workspaces/templates-lib/packages/template-ssr-cli"
   dependencies:
+    "@goldstack/infra": 0.3.38
     "@goldstack/infra-aws": 0.3.47
     "@goldstack/template-ssr": 0.1.8
     "@goldstack/template-ssr-server": 0.1.8


### PR DESCRIPTION
For #43 

- Allow to use long domain names for SSR applications by automatically truncating generated S3 bucket names for public and static files