### PR TITLE
[server-side-rendering] Improve greedy paths

### DIFF
--- a/workspaces/templates-lib/packages/template-ssr-server/src/templateSSRServer.ts
+++ b/workspaces/templates-lib/packages/template-ssr-server/src/templateSSRServer.ts
@@ -84,7 +84,7 @@ export const renderPage = async <PropType>({
   if (!staticFileMapper) {
     staticFileMapper = new StaticFileMapperRun({
       store: staticFileMapperStore as MappingStore,
-      baseUrl: '_goldstack/static/generated/',
+      baseUrl: '/_goldstack/static/generated/',
     });
   }
   if (event.queryStringParameters && event.queryStringParameters['resource']) {

--- a/workspaces/templates-lib/packages/utils-aws-http-api-local/src/utilsAwsHttpApiLocal.ts
+++ b/workspaces/templates-lib/packages/utils-aws-http-api-local/src/utilsAwsHttpApiLocal.ts
@@ -36,16 +36,17 @@ export const startServer = async (
   }
   const lambdaConfig = readLambdaConfig(options.routesDir);
 
-  injectRoutes({
-    app: app,
-    lambdaConfigs: lambdaConfig,
-  });
-
+  // these should come before dynamic routes
   if (options.staticRoutes) {
     Object.entries(options.staticRoutes).forEach((e) => {
       app.use(e[0], express.static(e[1]));
     });
   }
+
+  injectRoutes({
+    app: app,
+    lambdaConfigs: lambdaConfig,
+  });
 
   const result = await new Promise<Server>((resolve) => {
     const server = app.listen(parseInt(options.port), function () {

--- a/workspaces/templates/packages/server-side-rendering/src/routes/$index.tsx
+++ b/workspaces/templates/packages/server-side-rendering/src/routes/$index.tsx
@@ -33,7 +33,7 @@ export const handler: SSRHandler = async (event, context) => {
       message: 'Hi there',
     },
     entryPoint: __filename,
-    event: event,
+    event,
   });
 };
 

--- a/workspaces/templates/packages/server-side-rendering/src/state/staticFiles.json
+++ b/workspaces/templates/packages/server-side-rendering/src/state/staticFiles.json
@@ -3,24 +3,36 @@
     "names": [
       "goldstack-test-ssr--__index-bundle.js"
     ],
-    "generatedName": "-__index-bundle.930351029dd5c8271be7a5cc64ca99ad.js"
+    "generatedName": "-__index-bundle.e97f3abf7bcee6f636136c32a4138469.js"
   },
   {
     "names": [
       "goldstack-test-ssr--__index.map"
     ],
-    "generatedName": "-__index.0000ff79e59d0ba74762da840c0f2be4.map.json"
+    "generatedName": "-__index.20de119b8e0b6cbd0aeec387e637f962.map.json"
   },
   {
     "names": [
       "goldstack-test-ssr-posts.map"
     ],
-    "generatedName": "posts.b51ccd0b7463feb37566d6747bd9efac.map.json"
+    "generatedName": "posts.b9ce0ae35ba2d08c12d93733d4487582.map.json"
   },
   {
     "names": [
       "goldstack-test-ssr-posts-bundle.js"
     ],
-    "generatedName": "posts-bundle.8c010962434a654ca92d597d1837da1c.js"
+    "generatedName": "posts-bundle.1e939994e4994afd01497c3514c30ba6.js"
+  },
+  {
+    "names": [
+      "goldstack-test-ssr-_greedy__.map"
+    ],
+    "generatedName": "_greedy__.d7f84bd112c7f475fe81f4ba17013d86.map.json"
+  },
+  {
+    "names": [
+      "goldstack-test-ssr-_greedy__-bundle.js"
+    ],
+    "generatedName": "_greedy__-bundle.87bae541feacf843c258c7404ce9d39c.js"
   }
 ]


### PR DESCRIPTION
In local testing, it was previously not possible to access any static paths if a greedy route is given.

This PR fixes that issue by ensuring that the local express server resolves static routes before dynamic ones.