### PR TITLE
Fixing issues with Server-Side Rendering template

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -141,6 +141,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         "reference": "workspace:workspaces/templates/packages/template-metadata"\
       },\
       {\
+        "name": "@goldstack/template-test",\
+        "reference": "workspace:workspaces/templates/packages/template-test"\
+      },\
+      {\
         "name": "@goldstack/infra",\
         "reference": "workspace:workspaces/templates-lib/packages/infra"\
       },\
@@ -472,6 +476,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ["@goldstack/template-ssr-server", ["workspace:workspaces/templates-lib/packages/template-ssr-server"]],\
       ["@goldstack/template-ssr-server-compile-bundle", ["workspace:workspaces/templates-lib/packages/template-ssr-server-compile-bundle"]],\
       ["@goldstack/template-static-website-aws", ["workspace:workspaces/templates-lib/packages/template-static-website-aws"]],\
+      ["@goldstack/template-test", ["workspace:workspaces/templates/packages/template-test"]],\
       ["@goldstack/toc-generator", ["workspace:workspaces/docs/packages/toc-generator"]],\
       ["@goldstack/utils-aws-cli", ["workspace:workspaces/templates-lib/packages/utils-aws-cli"]],\
       ["@goldstack/utils-aws-http-api-local", ["workspace:workspaces/templates-lib/packages/utils-aws-http-api-local"]],\
