### PR TITLE
[server-side-rendering] Allow async rendering for documents

### DIFF
--- a/workspaces/templates-lib/packages/template-ssr-server/src/templateSSRServer.ts
+++ b/workspaces/templates-lib/packages/template-ssr-server/src/templateSSRServer.ts
@@ -41,7 +41,7 @@ export interface RenderDocumentProps<PropType> {
 export interface PartialRenderPageProps<PropType> {
   entryPoint: string;
   event: APIGatewayProxyEventV2;
-  renderDocument?: (props: RenderDocumentProps<PropType>) => string;
+  renderDocument?: (props: RenderDocumentProps<PropType>) => Promise<string>;
   appendToHead?: string;
   appendToBody?: string;
   component: React.FunctionComponent<PropType>;
@@ -56,7 +56,7 @@ export interface RenderPageProps<PropType> {
   event: APIGatewayProxyEventV2;
   appendToHead?: string;
   appendToBody?: string;
-  renderDocument: (props: RenderDocumentProps<PropType>) => string;
+  renderDocument: (props: RenderDocumentProps<PropType>) => Promise<string>;
   component: React.FunctionComponent<PropType>;
   staticFileMapper?: StaticFileMapper;
   staticFileMapperStore?: unknown;
@@ -165,7 +165,7 @@ export const renderPage = async <PropType>({
     });
   }
 
-  const document = renderDocument({
+  const document = await renderDocument({
     injectIntoHead: `${styles ? `<style>${styles}</style>` : ''}
     ${appendToHead ? appendToHead : ''}`,
     injectIntoBody: `

--- a/workspaces/templates/packages/server-side-rendering/src/_document.ts
+++ b/workspaces/templates/packages/server-side-rendering/src/_document.ts
@@ -2,7 +2,9 @@
 
 import type { RenderDocumentProps } from '@goldstack/template-ssr';
 
-const renderDocument = (props: RenderDocumentProps<unknown>): string => {
+const renderDocument = async (
+  props: RenderDocumentProps<unknown>
+): Promise<string> => {
   const template = `
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
Changes the `renderDocument` interface to support asynchronous functions. This is for instance required for doing lookups in the static file mapping.