### PR TITLE
Simplify way to get SQS queue url and name for node-trigger-template

### DIFF
--- a/workspaces/templates-lib/packages/template-sqs/src/templateSqs.ts
+++ b/workspaces/templates-lib/packages/template-sqs/src/templateSqs.ts
@@ -5,7 +5,7 @@ export {
   getSQSDLQQueueUrl,
   getSQSQueueName,
   getSQSQueueUrl,
-} from './sqsConnect'; // Now importing from SQS-related module
+} from './sqsConnect';
 
 import { SendMessageRequest, SQSClient } from '@aws-sdk/client-sqs';
 import { excludeInBundle } from '@goldstack/utils-esbuild';

--- a/workspaces/templates/packages/lambda-node-trigger/infra/aws/output.tf
+++ b/workspaces/templates/packages/lambda-node-trigger/infra/aws/output.tf
@@ -11,9 +11,17 @@ output "lambda_function_name" {
 }
 
 output "sqs_queue_name" {
-  value = var.sqs_queue_name 
+  value = length(var.sqs_queue_name) > 0 ? aws_sqs_queue.queue[0].name : null
+}
+
+output "sqs_queue_url" {
+  value = length(var.sqs_queue_name) > 0 ? aws_sqs_queue.queue[0].url : null
 }
 
 output "sqs_dlq_queue_name" {
-  value = "${var.lambda_name}-dlq" 
+  value = length(var.sqs_queue_name) > 0 ? aws_sqs_queue.dlq[0].name : null
+}
+
+output "sqs_dlq_queue_url" {
+  value = length(var.sqs_queue_name) > 0 ? aws_sqs_queue.dlq[0].url : null
 }

--- a/workspaces/templates/packages/lambda-node-trigger/src/lambda.spec.ts
+++ b/workspaces/templates/packages/lambda-node-trigger/src/lambda.spec.ts
@@ -1,21 +1,64 @@
 import { SendMessageCommand } from '@aws-sdk/client-sqs';
 import { info } from '@goldstack/utils-log';
-import { connectToSQSQueue, getSQSDLQQueueUrl, getSQSQueueUrl } from './lambda';
+import {
+  connectToSQSQueue,
+  getSQSDLQQueueUrl,
+  getSQSQueueName,
+  getSQSQueueUrl,
+  getSQSDLQQueueName,
+} from './lambda';
 
