### PR TITLE
User management local testing

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2597,6 +2597,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@goldstack/server-side-rendering", "workspace:workspaces/templates/packages/server-side-rendering"],\
             ["@goldstack/template-ssr", "workspace:workspaces/templates-lib/packages/template-ssr"],\
             ["@goldstack/template-ssr-cli", "workspace:workspaces/templates-lib/packages/template-ssr-cli"],\
+            ["@goldstack/user-management", "workspace:workspaces/templates/packages/user-management"],\
             ["@goldstack/utils-aws-http-api-local", "workspace:workspaces/templates-lib/packages/utils-aws-http-api-local"],\
             ["@goldstack/utils-esbuild", "workspace:workspaces/utils/packages/utils-esbuild"],\
             ["@jest-mock/express", "npm:1.4.5"],\

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,7 @@
   },
   "cSpell.words": [
     "GOLDSTACK",
+    "Jwks",
     "testcontainers"
   ]
 }

--- a/workspaces/templates-lib/packages/template-user-management/src/cognitoClientAuth.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/cognitoClientAuth.ts
@@ -1,4 +1,4 @@
-/* esbuild-ignore ui */
+/* esbuild-ignore server */
 
 import { EmbeddedPackageConfig } from '@goldstack/utils-package-config-embedded';
 import { getCodeVerifier } from './codeChallenge';
