### PR TITLE
Update dynamo-db-local to latest version

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -3105,7 +3105,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/tcp-port-used", "npm:1.0.1"],\
             ["@types/yargs", "npm:17.0.10"],\
             ["aws-sdk", "npm:2.1222.0"],\
-            ["dynamo-db-local", "npm:5.0.0"],\
+            ["dynamo-db-local", "npm:7.0.0"],\
             ["jest", "virtual:c517f8da57a5da8bfc1d1e83302c273ecb1d60e68c396bdaba5666ad4b8c39fa57ce0871dbd8f41202827d40cc5eee8ec09cf366499028a5dc8b1c0ecb931dbb#npm:29.3.1"],\
             ["rimraf", "npm:3.0.2"],\
             ["tcp-port-used", "npm:1.0.2"],\
@@ -10807,10 +10807,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["dynamo-db-local", [\
-        ["npm:5.0.0", {\
-          "packageLocation": "./.yarn/unplugged/dynamo-db-local-npm-5.0.0-ab7e022bff/node_modules/dynamo-db-local/",\
+        ["npm:7.0.0", {\
+          "packageLocation": "./.yarn/unplugged/dynamo-db-local-npm-7.0.0-97bf626b49/node_modules/dynamo-db-local/",\
           "packageDependencies": [\
-            ["dynamo-db-local", "npm:5.0.0"]\
+            ["dynamo-db-local", "npm:7.0.0"]\
           ],\
           "linkType": "HARD"\
         }]\

--- a/workspaces/templates-lib/packages/template-dynamodb/package.json
+++ b/workspaces/templates-lib/packages/template-dynamodb/package.json
@@ -48,7 +48,7 @@
     "@goldstack/utils-sh": "0.5.9",
     "@goldstack/utils-terraform": "0.4.13",
     "aws-sdk": "^2.1222.0",
-    "dynamo-db-local": "^5.0.0",
+    "dynamo-db-local": "^7.0.0",
     "tcp-port-used": "^1.0.2",
     "umzug": "^3.1.1"
   },

--- a/workspaces/templates-lib/packages/template-dynamodb/src/localDynamoDB.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb/src/localDynamoDB.ts
@@ -95,7 +95,7 @@ const spawnLocalDynamoDB = async (): Promise<DynamoDBInstance> => {
       },
     };
   }
-  if (commandExists('java')) {
+  if (commandExists('java') && false) {
     console.debug('Starting local DynamoDB with Java');
     const pr = dynamoDBLocal.spawn({ port: MAPPED_PORT, path: null });
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2080,7 +2080,7 @@ __metadata:
     "@types/tcp-port-used": ^1
     "@types/yargs": ^17.0.10
     aws-sdk: ^2.1222.0
-    dynamo-db-local: ^5.0.0
+    dynamo-db-local: ^7.0.0
     jest: ^29.3.1
     rimraf: ^3.0.2
     tcp-port-used: ^1.0.2
@@ -8733,10 +8733,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dynamo-db-local@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "dynamo-db-local@npm:5.0.0"
-  checksum: ba1761962cc9826d3c0fb0d106fd3bfc6794db295c7c9ad1e4e3dcb34123be04b56c0f72998bb9ac6416f56dffcd500e99e54fc8a2a791bba2336aaab047d1f1
+"dynamo-db-local@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "dynamo-db-local@npm:7.0.0"
+  checksum: 9de28277aef4644e856843f3c73790bd470aa2949df590ae876588fd99b5a493adf5f6a534a465dfe95c10911bfd06451558d1f70925b436998e313fad9371b9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue https://github.com/chrisguttandin/dynamo-db-local/issues/114 seems still not resolved, so leaving warning message in place when no Java is installed and the template needs to fall back to using Docker:

```
console.warn
    Docker doesn't currently support stopping the container, see https://github.com/chrisguttandin/dynamo-db-local/issues/114  
    It is recommended you install Java.
```