-describe('Local testing for trigger Lambda', () => {
-  test('Send message to SQS and trigger Lambda', async () => {
-    const client = await connectToSQSQueue();
+describe('Lambda SQS Integration', () => {
+  describe('SQS Operations', () => {
+    test('should connect and send message to SQS queue', async () => {
+      const client = await connectToSQSQueue();
+      await client.send(
+        new SendMessageCommand({
+          QueueUrl: await getSQSDLQQueueUrl(),
+          MessageBody: 'Hello World',
+        })
+      );
+    });
 
-    await client.send(
-      new SendMessageCommand({
-        QueueUrl: await getSQSDLQQueueUrl(),
-        MessageBody: 'Hello World',
-      })
-    );
+    test('should connect to SQS queue with and without deployment name', async () => {
+      const clientWithDeployment = await connectToSQSQueue('prod');
+      const clientWithoutDeployment = await connectToSQSQueue();
+      expect(clientWithDeployment).toBeDefined();
+      expect(clientWithoutDeployment).toBeDefined();
+    });
   });
-  test.only('Can retrieve queue url', async () => {
-    const queueURL = await getSQSQueueUrl('prod');
-    info(`Retrieved queue URL: ${queueURL}`);
-    expect(queueURL).toBeDefined();
+
+  describe('Queue Configuration', () => {
+    test('should retrieve main queue name and URL (with/without deployment)', async () => {
+      // With deployment name
+      const queueNameProd = await getSQSQueueName('prod');
+      const queueUrlProd = await getSQSQueueUrl('prod');
+      info(`Production queue name: ${queueNameProd}, URL: ${queueUrlProd}`);
+      expect(queueNameProd).toBeDefined();
+      expect(queueUrlProd).toBeDefined();
+
+      // Without deployment name
+      const queueName = await getSQSQueueName();
+      const queueUrl = await getSQSQueueUrl();
+      info(`Default queue name: ${queueName}, URL: ${queueUrl}`);
+      expect(queueName).toBeDefined();
+      expect(queueUrl).toBeDefined();
+    });
+
+    test('should retrieve DLQ name and URL (with/without deployment)', async () => {
+      // With deployment name
+      const dlqNameProd = await getSQSDLQQueueName('prod');
+      const dlqUrlProd = await getSQSDLQQueueUrl('prod');
+      info(`Production DLQ name: ${dlqNameProd}, URL: ${dlqUrlProd}`);
+      expect(dlqNameProd).toBeDefined();
+      expect(dlqUrlProd).toBeDefined();
+
+      // Without deployment name
+      const dlqName = await getSQSDLQQueueName();
+      const dlqUrl = await getSQSDLQQueueUrl();
+      info(`Default DLQ name: ${dlqName}, URL: ${dlqUrl}`);
+      expect(dlqName).toBeDefined();
+      expect(dlqUrl).toBeDefined();
+    });
   });
 });

--- a/workspaces/templates/packages/lambda-node-trigger/src/lambda.spec.ts
+++ b/workspaces/templates/packages/lambda-node-trigger/src/lambda.spec.ts
@@ -1,5 +1,6 @@
 import { SendMessageCommand } from '@aws-sdk/client-sqs';
-import { connectToSQSQueue, getSQSDLQQueueUrl } from './lambda';
+import { info } from '@goldstack/utils-log';
+import { connectToSQSQueue, getSQSDLQQueueUrl, getSQSQueueUrl } from './lambda';
 
 describe('Local testing for trigger Lambda', () => {
   test('Send message to SQS and trigger Lambda', async () => {
@@ -11,5 +12,10 @@ describe('Local testing for trigger Lambda', () => {
         MessageBody: 'Hello World',
       })
     );
+  });
+  test.only('Can retrieve queue url', async () => {
+    const queueURL = await getSQSQueueUrl('prod');
+    info(`Retrieved queue URL: ${queueURL}`);
+    expect(queueURL).toBeDefined();
   });
 });

--- a/workspaces/templates/packages/lambda-node-trigger/src/lambda.ts
+++ b/workspaces/templates/packages/lambda-node-trigger/src/lambda.ts
@@ -12,7 +12,7 @@ import {
 
 import { SendMessageRequest, SQSClient } from '@aws-sdk/client-sqs';
 
-import deployments from './state/deployments.json'; // Import deployments
+import deployments from './state/deployments.json';
 import goldstackConfig from './../goldstack.json';
 import goldstackSchema from './../schemas/package.schema.json';
 
@@ -41,6 +41,8 @@ export const handler: Handler = async (event, context) => {
   }
 
   const queue = await connectToSQSQueue();
+  console.log('QueueName: ' + (await getSQSQueueName()));
+  console.log('Queue URL: ' + (await getSQSQueueUrl()));
 };
 
 /**
@@ -105,7 +107,12 @@ export const connectToSQSQueue = async (
 export async function getSQSQueueName(
   deploymentName?: string
 ): Promise<string> {
-  return await fetchQueueName(goldstackConfig, goldstackSchema, deploymentName);
+  return await fetchQueueName(
+    goldstackConfig,
+    goldstackSchema,
+    deployments,
+    deploymentName
+  );
 }
 
 /**
@@ -114,7 +121,12 @@ export async function getSQSQueueName(
  * @returns {Promise<string>} The URL of the SQS queue.
  */
 export async function getSQSQueueUrl(deploymentName?: string): Promise<string> {
-  return await fetchQueueUrl(goldstackConfig, goldstackSchema, deploymentName);
+  return await fetchQueueUrl(
+    goldstackConfig,
+    goldstackSchema,
+    deployments,
+    deploymentName
+  );
 }
 
 /**
@@ -128,6 +140,7 @@ export async function getSQSDLQQueueName(
   return await fetchDLQQueueName(
     goldstackConfig,
     goldstackSchema,
+    deployments,
     deploymentName
   );
 }
@@ -143,6 +156,7 @@ export async function getSQSDLQQueueUrl(
   return await fetchDLQQueueUrl(
     goldstackConfig,
     goldstackSchema,
+    deployments,
     deploymentName
   );
 }

--- a/workspaces/templates/packages/lambda-node-trigger/src/state/deployments.json
+++ b/workspaces/templates/packages/lambda-node-trigger/src/state/deployments.json
@@ -25,7 +25,12 @@
       "sqs_queue_name": {
         "sensitive": false,
         "type": "string",
-        "value": "lambda-node-trigger-sqs-test"
+        "value": "lambda-node-trigger-test-queue"
+      },
+      "sqs_queue_url": {
+        "sensitive": false,
+        "type": "string",
+        "value": "https://sqs.us-west-2.amazonaws.com/475629728374/lambda-node-trigger-test-queue"
       }
     }
   }


### PR DESCRIPTION
Using the deployment state instead of the goldstack configuration.