@@ -29,19 +29,24 @@ export async function getToken(args: {
   packageSchema: any;
   deploymentsOutput: any;
   deploymentName?: string;
-}): Promise<GetTokenResults> {
+}): Promise<GetTokenResults | undefined> {
   const deploymentName = getDeploymentName(args.deploymentName);
 
   if (deploymentName === 'local') {
-    if (args.code !== 'dummy-client-token') {
+    if (args.code !== 'dummy-local-client-code') {
       throw new Error(
-        `Unexpected code for client auth: '${args.code}'. Expected: dummy-client-token`
+        `Unexpected code for client auth: '${args.code}'. Expected: dummy-local-client-code`
       );
     }
+    const mockedUserAccessToken = getMockedUserAccessToken();
+    const mockedIdToken = getMockedUserIdToken();
+    if (!mockedUserAccessToken || !mockedIdToken) {
+      return;
+    }
     return {
-      accessToken: getMockedUserAccessToken(),
+      accessToken: mockedUserAccessToken,
       refreshToken: 'dummyRefreshToken',
-      idToken: getMockedUserIdToken(),
+      idToken: mockedIdToken,
     };
   }
 

--- a/workspaces/templates-lib/packages/template-user-management/src/cognitoClientAuth.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/cognitoClientAuth.ts
@@ -1,3 +1,5 @@
+/* esbuild-ignore ui */
+
 import { EmbeddedPackageConfig } from '@goldstack/utils-package-config-embedded';
 import { getCodeVerifier } from './codeChallenge';
 import { getEndpoint } from './cognitoEndpoints';
@@ -5,6 +7,10 @@ import {
   UserManagementDeployment,
   UserManagementPackage,
 } from './templateUserManagement';
+import {
+  getMockedUserAccessToken,
+  getMockedUserIdToken,
+} from './userManagementClientMock';
 import {
   getDeploymentName,
   getDeploymentsOutput,
@@ -33,9 +39,9 @@ export async function getToken(args: {
       );
     }
     return {
-      accessToken: 'dummyToken',
+      accessToken: getMockedUserAccessToken(),
       refreshToken: 'dummyRefreshToken',
-      idToken: 'dummyIdToken',
+      idToken: getMockedUserIdToken(),
     };
   }
 

--- a/workspaces/templates-lib/packages/template-user-management/src/cognitoTokenVerify.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/cognitoTokenVerify.ts
@@ -13,6 +13,21 @@ import {
   getDeploymentName,
   getDeploymentsOutput,
 } from './userManagementConfig';
+import {
+  getLocalUserManager,
+  LocalUserManagerImpl,
+} from './userManagementServerMock';
+
+export interface CognitoManager {
+  validate(accessToken: string): Promise<CognitoAccessTokenPayload>;
+  /**
+   * Validates an id token without validating it. On the server, ensure to validate the <i>accessToken</i> as well.
+   * It is not recommended practice to assert authentication for an API using an id token only.
+   */
+  validateIdToken(
+    idToken: string
+  ): Promise<CognitoIdTokenPayload & { email: string }>;
+}
 
 /**
  * We want to keep only one JWKS cache globally for our application.
@@ -33,7 +48,7 @@ export async function connectWithCognito({
   deploymentName = getDeploymentName(deploymentName);
 
   if (deploymentName === 'local') {
-    return new LocalUserManagerImpl();
+    return getLocalUserManager();
   }
 
   const deploymentOutput = getDeploymentsOutput(
@@ -68,17 +83,6 @@ export async function connectWithCognito({
   return new CognitoManagerImpl(accessTokenVerifier, idTokenVerifier);
 }
 
-export interface CognitoManager {
-  validate(accessToken: string): Promise<CognitoAccessTokenPayload>;
-  /**
-   * Validates an id token without validating it. On the server, ensure to validate the <i>accessToken</i> as well.
-   * It is not recommended practice to assert authentication for an API using an id token only.
-   */
-  validateIdToken(
-    idToken: string
-  ): Promise<CognitoIdTokenPayload & { email: string }>;
-}
-
 export class CognitoManagerImpl implements CognitoManager {
   accessTokenVerifier: CognitoJwtVerifier<any, any, any>;
   idTokenVerifier: CognitoJwtVerifier<any, any, any>;
@@ -109,48 +113,5 @@ export class CognitoManagerImpl implements CognitoManager {
     } catch {
       throw new Error('Invalid token');
     }
-  }
-}
-
-export class LocalUserManagerImpl implements CognitoManager {
-  async validateIdToken(
-    idToken: string
-  ): Promise<CognitoIdTokenPayload & { email: string }> {
-    return {
-      at_hash: 'NixgfrD9129y_3vcIILTIg',
-      sub: '9ad18936-07ce-4c17-8ed9-278fdd35406a',
-      email_verified: true,
-      phone_number_verified: false,
-      'cognito:preferred_role': '',
-      'cognito:roles': [],
-      identities: [],
-      iss: 'https://cognito-idp.us-west-2.amazonaws.com/us-west-2_AnBhna7ph',
-      'cognito:username': '9ad18936-07ce-4c17-8ed9-278fdd35406a',
-      origin_jti: '72408fc1-2223-4a04-9a45-f10aaefd77ee',
-      aud: '7cuiqmug2c50sgqi93igjk16mf',
-      event_id: '4dcbf59b-53a8-4674-94c9-81eb2171b66d',
-      token_use: 'id',
-      auth_time: Math.floor(Date.now() / 1000),
-      exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
-      iat: Math.floor(Date.now() / 1000),
-      jti: '17fdf966-9882-4114-8095-ecc9ac19aa7b',
-      email: 'dummy@dummy.com',
-    };
-  }
-  async validate(jwtToken: string): Promise<CognitoAccessTokenPayload> {
-    return {
-      auth_time: Math.floor(Date.now() / 1000),
-      client_id: '7cuiqmug2c50sgqi93igjk16mf',
-      exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
-      iat: Math.floor(Date.now() / 1000),
-      iss: 'https://cognito-idp.us-west-2.amazonaws.com/us-west-2_AnBhna7ph',
-      jti: '53b68584-3a9e-4b97-b7de-10924c57d191',
-      origin_jti: '4ee806c2-6948-4d57-886b-1e94eb0f5193',
-      scope: 'openid email',
-      sub: '9ad18936-07ce-4c17-8ed9-278fdd35406a',
-      username: '9ad18936-07ce-4c17-8ed9-278fdd35406a',
-      token_use: 'access',
-      version: 2,
-    };
   }
 }

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -41,27 +41,27 @@ export function setLocalUserManager(userManager: CognitoManager): void {
 export function generateTestIdToken(
   properties: CognitoIdTokenPayload | object
 ): string {
-  if (typeof window === 'undefined') {
-    return userManagementServerMock.generateTestIdToken(properties);
-  } else {
-    return userManagementClientMock.getMockedUserAccessToken();
-  }
+  return userManagementServerMock.generateTestIdToken(properties);
 }
 
 export function generateTestAccessToken(
   properties: CognitoAccessTokenPayload | object
 ): string {
-  if (typeof window === 'undefined') {
-    return userManagementServerMock.generateTestAccessToken(properties);
-  } else {
-    return userManagementClientMock.getMockedUserIdToken();
-  }
+  return userManagementServerMock.generateTestAccessToken(properties);
+}
+
+export function getMockedUserIdToken() {
+  return userManagementClientMock.getMockedUserIdToken();
 }
 
 export function setMockedUserIdToken(
   propertiesOrToken: CognitoIdTokenPayload | object | string
 ) {
   return userManagementClientMock.setMockedUserIdToken(propertiesOrToken);
+}
+
+export function getMockedUserAccessToken() {
+  return userManagementClientMock.getMockedUserAccessToken();
 }
 
 export function setMockedUserAccessToken(

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -1,6 +1,8 @@
 export * from './types/UserManagementPackage';
 
 import * as tokenVerify from './cognitoTokenVerify';
+import * as userManagementServerMock from './userManagementServerMock';
+import * as userManagementClientMock from './userManagementClientMock';
 
 import { getEndpoint as getEndpointLib } from './cognitoEndpoints';
 import { getToken as getTokenLib } from './cognitoClientAuth';
@@ -13,6 +15,10 @@ import UserManagementPackage, {
 export type { CognitoManager } from './cognitoTokenVerify';
 
 import type { GetTokenResults } from './cognitoClientAuth';
+import {
+  CognitoAccessTokenPayload,
+  CognitoIdTokenPayload,
+} from 'aws-jwt-verify/jwt-model';
 export type { GetTokenResults };
 
 export async function connectWithCognito(args: {
@@ -22,6 +28,46 @@ export async function connectWithCognito(args: {
   deploymentName?: string;
 }): Promise<CognitoManager> {
   return tokenVerify.connectWithCognito(args);
+}
+
+export function getLocalUserManager(): CognitoManager {
+  return userManagementServerMock.getLocalUserManager();
+}
+
+export function setLocalUserManager(userManager: CognitoManager): void {
+  userManagementServerMock.setLocalUserManager(userManager);
+}
+
+export function generateTestIdToken(
+  properties: CognitoIdTokenPayload | object
+): string {
+  if (typeof window === 'undefined') {
+    return userManagementServerMock.generateTestIdToken(properties);
+  } else {
+    return userManagementClientMock.getMockedUserAccessToken();
+  }
+}
+
+export function generateTestAccessToken(
+  properties: CognitoAccessTokenPayload | object
+): string {
+  if (typeof window === 'undefined') {
+    return userManagementServerMock.generateTestAccessToken(properties);
+  } else {
+    return userManagementClientMock.getMockedUserIdToken();
+  }
+}
+
+export function setMockedUserIdToken(
+  propertiesOrToken: CognitoIdTokenPayload | object | string
+) {
+  return userManagementClientMock.setMockedUserIdToken(propertiesOrToken);
+}
+
+export function setMockedUserAccessToken(
+  propertiesOrToken: CognitoAccessTokenPayload | object | string
+) {
+  return userManagementClientMock.setMockedUserAccessToken(propertiesOrToken);
 }
 
 export type Endpoint =

--- a/workspaces/templates-lib/packages/template-user-management/src/userManagementClientMock.spec.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/userManagementClientMock.spec.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import {
   getMockedUserAccessToken,
   getMockedUserIdToken,
@@ -15,6 +16,7 @@ test('Should generate client-side tokens', () => {
     username: '024651bd-6c2d-4890-a15b-51fe281516b7',
   });
   const accessToken = getMockedUserAccessToken();
+  assert(accessToken);
   const accessTokenData = parseToken(accessToken);
   expect(accessTokenData.username).toEqual(
     '024651bd-6c2d-4890-a15b-51fe281516b7'
@@ -27,7 +29,14 @@ test('Should generate client-side tokens', () => {
     email: 'frontend@email.com',
   });
   const idToken = getMockedUserIdToken();
+  assert(idToken);
   const idTokenData = parseToken(idToken);
   expect(idTokenData.email).toEqual('frontend@email.com');
   expect(idTokenData.token_use).toEqual(getMockedIdTokenProperties().token_use);
+});
+
+test('Should be possible to switch to unauthenticated', () => {
+  setMockedUserAccessToken(undefined);
+  const accessToken = getMockedUserAccessToken();
+  expect(accessToken).toBeUndefined();
 });

--- a/workspaces/templates-lib/packages/template-user-management/src/userManagementClientMock.spec.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/userManagementClientMock.spec.ts
@@ -1,0 +1,33 @@
+import {
+  getMockedUserAccessToken,
+  getMockedUserIdToken,
+  parseToken,
+  setMockedUserAccessToken,
+  setMockedUserIdToken,
+} from './userManagementClientMock';
+import {
+  getMockedAccessTokenProperties,
+  getMockedIdTokenProperties,
+} from './userManagementMock';
+
+test('Should generate client-side tokens', () => {
+  setMockedUserAccessToken({
+    username: '024651bd-6c2d-4890-a15b-51fe281516b7',
+  });
+  const accessToken = getMockedUserAccessToken();
+  const accessTokenData = parseToken(accessToken);
+  expect(accessTokenData.username).toEqual(
+    '024651bd-6c2d-4890-a15b-51fe281516b7'
+  );
+  expect(accessTokenData.client_id).toEqual(
+    getMockedAccessTokenProperties().client_id
+  );
+
+  setMockedUserIdToken({
+    email: 'frontend@email.com',
+  });
+  const idToken = getMockedUserIdToken();
+  const idTokenData = parseToken(idToken);
+  expect(idTokenData.email).toEqual('frontend@email.com');
+  expect(idTokenData.token_use).toEqual(getMockedIdTokenProperties().token_use);
+});

--- a/workspaces/templates-lib/packages/template-user-management/src/userManagementClientMock.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/userManagementClientMock.ts
@@ -1,0 +1,90 @@
+/* esbuild-ignore server */
+
+import {
+  CognitoAccessTokenPayload,
+  CognitoIdTokenPayload,
+} from 'aws-jwt-verify/jwt-model';
+import {
+  getMockedAccessTokenProperties,
+  getMockedIdTokenProperties,
+} from './userManagementMock';
+
+let mockedUserAccessToken: string | undefined = undefined;
+let mockedUserIdToken: string | undefined = undefined;
+
+export function setMockedUserAccessToken(
+  propertiesOrToken: CognitoAccessTokenPayload | object | string
+) {
+  if (typeof propertiesOrToken === 'string') {
+    mockedUserAccessToken = propertiesOrToken;
+  }
+  if (!(typeof propertiesOrToken === 'object')) {
+    throw new Error(
+      'Properties for access token must be an object if not string token provided.'
+    );
+  }
+  mockedUserAccessToken = generateToken({
+    ...getMockedAccessTokenProperties(),
+    ...propertiesOrToken,
+  });
+}
+
+export function setMockedUserIdToken(
+  propertiesOrToken: CognitoIdTokenPayload | object | string
+) {
+  if (typeof propertiesOrToken === 'string') {
+    mockedUserIdToken = propertiesOrToken;
+  }
+  if (!(typeof propertiesOrToken === 'object')) {
+    throw new Error(
+      'Properties for id token must be an object if not string token provided.'
+    );
+  }
+  mockedUserIdToken = generateToken({
+    ...getMockedIdTokenProperties(),
+    ...propertiesOrToken,
+  });
+}
+
+function encodeBase64(str: string) {
+  return btoa(str);
+}
+
+function stringify(obj: unknown) {
+  return JSON.stringify(obj);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function checkSumGen(head: string, body: string): string {
+  return 'vCooWRquc3jzGtERLzDmO1JIjdXSwTVKHbA1T34VR0w';
+}
+
+function generateToken(properties: unknown): string {
+  let result = '';
+  const alg = { alg: 'HS256', typ: 'JWT' };
+  const header = encodeBase64(stringify(alg));
+  result += header + '.';
+  const body = encodeBase64(stringify(properties));
+  result += body + '.';
+  const checkSum = checkSumGen(header, body);
+  result += checkSum;
+  return result;
+}
+
+export function getMockedUserAccessToken() {
+  if (!mockedUserAccessToken) {
+    return generateToken(getMockedAccessTokenProperties());
+  }
+  return mockedUserAccessToken;
+}
+
+export function getMockedUserIdToken() {
+  if (!mockedUserIdToken) {
+    return generateToken(getMockedIdTokenProperties());
+  }
+  return mockedUserIdToken;
+}
+
+export function parseToken(token: string) {
+  return JSON.parse(atob(token.split('.')[1]));
+}

--- a/workspaces/templates-lib/packages/template-user-management/src/userManagementClientMock.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/userManagementClientMock.ts
@@ -13,8 +13,12 @@ let mockedUserAccessToken: string | undefined = undefined;
 let mockedUserIdToken: string | undefined = undefined;
 
 export function setMockedUserAccessToken(
-  propertiesOrToken: CognitoAccessTokenPayload | object | string
+  propertiesOrToken: CognitoAccessTokenPayload | object | string | undefined
 ) {
+  if (!propertiesOrToken) {
+    mockedUserAccessToken = undefined;
+    return;
+  }
   if (typeof propertiesOrToken === 'string') {
     mockedUserAccessToken = propertiesOrToken;
   }
@@ -30,8 +34,12 @@ export function setMockedUserAccessToken(
 }
 
 export function setMockedUserIdToken(
-  propertiesOrToken: CognitoIdTokenPayload | object | string
+  propertiesOrToken: CognitoIdTokenPayload | object | string | undefined
 ) {
+  if (!propertiesOrToken) {
+    mockedUserIdToken = undefined;
+    return;
+  }
   if (typeof propertiesOrToken === 'string') {
     mockedUserIdToken = propertiesOrToken;
   }
@@ -72,19 +80,16 @@ function generateToken(properties: unknown): string {
 }
 
 export function getMockedUserAccessToken() {
-  if (!mockedUserAccessToken) {
-    return generateToken(getMockedAccessTokenProperties());
-  }
   return mockedUserAccessToken;
 }
 
 export function getMockedUserIdToken() {
-  if (!mockedUserIdToken) {
-    return generateToken(getMockedIdTokenProperties());
-  }
   return mockedUserIdToken;
 }
 
 export function parseToken(token: string) {
   return JSON.parse(atob(token.split('.')[1]));
 }
+
+setMockedUserAccessToken({});
+setMockedUserIdToken({});

--- a/workspaces/templates-lib/packages/template-user-management/src/userManagementConfig.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/userManagementConfig.ts
@@ -4,6 +4,10 @@ export function getDeploymentName(deploymentName?: string) {
       deploymentName = process.env.GOLDSTACK_DEPLOYMENT;
     } else {
       deploymentName = (window as any).GOLDSTACK_DEPLOYMENT;
+      // fallback for Jest tests
+      if (!deploymentName && typeof process !== 'undefined') {
+        deploymentName = process.env.GOLDSTACK_DEPLOYMENT;
+      }
     }
   }
 

--- a/workspaces/templates-lib/packages/template-user-management/src/userManagementMock.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/userManagementMock.ts
@@ -1,0 +1,39 @@
+export function getMockedIdTokenProperties() {
+  return {
+    at_hash: 'NixgfrD9129y_3vcIILTIg',
+    sub: '9ad18936-07ce-4c17-8ed9-278fdd35406a',
+    email_verified: true,
+    phone_number_verified: false,
+    'cognito:preferred_role': '',
+    'cognito:roles': [],
+    identities: [],
+    iss: 'https://cognito-idp.us-west-2.amazonaws.com/us-west-2_AnBhna7ph',
+    'cognito:username': '9ad18936-07ce-4c17-8ed9-278fdd35406a',
+    origin_jti: '72408fc1-2223-4a04-9a45-f10aaefd77ee',
+    aud: '7cuiqmug2c50sgqi93igjk16mf',
+    event_id: '4dcbf59b-53a8-4674-94c9-81eb2171b66d',
+    token_use: 'id',
+    auth_time: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
+    iat: Math.floor(Date.now() / 1000),
+    jti: '17fdf966-9882-4114-8095-ecc9ac19aa7b',
+    email: 'dummy@dummy.com',
+  };
+}
+
+export function getMockedAccessTokenProperties() {
+  return {
+    auth_time: Math.floor(Date.now() / 1000),
+    client_id: '7cuiqmug2c50sgqi93igjk16mf',
+    exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
+    iat: Math.floor(Date.now() / 1000),
+    iss: 'https://cognito-idp.us-west-2.amazonaws.com/us-west-2_AnBhna7ph',
+    jti: '53b68584-3a9e-4b97-b7de-10924c57d191',
+    origin_jti: '4ee806c2-6948-4d57-886b-1e94eb0f5193',
+    scope: 'openid email',
+    sub: '9ad18936-07ce-4c17-8ed9-278fdd35406a',
+    username: '9ad18936-07ce-4c17-8ed9-278fdd35406a',
+    token_use: 'access',
+    version: 2,
+  };
+}

--- a/workspaces/templates-lib/packages/template-user-management/src/userManagementServerMock.spec.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/userManagementServerMock.spec.ts
@@ -1,0 +1,20 @@
+import {
+  generateTestIdToken,
+  getLocalUserManager,
+} from './userManagementServerMock';
+
+test('Should generate valid test tokens', async () => {
+  const cognitoManager = getLocalUserManager();
+
+  const idToken = generateTestIdToken({ email: 'myUser@email.com' });
+  const idTokenData = await cognitoManager.validateIdToken(idToken);
+  expect(idTokenData.email).toEqual('myUser@email.com');
+
+  const accessToken = generateTestIdToken({
+    username: '99918936-07ce-4c17-8ed9-278fdd35406a',
+  });
+  const accessTokenData = await cognitoManager.validateIdToken(accessToken);
+  expect(accessTokenData.username).toEqual(
+    '99918936-07ce-4c17-8ed9-278fdd35406a'
+  );
+});

--- a/workspaces/templates-lib/packages/template-user-management/src/userManagementServerMock.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/userManagementServerMock.ts
@@ -1,0 +1,96 @@
+/* esbuild-ignore ui */
+import crypto from 'crypto';
+
+import {
+  CognitoAccessTokenPayload,
+  CognitoIdTokenPayload,
+} from 'aws-jwt-verify/jwt-model';
+import { CognitoManager } from './cognitoTokenVerify';
+import {
+  getMockedAccessTokenProperties,
+  getMockedIdTokenProperties,
+} from './userManagementMock';
+
+let localCognitoManager: CognitoManager | undefined;
+
+export function getLocalUserManager(): CognitoManager {
+  if (localCognitoManager) {
+    return localCognitoManager;
+  }
+  localCognitoManager = new LocalUserManagerImpl();
+  return localCognitoManager;
+}
+
+export function setLocalUserManager(userManager: CognitoManager) {
+  localCognitoManager = userManager;
+}
+
+function encodeBase64(str: string) {
+  return Buffer.from(str).toString('base64');
+}
+
+function stringify(obj: unknown) {
+  return JSON.stringify(obj);
+}
+
+function checkSumGen(head: string, body: string): string {
+  const checkSumStr = head + '.' + body;
+  const hash = crypto.createHmac('sha256', 'dummy-key-for-local-testing');
+  const checkSum = hash.update(checkSumStr).digest('base64');
+  return checkSum;
+}
+
+function generateToken(properties: unknown): string {
+  let result = '';
+  const alg = { alg: 'HS256', typ: 'JWT' };
+  const header = encodeBase64(stringify(alg));
+  result += header + '.';
+  const body = encodeBase64(stringify(properties));
+  result += body + '.';
+  const checkSum = checkSumGen(header, body);
+  result += checkSum;
+  return result;
+}
+
+export function generateTestIdToken(
+  properties: CognitoIdTokenPayload | object
+): string {
+  const data = {
+    ...getMockedIdTokenProperties(),
+    ...properties,
+  };
+  return generateToken(data);
+}
+
+export function generateTestAccessToken(
+  properties: CognitoAccessTokenPayload | object
+): string {
+  const data = {
+    ...getMockedAccessTokenProperties(),
+    ...properties,
+  };
+  return generateToken(data);
+}
+
+function assertNotInProd() {
+  if (process.env.LAMBDA_TASK_ROOT) {
+    console.warn(
+      'JWT token validated using mock validator. ' +
+        'This validator does not verify if the token is verified correctly.'
+    );
+  }
+}
+
+export class LocalUserManagerImpl implements CognitoManager {
+  async validateIdToken(
+    idToken: string
+  ): Promise<CognitoIdTokenPayload & { email: string }> {
+    assertNotInProd();
+    return JSON.parse(Buffer.from(idToken.split('.')[1], 'base64').toString());
+  }
+
+  async validate(jwtToken: string): Promise<CognitoAccessTokenPayload> {
+    assertNotInProd();
+    return JSON.parse(Buffer.from(jwtToken.split('.')[1], 'base64').toString());
+  }
+}

--- a/workspaces/templates/packages/server-side-rendering/package.json
+++ b/workspaces/templates/packages/server-side-rendering/package.json
@@ -18,13 +18,14 @@
     "template": "yarn template-ts",
     "template-ts": "ts-node --project tsconfig.local.json --transpile-only src/template.ts",
     "test": "concurrently \"yarn test-ci-server --watch\" \"yarn test-ci-ui --watch\"",
-    "test-ci": "yarn test-ci-server && yarn test-ci-ui",
+    "test-ci": "GOLDSTACK_DEPLOYMENT=local yarn test-ci-server && yarn test-ci-ui",
     "test-ci-server": "TEST_SERVER_PORT=50331 CORS=http://localhost:3000 GOLDSTACK_DEPLOYMENT=local jest --passWithNoTests --verbose --config=jest.config.js --runInBand",
     "test-ci-ui": "GOLDSTACK_DEPLOYMENT=local jest --passWithNoTests --verbose --config=jest.config.ui.js --runInBand",
     "watch": "PORT=5054 CORS=http://localhost:3000 GOLDSTACK_DEPLOYMENT=local ts-node-dev --respawn --transpile-only --project tsconfig.local.json -r ./scripts/register.js ./scripts/start.ts"
   },
   "dependencies": {
     "@goldstack/template-ssr": "0.3.13",
+    "@goldstack/user-management": "workspace:^",
     "@goldstack/utils-esbuild": "0.5.4",
     "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.15",
     "date-fns": "^2.28.0",

--- a/workspaces/templates/packages/server-side-rendering/src/routes/$index.tsx
+++ b/workspaces/templates/packages/server-side-rendering/src/routes/$index.tsx
@@ -5,7 +5,14 @@ import { renderPage, hydrate } from './../render';
 import Panel from './../components/Panel';
 import styles from './$index.module.css';
 
+import {
+  performClientAuth,
+  performLogout,
+  setMockedUserAccessToken,
+} from '@goldstack/user-management';
 const Index = (props: { message: string }): JSX.Element => {
+  performClientAuth();
+  // performLogout();
   const [clicked, setClicked] = useState(false);
   return (
     <>
@@ -13,6 +20,7 @@ const Index = (props: { message: string }): JSX.Element => {
         onClick={() => {
           alert('hi');
           setClicked(true);
+          performLogout();
           // throw new Error('Havent seen this');
         }}
         className={`${styles.message}`}

--- a/workspaces/templates/packages/server-side-rendering/src/routes/posts.tsx
+++ b/workspaces/templates/packages/server-side-rendering/src/routes/posts.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { SSRHandler } from '@goldstack/template-ssr';
-
 import { renderPage, hydrate } from './../render';
 
+import {
+  performClientAuth,
+  performLogout,
+  setMockedUserAccessToken,
+} from '@goldstack/user-management';
+
 const Posts = (props: { posts: string[] }): JSX.Element => {
+  performClientAuth();
   return (
     <>
       <p>Posts:</p>

--- a/workspaces/templates/packages/server-side-rendering/src/state/staticFiles.json
+++ b/workspaces/templates/packages/server-side-rendering/src/state/staticFiles.json
@@ -3,25 +3,25 @@
     "names": [
       "goldstack-test-ssr--__index-bundle.js"
     ],
-    "generatedName": "-__index-bundle.54a9202a75c34a040e60f2834117e34e.js"
+    "generatedName": "-__index-bundle.e50679014ad8fa3ee7cc660fc2a05771.js"
   },
   {
     "names": [
       "goldstack-test-ssr--__index.map"
     ],
-    "generatedName": "-__index.9f81ff95f75b24a839b78d9c5dc7f334.map.json"
+    "generatedName": "-__index.30c84370b5e93e6ead50c675dafabef7.map.json"
   },
   {
     "names": [
       "goldstack-test-ssr-posts.map"
     ],
-    "generatedName": "posts.2acd377fa71fdaa25555fb9abffe23f5.map.json"
+    "generatedName": "posts.52ddad340905e35ce435f1f01fe36de2.map.json"
   },
   {
     "names": [
       "goldstack-test-ssr-posts-bundle.js"
     ],
-    "generatedName": "posts-bundle.f65251373dee693cff8b8e856a7aa792.js"
+    "generatedName": "posts-bundle.234d104564560bb5f0ae05adb1b6aabf.js"
   },
   {
     "names": [

--- a/workspaces/templates/packages/user-management/src/state/deployments.json
+++ b/workspaces/templates/packages/user-management/src/state/deployments.json
@@ -5,17 +5,17 @@
       "endpoint": {
         "sensitive": false,
         "type": "string",
-        "value": "cognito-idp.us-west-2.amazonaws.com/us-west-2_AnBhna7ph"
+        "value": "cognito-idp.us-west-2.amazonaws.com/us-west-2_Hilv7cc7L"
       },
       "user_pool_client_id": {
         "sensitive": false,
         "type": "string",
-        "value": "7cuiqmug2c50sgqi93igjk16mf"
+        "value": "n0cqc43fm4jvmfl9msnih3dah"
       },
       "user_pool_id": {
         "sensitive": false,
         "type": "string",
-        "value": "us-west-2_AnBhna7ph"
+        "value": "us-west-2_Hilv7cc7L"
       }
     }
   }

--- a/workspaces/templates/packages/user-management/src/users.spec.ts
+++ b/workspaces/templates/packages/user-management/src/users.spec.ts
@@ -1,12 +1,30 @@
-import { connectWithCognito, getEndpoint } from './users';
+import {
+  connectWithCognito,
+  generateTestAccessToken,
+  generateTestIdToken,
+  getEndpoint,
+} from './users';
 
 it('Should validate tokens', async () => {
   const cognito = await connectWithCognito();
-  const token = await cognito.validate('somedummytoken');
-  console.log(token);
+  const accessToken = generateTestAccessToken({
+    username: '37ba5b3e-2e76-4c45-baa3-e7b21101f40d',
+  });
+  const accessTokenData = await cognito.validate(accessToken);
+  expect(accessTokenData.username).toEqual(
+    '37ba5b3e-2e76-4c45-baa3-e7b21101f40d'
+  );
+  expect(accessTokenData.token_use).toEqual('access');
+
+  const idToken = generateTestIdToken({ email: 'testUser@email.com' });
+  const idTokenData = await cognito.validateIdToken(idToken);
+  expect(idTokenData.email).toEqual('testUser@email.com');
+  expect(idTokenData.token_use).toEqual('id');
 });
 
 it('Generate endpoints', async () => {
   const endpoint = await getEndpoint('authorize', 'prod');
-  console.log(endpoint);
+  expect(endpoint).toContain('oauth2/authorize');
+  expect(endpoint).toContain('client_id');
+  expect(endpoint).toContain('redirect_uri');
 });

--- a/workspaces/templates/packages/user-management/src/users.ts
+++ b/workspaces/templates/packages/user-management/src/users.ts
@@ -11,6 +11,15 @@ import goldstackConfig from './../goldstack.json';
 import packageSchema from './../schemas/package.schema.json';
 import deploymentsOutput from './state/deployments.json';
 
+export {
+  setLocalUserManager,
+  setMockedUserAccessToken,
+  setMockedUserIdToken,
+  generateTestAccessToken,
+  generateTestIdToken,
+  getLocalUserManager,
+} from '@goldstack/template-user-management';
+
 export async function performClientAuth(deploymentName?: string) {
   return templatePerformClientAuth({
     goldstackConfig,

--- a/workspaces/templates/packages/user-management/src/users.ts
+++ b/workspaces/templates/packages/user-management/src/users.ts
@@ -15,6 +15,8 @@ export {
   setLocalUserManager,
   setMockedUserAccessToken,
   setMockedUserIdToken,
+  getMockedUserAccessToken,
+  getMockedUserIdToken,
   generateTestAccessToken,
   generateTestIdToken,
   getLocalUserManager,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,6 +1617,7 @@ __metadata:
   dependencies:
     "@goldstack/template-ssr": 0.3.13
     "@goldstack/template-ssr-cli": 0.3.15
+    "@goldstack/user-management": "workspace:^"
     "@goldstack/utils-aws-http-api-local": 0.3.12
     "@goldstack/utils-esbuild": 0.5.4
     "@jest-mock/express": ^1.4.5
@@ -2554,7 +2555,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@goldstack/user-management@workspace:workspaces/templates/packages/user-management":
+"@goldstack/user-management@workspace:^, @goldstack/user-management@workspace:workspaces/templates/packages/user-management":
   version: 0.0.0-use.local
   resolution: "@goldstack/user-management@workspace:workspaces/templates/packages/user-management"
   dependencies:


### PR DESCRIPTION
For #276 

Extend user management local testing capability:

- Allow for testing with unauthenticated users
- Support tests in local browser, Jest + JSDOM and Node.js+Jest