### PR TITLE
Removing singleton client for mocked SQS

### DIFF
--- a/workspaces/templates-lib/packages/template-sqs/src/sqsConnect.spec.ts
+++ b/workspaces/templates-lib/packages/template-sqs/src/sqsConnect.spec.ts
@@ -1,16 +1,25 @@
-import { SendMessageCommand } from '@aws-sdk/client-sqs';
+import { SendMessageCommand, SendMessageRequest } from '@aws-sdk/client-sqs';
 import {
   getSentMessageRequests,
   connect,
   getMockedDLQSQS,
+  getSQSQueueUrl,
+  getSQSDLQQueueUrl,
+  getMockedSQS,
 } from './templateSqs';
 
 describe('SQS connect', () => {
   it('Should connect to mocked SQS', async () => {
-    const sqs = await connect({}, {}, 'local');
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const sqs = getMockedSQS({ name: 'template-sqs' }, () => {});
     await sqs.send(
       new SendMessageCommand({
-        QueueUrl: 'https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue',
+        QueueUrl: await getSQSQueueUrl(
+          { name: 'template-sqs' },
+          {},
+          {},
+          'local'
+        ),
         MessageBody: 'This is a test message',
       })
     );
@@ -23,15 +32,62 @@ describe('SQS connect', () => {
     const sqs = getMockedDLQSQS({ name: 'template-sqs' });
     await sqs.send(
       new SendMessageCommand({
-        QueueUrl: 'https://sqs.us-east-1.amazonaws.com/123456789012/MyDLQQueue',
+        QueueUrl: await getSQSDLQQueueUrl(
+          { name: 'template-sqs' },
+          {},
+          {},
+          'local'
+        ),
         MessageBody: 'This is a second test message',
       })
     );
 
     const sentMessageRequests = getSentMessageRequests(sqs);
-    expect(sentMessageRequests).toHaveLength(2);
-    expect(sentMessageRequests[1].MessageBody).toBe(
+    expect(sentMessageRequests).toHaveLength(1);
+    expect(sentMessageRequests[0].MessageBody).toBe(
       'This is a second test message'
+    );
+  });
+  it('Should connect to multiple mocked SQS', async () => {
+    const callbackHandledRequests1: SendMessageRequest[] = [];
+
+    const callbackHandledRequests2: SendMessageRequest[] = [];
+    const sqs1 = getMockedSQS({ name: 'template-sqs-1' }, (request) => {
+      callbackHandledRequests1.push(request);
+    });
+    const sqs2 = getMockedSQS({ name: 'template-sqs-2' }, (request) => {
+      callbackHandledRequests2.push(request);
+    });
+    await sqs1.send(
+      new SendMessageCommand({
+        QueueUrl: await getSQSQueueUrl(
+          { name: 'template-sqs-1' },
+          {},
+          {},
+          'local'
+        ),
+        MessageBody: 'This is a test message for queue 1',
+      })
+    );
+
+    sqs2.send(
+      new SendMessageCommand({
+        QueueUrl: await getSQSQueueUrl(
+          { name: 'template-sqs-2' },
+          {},
+          {},
+          'local'
+        ),
+        MessageBody: 'This is a test message for queue 2',
+      })
+    );
+
+    expect(callbackHandledRequests1).toHaveLength(1);
+    expect(callbackHandledRequests2).toHaveLength(1);
+    const sentMessageRequests = getSentMessageRequests(sqs1);
+    expect(sentMessageRequests).toHaveLength(1);
+    expect(sentMessageRequests[0].MessageBody).toBe(
+      'This is a test message for queue 1'
     );
   });
 });

--- a/workspaces/templates-lib/packages/template-sqs/src/sqsConnect.ts
+++ b/workspaces/templates-lib/packages/template-sqs/src/sqsConnect.ts
@@ -8,8 +8,7 @@ import { excludeInBundle } from '@goldstack/utils-esbuild';
 import { CreateSQSClientSignature } from './mockedSQS';
 import { SqsDeployment, SqsPackage } from './templateSqs';
 import { AWSDeploymentRegion, getAWSUser } from '@goldstack/infra-aws';
-
-let mockedSQS: SQSClient | undefined;
+import { warn } from '@goldstack/utils-log';
 
 /**
  * Retrieves an environment variable by key. Throws an error if the variable is not set.
@@ -36,20 +35,14 @@ export const getMockedSQS = (
   goldstackConfig: any,
   onMessageSend?: MessageCallback
 ): SQSClient => {
-  if (!mockedSQS) {
-    const createSQSClient: CreateSQSClientSignature = require(excludeInBundle(
-      './mockedSQS'
-    )).createSQSClient;
-    mockedSQS = createSQSClient({
-      queueUrl: getLocalSQSQueueUrl(goldstackConfig),
-      sqsClient: undefined,
-      onMessageSend,
-    });
-  }
-  if (!mockedSQS) {
-    throw new Error('Mocked SQS client not initialized');
-  }
-  return mockedSQS;
+  const createSQSClient: CreateSQSClientSignature = require(excludeInBundle(
+    './mockedSQS'
+  )).createSQSClient;
+  return createSQSClient({
+    queueUrl: getLocalSQSQueueUrl(goldstackConfig),
+    sqsClient: undefined,
+    onMessageSend,
+  });
 };
 
 /**
@@ -61,20 +54,14 @@ export const getMockedDLQSQS = (
   goldstackConfig: any,
   onMessageSend?: MessageCallback
 ): SQSClient => {
-  if (!mockedSQS) {
-    const createSQSClient: CreateSQSClientSignature = require(excludeInBundle(
-      './mockedSQS'
-    )).createSQSClient;
-    mockedSQS = createSQSClient({
-      queueUrl: getLocalSQSDLQUrl(goldstackConfig),
-      sqsClient: undefined,
-      onMessageSend,
-    });
-  }
-  if (!mockedSQS) {
-    throw new Error('Mocked SQS client not initialized');
-  }
-  return mockedSQS;
+  const createSQSClient: CreateSQSClientSignature = require(excludeInBundle(
+    './mockedSQS'
+  )).createSQSClient;
+  return createSQSClient({
+    queueUrl: getLocalSQSDLQUrl(goldstackConfig),
+    sqsClient: undefined,
+    onMessageSend,
+  });
 };
 
 /**
@@ -143,6 +130,9 @@ export const connect = async (
   );
 
   if (deployment.name === 'local') {
+    warn(
+      `Initializing mocked SQS without handler for ${goldstackConfig.name}. Consider calling the connect() method from the instantiated template or use getMockedSQS()`
+    );
     return getMockedSQS(goldstackConfig);
   }
 

--- a/workspaces/templates/packages/lambda-node-trigger/src/lambda.spec.ts
+++ b/workspaces/templates/packages/lambda-node-trigger/src/lambda.spec.ts
@@ -34,7 +34,7 @@ describe('Lambda SQS Integration', () => {
       );
 
       const sentRequests = getSentMessageRequests(dlqClient);
-      expect(sentRequests).toHaveLength(2);
+      expect(sentRequests).toHaveLength(1);
     });
 
     test('should connect to default SQS queue', async () => {


### PR DESCRIPTION
This allows to test for messages sent to specific clients.

Also, without this, only the first client would be initialized correctly.