### PR TITLE
Adding Documentation for Creating Templates

### DIFF
--- a/CONTRIBUTING.template.md
+++ b/CONTRIBUTING.template.md
@@ -1,5 +1,10 @@
 Thanks for taking the time to contribute! While the following documentation intends to be as comprehensive as possible, please do not hesitate to reach out by [opening a GitHub issue](https://github.com/goldstack/goldstack/issues) or on Twitter: [@mxro](https://twitter.com/mxro).
 
+Contents:
+
+- Getting Started with Development
+- Creating Templates
+
 ## Getting Started with Development
 
 ### Project Setup
@@ -96,3 +101,35 @@ If you make changes to the libraries in [template-lib](https://github.com/goldst
 You can take a look this video if you have any issues getting this working: https://youtu.be/wIXxhM4qWkA
 
 You can commit any changes to the Goldstack monorepo for a PR to this repository. You must use a separate git repository for your own project. Therefore it is important to place the generated project into the `workspaces/generated` folder since this is added to the `.gitignore` file in the Goldstack monorepo.
+
+## Creating Templates
+
+All Goldstack templates are defined as packages in the [`templates` workspace](https://github.com/goldstack/goldstack/tree/master/workspaces/templates/packages).
+
+A Goldstack template consists of the following:
+
+- A `template.json` file describing some template metadata
+- A `goldstack.json` file describing the configuration for deployments
+- A set of JSON schemas describing the template configuration. This is used to automatically render the Web interface for defining template configuration.
+- A `build.json` file that provides information which files should be included in the template and allows for some file modifications.
+
+Creating a new template will involve the following:
+
+1. Add the template source code as a new package in [`workspaces/templates/packages`](https://github.com/goldstack/goldstack/tree/master/workspaces/templates/packages)
+2. A template may use any of the Goldstack libraries provided or not. You can also define new reusable libraries in the [`templates-lib`](https://github.com/goldstack/goldstack/tree/master/workspaces/templates-lib) workspace. For an example for a simple library to provide a CLI for deploying the infrastructure for a template, see [templateS3Cli.ts](https://github.com/goldstack/goldstack/blob/master/workspaces/templates-lib/packages/template-s3-cli/src/templateS3Cli.ts).
+3. Every template must contain a `goldstack.json` and corresponding [JSON Schemas](https://github.com/goldstack/goldstack/tree/master/workspaces/templates/packages/app-nextjs/schemas). The `goldstack.json` file must reference the `package.schema.json` JSON schema, see
+
+```json
+{
+  "$schema": "./schemas/package.schema.json",
+  "name": "",
+  "template": ""
+}
+```
+
+4. Every template must contain a [`template.json`](https://github.com/goldstack/goldstack/blob/master/workspaces/templates/packages/app-nextjs/template.json) file.
+5. Every template must contain a [`build.json`](https://github.com/goldstack/goldstack/blob/master/workspaces/templates/packages/app-nextjs/build.json) file. This determines what files will be included in the template provided in projects.
+6. Template metadata used for building and rendering the template on the Goldstack UI is defined in the [`template-metadata`](https://github.com/goldstack/goldstack/tree/master/workspaces/templates/packages/template-metadata/src) package.
+7. The deploy set defined in the template metadata needs to be referenced in the GitHub deployment workflows for [dev](https://github.com/goldstack/goldstack/blob/master/.github/workflows/template_deploy_dev.yml#L11) and [prod](https://github.com/goldstack/goldstack/blob/master/.github/workflows/template_deploy_prod.yml#L11).
+
+We plan to simplify contributing templates in the future. For now, please don't hesitate to [reach out for help](https://github.com/goldstack/goldstack/issues).


### PR DESCRIPTION
Adding some basic documentation for creating templates.

This is probably going to change in the [next version](https://github.com/goldstack/goldstack/issues/302) of Goldstack.