### PR TITLE
Ensure types from esbuild are marked as type imports for plugin

### DIFF
--- a/workspaces/templates/packages/template-metadata/src/templates/userManagementTemplateData.ts
+++ b/workspaces/templates/packages/template-metadata/src/templates/userManagementTemplateData.ts
@@ -14,7 +14,7 @@ export const getUserManagementTemplate = (): ProjectTemplateProps => {
     metaDescription:
       'Add sign up and sign in capabilities to your web application in minutes. Also provides libraries to protect your backend APIs.',
     description:
-      'Provide sign up and sign up capabilities to your application using Amazon Cognito.',
+      'Provide sign up and sign in capabilities to your application using Amazon Cognito.',
     longDescription:
       'This module configures Amazon Cognito to provide sign up and sign in capabilities for your applications. Includes hosted UI for users to perform sign up and sign in operations.',
     actionLink: '/build?stack=user-management',

--- a/workspaces/utils/packages/esbuild-ssr-css-modules-plugin/src/esbuildSsrCssModulesPlugin.ts
+++ b/workspaces/utils/packages/esbuild-ssr-css-modules-plugin/src/esbuildSsrCssModulesPlugin.ts
@@ -1,4 +1,4 @@
-import { OnLoadArgs, OnLoadResult, Plugin, PluginBuild } from 'esbuild';
+import type { OnLoadArgs, OnLoadResult, Plugin, PluginBuild } from 'esbuild';
 import fs from 'fs';
 import { compileCss, CompileCssConfiguration } from 'node-css-require';
 import sha256 from 'sha256';


### PR DESCRIPTION
Unfortunately, even with this change there is an issue when trying to link the Goldstack monorepo locally (see #286 ). Somehow it only compiles when making `esbuild` into a normal (and not a dev) dependency.