@@ -2411,11 +2416,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         ["workspace:workspaces/templates-management/packages/project-build", {\
           "packageLocation": "./workspaces/templates-management/packages/project-build/",\
           "packageDependencies": [\
-            ["@goldstack/project-build", "workspace:workspaces/templates-management/packages/project-build"],\
             ["@goldstack/infra-aws", "workspace:workspaces/templates-lib/packages/infra-aws"],\
             ["@goldstack/module-template-utils", "workspace:workspaces/templates/packages/module-template-utils"],\
+            ["@goldstack/project-build", "workspace:workspaces/templates-management/packages/project-build"],\
             ["@goldstack/template-build", "workspace:workspaces/templates-management/packages/template-build"],\
-            ["@goldstack/template-metadata", "workspace:workspaces/templates/packages/template-metadata"],\
             ["@goldstack/template-repository", "workspace:workspaces/templates-management/packages/template-repository"],\
             ["@goldstack/utils-config", "workspace:workspaces/templates-lib/packages/utils-config"],\
             ["@goldstack/utils-log", "workspace:workspaces/utils/packages/utils-log"],\
@@ -3464,6 +3468,31 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ts-node", "virtual:36a01d8083315b8a6e8362097258ea8bc0f9dfb672cb210742e054760850c673a1038f542a6b7156397b5275ace8ee0482231cac5e8898044fa1a1c29f78ee5b#npm:10.9.1"],\
             ["typescript", "patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=a1c5e5"],\
             ["yargs", "npm:17.5.1"]\
+          ],\
+          "linkType": "SOFT"\
+        }]\
+      ]],\
+      ["@goldstack/template-test", [\
+        ["workspace:workspaces/templates/packages/template-test", {\
+          "packageLocation": "./workspaces/templates/packages/template-test/",\
+          "packageDependencies": [\
+            ["@goldstack/template-test", "workspace:workspaces/templates/packages/template-test"],\
+            ["@goldstack/infra-aws", "workspace:workspaces/templates-lib/packages/infra-aws"],\
+            ["@goldstack/module-template-utils", "workspace:workspaces/templates/packages/module-template-utils"],\
+            ["@goldstack/project-build", "workspace:workspaces/templates-management/packages/project-build"],\
+            ["@goldstack/template-build-set", "workspace:workspaces/templates-management/packages/template-build-set"],\
+            ["@goldstack/template-metadata", "workspace:workspaces/templates/packages/template-metadata"],\
+            ["@goldstack/template-repository", "workspace:workspaces/templates-management/packages/template-repository"],\
+            ["@goldstack/utils-config", "workspace:workspaces/templates-lib/packages/utils-config"],\
+            ["@goldstack/utils-project", "workspace:workspaces/templates-lib/packages/utils-project"],\
+            ["@goldstack/utils-sh", "workspace:workspaces/utils/packages/utils-sh"],\
+            ["@goldstack/utils-template-test", "workspace:workspaces/templates-management/packages/utils-template-test"],\
+            ["@types/jest", "npm:28.1.8"],\
+            ["@types/node", "npm:18.7.13"],\
+            ["jest", "virtual:c517f8da57a5da8bfc1d1e83302c273ecb1d60e68c396bdaba5666ad4b8c39fa57ce0871dbd8f41202827d40cc5eee8ec09cf366499028a5dc8b1c0ecb931dbb#npm:28.1.0"],\
+            ["rimraf", "npm:3.0.2"],\
+            ["ts-jest", "virtual:c517f8da57a5da8bfc1d1e83302c273ecb1d60e68c396bdaba5666ad4b8c39fa57ce0871dbd8f41202827d40cc5eee8ec09cf366499028a5dc8b1c0ecb931dbb#npm:28.0.2"],\
+            ["typescript", "patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=a1c5e5"]\
           ],\
           "linkType": "SOFT"\
         }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2413,7 +2413,9 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [\
             ["@goldstack/project-build", "workspace:workspaces/templates-management/packages/project-build"],\
             ["@goldstack/infra-aws", "workspace:workspaces/templates-lib/packages/infra-aws"],\
+            ["@goldstack/module-template-utils", "workspace:workspaces/templates/packages/module-template-utils"],\
             ["@goldstack/template-build", "workspace:workspaces/templates-management/packages/template-build"],\
+            ["@goldstack/template-metadata", "workspace:workspaces/templates/packages/template-metadata"],\
             ["@goldstack/template-repository", "workspace:workspaces/templates-management/packages/template-repository"],\
             ["@goldstack/utils-config", "workspace:workspaces/templates-lib/packages/utils-config"],\
             ["@goldstack/utils-log", "workspace:workspaces/utils/packages/utils-log"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2417,9 +2417,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./workspaces/templates-management/packages/project-build/",\
           "packageDependencies": [\
             ["@goldstack/infra-aws", "workspace:workspaces/templates-lib/packages/infra-aws"],\
-            ["@goldstack/module-template-utils", "workspace:workspaces/templates/packages/module-template-utils"],\
             ["@goldstack/project-build", "workspace:workspaces/templates-management/packages/project-build"],\
-            ["@goldstack/template-build", "workspace:workspaces/templates-management/packages/template-build"],\
             ["@goldstack/template-repository", "workspace:workspaces/templates-management/packages/template-repository"],\
             ["@goldstack/utils-config", "workspace:workspaces/templates-lib/packages/utils-config"],\
             ["@goldstack/utils-log", "workspace:workspaces/utils/packages/utils-log"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2416,8 +2416,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         ["workspace:workspaces/templates-management/packages/project-build", {\
           "packageLocation": "./workspaces/templates-management/packages/project-build/",\
           "packageDependencies": [\
-            ["@goldstack/infra-aws", "workspace:workspaces/templates-lib/packages/infra-aws"],\
             ["@goldstack/project-build", "workspace:workspaces/templates-management/packages/project-build"],\
+            ["@goldstack/infra-aws", "workspace:workspaces/templates-lib/packages/infra-aws"],\
             ["@goldstack/template-repository", "workspace:workspaces/templates-management/packages/template-repository"],\
             ["@goldstack/utils-config", "workspace:workspaces/templates-lib/packages/utils-config"],\
             ["@goldstack/utils-log", "workspace:workspaces/utils/packages/utils-log"],\

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -122,6 +122,9 @@
       "path": "workspaces/templates/packages/template-metadata"
     },
     {
+      "path": "workspaces/templates/packages/template-test"
+    },
+    {
       "path": "workspaces/templates-lib/packages/infra"
     },
     {

--- a/workspaces/templates-lib/packages/template-ssr-cli/src/templateSSRCli.ts
+++ b/workspaces/templates-lib/packages/template-ssr-cli/src/templateSSRCli.ts
@@ -88,19 +88,21 @@ export const run = async (
     if (command === 'build') {
       const deployment = packageConfig.getDeployment(opArgs[0]);
       const lambdaNamePrefix = deployment.configuration.lambdaNamePrefix;
-      await buildFunctions({
-        routesDir: defaultRoutesPath,
-        deploymentName: deployment.name,
-        buildOptions: buildConfig.createServerBuildOptions,
-        configs: lambdaRoutes,
-        lambdaNamePrefix: lambdaNamePrefix || '',
-      });
+      // bundles need to be built first since static mappings are updated
+      // during bundle built and they are injected into function bundle
       await buildBundles({
         routesDir: defaultRoutesPath,
         configs: lambdaRoutes,
         deploymentName: deployment.name,
         lambdaNamePrefix: lambdaNamePrefix || '',
         buildConfig,
+      });
+      await buildFunctions({
+        routesDir: defaultRoutesPath,
+        deploymentName: deployment.name,
+        buildOptions: buildConfig.createServerBuildOptions,
+        configs: lambdaRoutes,
+        lambdaNamePrefix: lambdaNamePrefix || '',
       });
       return;
     }

--- a/workspaces/templates-management/packages/project-build/jest.config.js
+++ b/workspaces/templates-management/packages/project-build/jest.config.js
@@ -3,6 +3,9 @@ const base = require('./../../jest.config');
 
 module.exports = {
   ...base,
+  coveragePathIgnorePatterns: ['/goldstackLocal/'],
+  modulePathIgnorePatterns: ['/goldstackLocal/'],
+  testPathIgnorePatterns: ['/goldstackLocal/'],
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.json',

--- a/workspaces/templates-management/packages/project-build/package.json
+++ b/workspaces/templates-management/packages/project-build/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@goldstack/infra-aws": "0.4.1",
-    "@goldstack/project-build": "0.1.0",
     "@goldstack/template-repository": "0.1.0",
     "@goldstack/utils-config": "0.4.1",
     "@goldstack/utils-log": "0.3.1",

--- a/workspaces/templates-management/packages/project-build/package.json
+++ b/workspaces/templates-management/packages/project-build/package.json
@@ -32,8 +32,6 @@
     "extract-zip": "^2.0.1"
   },
   "devDependencies": {
-    "@goldstack/module-template-utils": "0.1.0",
-    "@goldstack/template-build": "0.1.0",
     "@goldstack/utils-template-test": "0.1.0",
     "@types/jest": "^28.1.8",
     "@types/node": "^18.7.13",

--- a/workspaces/templates-management/packages/project-build/package.json
+++ b/workspaces/templates-management/packages/project-build/package.json
@@ -31,7 +31,9 @@
     "extract-zip": "^2.0.1"
   },
   "devDependencies": {
+    "@goldstack/module-template-utils": "0.1.0",
     "@goldstack/template-build": "0.1.0",
+    "@goldstack/template-metadata": "0.1.0",
     "@goldstack/utils-template-test": "0.1.0",
     "@types/jest": "^28.1.8",
     "@types/node": "^18.7.13",

--- a/workspaces/templates-management/packages/project-build/src/projectBuild.spec.ts
+++ b/workspaces/templates-management/packages/project-build/src/projectBuild.spec.ts
@@ -7,15 +7,19 @@ import {
 import { S3TemplateRepository } from '@goldstack/template-repository';
 
 import { buildProject } from './projectBuild';
-import { rmSafe, mkdir, read } from '@goldstack/utils-sh';
+import { rmSafe, mkdir, read, write } from '@goldstack/utils-sh';
 import { ProjectConfiguration } from '@goldstack/utils-project';
+
+import { getModuleTemplatesNames } from '@goldstack/module-template-utils';
 
 import { getAwsConfigPath } from '@goldstack/utils-config';
 import { readConfig } from '@goldstack/infra-aws';
 
+import { createServerSideRenderingBuildSetConfig } from '@goldstack/template-metadata';
+
 import assert from 'assert';
 
-jest.setTimeout(60000);
+jest.setTimeout(600000);
 
 describe('Template Building', () => {
   const goldstackTestsDir = './goldstackLocal/tests/build/';
@@ -30,49 +34,21 @@ describe('Template Building', () => {
     expect(config).toBeUndefined();
   });
 
+  it('Should be able to build all templates', async () => {
+    const templateNames = getModuleTemplatesNames();
+
+    for (const templateName of templateNames) {
+      await buildTemplate({
+        templateName,
+        repo,
+        goldstackTestsDir,
+      });
+    }
+  });
+
   it('Should build root template', async () => {
     await buildTemplate({
       templateName: 'yarn-pnp-monorepo',
-      repo,
-      goldstackTestsDir,
-    });
-  });
-
-  it('Should be able to build static website', async () => {
-    await buildTemplate({
-      templateName: 'static-website-aws',
-      repo,
-      goldstackTestsDir,
-    });
-  });
-
-  it('Should be able to build docker-image-aws', async () => {
-    await buildTemplate({
-      templateName: 'docker-image-aws',
-      repo,
-      goldstackTestsDir,
-    });
-  });
-
-  it('Should be able to build s3', async () => {
-    await buildTemplate({
-      templateName: 's3',
-      repo,
-      goldstackTestsDir,
-    });
-  });
-
-  it('Should be able to build lambda go gin template', async () => {
-    await buildTemplate({
-      templateName: 'lambda-go-gin',
-      repo,
-      goldstackTestsDir,
-    });
-  });
-
-  it('Should be able to build lambda email-send template', async () => {
-    await buildTemplate({
-      templateName: 'email-send',
       repo,
       goldstackTestsDir,
     });
@@ -301,5 +277,69 @@ describe('Template Building', () => {
       read(emailSendPackageDir + 'src/state/deployments.json')
     );
     expect(emailSendDeploymentState).toEqual([]);
+  });
+
+  it('Should be able to build a project for server-side-rendering', async () => {
+    const config: ProjectConfiguration = {
+      projectName: 'project-server-side-rendering',
+      rootTemplateReference: {
+        templateName: 'yarn-pnp-monorepo',
+      },
+      packages: [
+        {
+          packageName: 'server-side-rendering-1',
+          templateReference: {
+            templateName: 'server-side-rendering',
+          },
+        },
+      ],
+    };
+
+    assert(repo);
+    const projectDir = goldstackTestsDir + `projects/${config.projectName}/`;
+    await rmSafe(projectDir);
+    mkdir('-p', projectDir);
+
+    await buildProject({
+      destinationDirectory: projectDir,
+      config,
+      s3: repo,
+    });
+
+    // check SSR
+    const ssrPackageDir =
+      projectDir + 'packages/' + config.packages[0].packageName + '/';
+    assertFilesExist([
+      ssrPackageDir + 'infra/aws/.gitignore',
+      ssrPackageDir + 'infra/aws/main.tf',
+      ssrPackageDir + '.gitignore',
+    ]);
+
+    // ensure config values are overwritten
+    const ssrGoldstackConfig = JSON.parse(
+      read(ssrPackageDir + 'goldstack.json')
+    );
+    expect(Object.entries(ssrGoldstackConfig.configuration).length).toEqual(0);
+
+    const ssrDeploymentState = JSON.parse(
+      read(ssrPackageDir + 'src/state/deployments.json')
+    );
+    expect(ssrDeploymentState).toEqual([]);
+
+    const ssrStaticFiles = JSON.parse(
+      read(ssrPackageDir + 'src/state/staticFiles.json')
+    );
+    expect(ssrStaticFiles).toEqual([]);
+
+    const ssrBuildSetConfig = await createServerSideRenderingBuildSetConfig();
+
+    const packageConfig =
+      ssrBuildSetConfig.projects[0].packageConfigurations[0];
+
+    ssrGoldstackConfig.deployments = packageConfig.deployments;
+    write(
+      JSON.stringify(ssrGoldstackConfig, null, 2),
+      ssrPackageDir + 'goldstack.json'
+    );
   });
 });

--- a/workspaces/templates-management/packages/project-build/tsconfig.json
+++ b/workspaces/templates-management/packages/project-build/tsconfig.json
@@ -33,9 +33,6 @@
       "path": "../../../utils/packages/utils-sh"
     },
     {
-      "path": "../template-build"
-    },
-    {
       "path": "../utils-template-test"
     }
   ]

--- a/workspaces/templates-management/packages/project-build/tsconfig.json
+++ b/workspaces/templates-management/packages/project-build/tsconfig.json
@@ -3,6 +3,9 @@
   "include": [
     "./src/**/*"
   ],
+  "exclude": [
+    "./goldstackLocal/**/*"
+  ],
   "compilerOptions": {
     "outDir": "dist",
     "baseUrl": "."

--- a/workspaces/templates/packages/dynamodb/package.json
+++ b/workspaces/templates/packages/dynamodb/package.json
@@ -17,7 +17,7 @@
     "coverage": "jest --collect-coverage --passWithNoTests --config=./jest.config.js --runInBand",
     "deploy": "yarn node dist/src/template.js deploy $@",
     "infra": "yarn node dist/src/template.js infra",
-    "template": "yarn node dist/src/template.js",
+    "template": "yarn template-ts",
     "template-ts": "ts-node src/template.ts",
     "test-ci": "GOLDSTACK_DEPLOYMENT=local jest --passWithNoTests --config=./jest.config.js --runInBand",
     "watch": "GOLDSTACK_DEPLOYMENT=local ts-node scripts/watch.ts"

--- a/workspaces/templates/packages/server-side-rendering/build.json
+++ b/workspaces/templates/packages/server-side-rendering/build.json
@@ -24,7 +24,8 @@
     "infra/aws/.terraform/",
     "infra/aws/tfplan",
     "infra/aws/terraform.tfstate.d/",
-    "src/bucket.spec.ts"
+    "src/bucket.spec.ts",
+    "static/generated/"
   ],
   "overwriteFiles": [
     {

--- a/workspaces/templates/packages/server-side-rendering/package.json
+++ b/workspaces/templates/packages/server-side-rendering/package.json
@@ -17,7 +17,7 @@
     "deploy-ts": "yarn build-lambda-ts \"$@\" && yarn template-ts deploy \"$@\"",
     "infra": "yarn template infra \"$@\"",
     "start": "PORT=5054 CORS=http://localhost:3000 GOLDSTACK_DEPLOYMENT=local ts-node scripts/start.ts",
-    "template": "yarn node dist/src/template.js",
+    "template": "yarn template-ts",
     "template-ts": "ts-node --project tsconfig.local.json src/template.ts",
     "test": "concurrently \"yarn test-ci-server --watch\" \"yarn test-ci-ui --watch\"",
     "test-ci": "yarn test-ci-server && yarn test-ci-ui",

--- a/workspaces/templates/packages/server-side-rendering/src/state/staticFiles.json
+++ b/workspaces/templates/packages/server-side-rendering/src/state/staticFiles.json
@@ -3,7 +3,7 @@
     "names": [
       "goldstack-test-ssr--__index-bundle.js"
     ],
-    "generatedName": "-__index-bundle.9acec23e0d55cdf20e144ddfd0661a30.js"
+    "generatedName": "-__index-bundle.3b812cf2fbe97a363e70da6cdcad2d23.js"
   },
   {
     "names": [

--- a/workspaces/templates/packages/server-side-rendering/src/state/staticFiles.json
+++ b/workspaces/templates/packages/server-side-rendering/src/state/staticFiles.json
@@ -3,7 +3,7 @@
     "names": [
       "goldstack-test-ssr--__index-bundle.js"
     ],
-    "generatedName": "-__index-bundle.3b812cf2fbe97a363e70da6cdcad2d23.js"
+    "generatedName": "-__index-bundle.36077e1f0f27491bf615e7d6cc67b2a2.js"
   },
   {
     "names": [

--- a/workspaces/templates/packages/template-metadata/src/deploySets/deploySets.ts
+++ b/workspaces/templates/packages/template-metadata/src/deploySets/deploySets.ts
@@ -11,6 +11,8 @@ import { createNextjsBuildSetConfig } from './nextjs';
 import { createDynamoDBBuildSetConfig } from './dynamodb';
 import { createServerSideRenderingBuildSetConfig } from './serverSideRendering';
 
+export { createServerSideRenderingBuildSetConfig } from './serverSideRendering';
+
 export const getAllBuildSets = async (): Promise<DeploySetConfig[]> => {
   return [
     await createBackendNodejsExpressBuildSetConfig(),

--- a/workspaces/templates/packages/template-metadata/src/projectTemplateData.ts
+++ b/workspaces/templates/packages/template-metadata/src/projectTemplateData.ts
@@ -28,7 +28,11 @@ export { getNextJsTemplateData };
 export { getExpressTemplateData };
 export { getNextjsBootstrapTemplateData };
 export { getGoGinTemplateData };
-export { getAllBuildSets, getBuildSet } from './deploySets/deploySets';
+export {
+  getAllBuildSets,
+  getBuildSet,
+  createServerSideRenderingBuildSetConfig,
+} from './deploySets/deploySets';
 
 export const allTemplates = (): ProjectTemplateProps[] => {
   const templates = [

--- a/workspaces/templates/packages/template-test/.gitignore
+++ b/workspaces/templates/packages/template-test/.gitignore
@@ -1,0 +1,3 @@
+goldstackTest/
+goldstackLocal/
+work/

--- a/workspaces/templates/packages/template-test/.npmignore
+++ b/workspaces/templates/packages/template-test/.npmignore
@@ -1,0 +1,5 @@
+/*
+!/dist/
+!/package.json
+!/README.md
+/dist/tsconfig.tsbuildinfo

--- a/workspaces/templates/packages/template-test/jest.config.js
+++ b/workspaces/templates/packages/template-test/jest.config.js
@@ -1,0 +1,12 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const base = require('../../jest.config');
+
+module.exports = {
+  ...base,
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+      packageJson: 'package.json',
+    },
+  },
+};

--- a/workspaces/templates/packages/template-test/jest.config.js
+++ b/workspaces/templates/packages/template-test/jest.config.js
@@ -1,8 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const base = require('../../jest.config');
+const base = require('./../../jest.config');
 
 module.exports = {
   ...base,
+  coveragePathIgnorePatterns: ['/goldstackLocal/'],
+  modulePathIgnorePatterns: ['/goldstackLocal/'],
+  testPathIgnorePatterns: ['/goldstackLocal/'],
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.json',

--- a/workspaces/templates/packages/template-test/package.json
+++ b/workspaces/templates/packages/template-test/package.json
@@ -1,13 +1,11 @@
 {
-  "name": "@goldstack/project-build",
+  "name": "@goldstack/template-test",
   "version": "0.1.0",
+  "description": "",
   "license": "MIT",
   "author": "Max Rohde",
   "sideEffects": false,
-  "main": "src/projectBuild.ts",
-  "files": [
-    "dist"
-  ],
+  "main": "src/templateTest.ts",
   "scripts": {
     "build": "yarn clean && yarn compile",
     "build:watch": "yarn clean && yarn compile-watch",
@@ -17,24 +15,24 @@
     "compile-watch:light": "nodemon --watch ./src/ -e '*' --exec 'yarn compile'",
     "coverage": "jest --collect-coverage --passWithNoTests --config=./jest.config.js --runInBand",
     "prepublishOnly": "yarn run build",
+    "publish": "yarn npm publish",
     "test": "jest --config=./jest.config.js --watch",
-    "test-ci": "jest --passWithNoTests --config=./jest.config.js --runInBand"
+    "test-ci": "jest --passWithNoTests --config=./jest.config.js --runInBand",
+    "version:apply": "yarn version \"$@\" && yarn version apply"
   },
   "dependencies": {
     "@goldstack/infra-aws": "0.4.1",
+    "@goldstack/module-template-utils": "0.1.0",
     "@goldstack/project-build": "0.1.0",
+    "@goldstack/template-build-set": "0.1.0",
+    "@goldstack/template-metadata": "0.1.0",
     "@goldstack/template-repository": "0.1.0",
     "@goldstack/utils-config": "0.4.1",
-    "@goldstack/utils-log": "0.3.1",
-    "@goldstack/utils-package": "0.4.1",
     "@goldstack/utils-project": "0.4.1",
     "@goldstack/utils-sh": "0.5.1",
-    "extract-zip": "^2.0.1"
+    "@goldstack/utils-template-test": "0.1.0"
   },
   "devDependencies": {
-    "@goldstack/module-template-utils": "0.1.0",
-    "@goldstack/template-build": "0.1.0",
-    "@goldstack/utils-template-test": "0.1.0",
     "@types/jest": "^28.1.8",
     "@types/node": "^18.7.13",
     "jest": "^28.1.0",

--- a/workspaces/templates/packages/template-test/src/projectBuild.spec.ts
+++ b/workspaces/templates/packages/template-test/src/projectBuild.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@goldstack/utils-template-test';
 import { S3TemplateRepository } from '@goldstack/template-repository';
 
-import { buildProject } from './projectBuild';
+import { buildProject } from '@goldstack/project-build';
 import { rmSafe, mkdir, read, write } from '@goldstack/utils-sh';
 import { ProjectConfiguration } from '@goldstack/utils-project';
 

--- a/workspaces/templates/packages/template-test/tsconfig.json
+++ b/workspaces/templates/packages/template-test/tsconfig.json
@@ -3,16 +3,43 @@
   "include": [
     "./src/**/*"
   ],
+  "exclude": [
+    "./goldstackLocal/**/*"
+  ],
   "compilerOptions": {
     "outDir": "dist",
     "baseUrl": "."
   },
   "references": [
     {
+      "path": "../../../templates-lib/packages/infra-aws"
+    },
+    {
+      "path": "../module-template-utils"
+    },
+    {
+      "path": "../../../templates-management/packages/project-build"
+    },
+    {
       "path": "../../../templates-management/packages/template-build-set"
     },
     {
+      "path": "../template-metadata"
+    },
+    {
+      "path": "../../../templates-management/packages/template-repository"
+    },
+    {
+      "path": "../../../templates-lib/packages/utils-config"
+    },
+    {
       "path": "../../../templates-lib/packages/utils-project"
+    },
+    {
+      "path": "../../../utils/packages/utils-sh"
+    },
+    {
+      "path": "../../../templates-management/packages/utils-template-test"
     }
   ]
 }

--- a/workspaces/templates/packages/template-test/tsconfig.json
+++ b/workspaces/templates/packages/template-test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "./src/**/*"
+  ],
+  "compilerOptions": {
+    "outDir": "dist",
+    "baseUrl": "."
+  },
+  "references": [
+    {
+      "path": "../../../templates-management/packages/template-build-set"
+    },
+    {
+      "path": "../../../templates-lib/packages/utils-project"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,7 +1460,9 @@ __metadata:
   resolution: "@goldstack/project-build@workspace:workspaces/templates-management/packages/project-build"
   dependencies:
     "@goldstack/infra-aws": 0.4.1
+    "@goldstack/module-template-utils": 0.1.0
     "@goldstack/template-build": 0.1.0
+    "@goldstack/template-metadata": 0.1.0
     "@goldstack/template-repository": 0.1.0
     "@goldstack/utils-config": 0.4.1
     "@goldstack/utils-log": 0.3.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,7 +1460,6 @@ __metadata:
   resolution: "@goldstack/project-build@workspace:workspaces/templates-management/packages/project-build"
   dependencies:
     "@goldstack/infra-aws": 0.4.1
-    "@goldstack/project-build": 0.1.0
     "@goldstack/template-repository": 0.1.0
     "@goldstack/utils-config": 0.4.1
     "@goldstack/utils-log": 0.3.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,9 +1460,7 @@ __metadata:
   resolution: "@goldstack/project-build@workspace:workspaces/templates-management/packages/project-build"
   dependencies:
     "@goldstack/infra-aws": 0.4.1
-    "@goldstack/module-template-utils": 0.1.0
     "@goldstack/project-build": 0.1.0
-    "@goldstack/template-build": 0.1.0
     "@goldstack/template-repository": 0.1.0
     "@goldstack/utils-config": 0.4.1
     "@goldstack/utils-log": 0.3.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,8 +1461,8 @@ __metadata:
   dependencies:
     "@goldstack/infra-aws": 0.4.1
     "@goldstack/module-template-utils": 0.1.0
+    "@goldstack/project-build": 0.1.0
     "@goldstack/template-build": 0.1.0
-    "@goldstack/template-metadata": 0.1.0
     "@goldstack/template-repository": 0.1.0
     "@goldstack/utils-config": 0.4.1
     "@goldstack/utils-log": 0.3.1
@@ -2467,6 +2467,29 @@ __metadata:
   bin:
     template: ./bin/template
     template-static-website-aws: ./bin/template
+  languageName: unknown
+  linkType: soft
+
+"@goldstack/template-test@workspace:workspaces/templates/packages/template-test":
+  version: 0.0.0-use.local
+  resolution: "@goldstack/template-test@workspace:workspaces/templates/packages/template-test"
+  dependencies:
+    "@goldstack/infra-aws": 0.4.1
+    "@goldstack/module-template-utils": 0.1.0
+    "@goldstack/project-build": 0.1.0
+    "@goldstack/template-build-set": 0.1.0
+    "@goldstack/template-metadata": 0.1.0
+    "@goldstack/template-repository": 0.1.0
+    "@goldstack/utils-config": 0.4.1
+    "@goldstack/utils-project": 0.4.1
+    "@goldstack/utils-sh": 0.5.1
+    "@goldstack/utils-template-test": 0.1.0
+    "@types/jest": ^28.1.8
+    "@types/node": ^18.7.13
+    jest: ^28.1.0
+    rimraf: ^3.0.2
+    ts-jest: ^28.0.2
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
For #247 

- Fix order in which bundles are built: Client bundles should always come first since they update static mappings
- Exclude static generated files in server-side rendering template package
- Improve integration tests for project building; ensure all templates are built
