### PR TITLE
Explicitly define the log group for all AWS Lambdas

### DIFF
--- a/workspaces/templates/packages/app-nextjs-bootstrap/infra/aws/edge.tf
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/infra/aws/edge.tf
@@ -39,6 +39,12 @@ data "archive_file" "empty_lambda" {
   }
 }
 
+resource "aws_cloudwatch_log_group" "edge" {
+  provider          = aws.us-east-1
+  name              = "/aws/lambda/${replace(var.website_domain, ".", "-")}-edge"
+  retention_in_days = 30
+}
+
 resource "aws_lambda_function" "edge" {
   provider         = aws.us-east-1
   function_name    =  "${replace(var.website_domain, ".", "-")}-edge"
@@ -50,14 +56,18 @@ resource "aws_lambda_function" "edge" {
   timeout          = 30
   memory_size      = 512
   publish          = true
+
+  logging_config {
+    log_format = "Text"
+    log_group = aws_cloudwatch_log_group.edge.name
+  }
+
   lifecycle {
     ignore_changes = [
        filename,
     ]
   }
 }
-
-
 
 # Explicit roles to allow logging for Lambda. Not strictly required here due to the full admin access
 # granted in the lambda_admin_role_attach above. But added here to make it easier to fine-tune permissions

--- a/workspaces/templates/packages/app-nextjs/infra/aws/edge.tf
+++ b/workspaces/templates/packages/app-nextjs/infra/aws/edge.tf
@@ -31,6 +31,12 @@ data "archive_file" "empty_lambda" {
   }
 }
 
+resource "aws_cloudwatch_log_group" "edge" {
+  provider          = aws.us-east-1
+  name              = "/aws/lambda/${replace(var.website_domain, ".", "-")}-edge"
+  retention_in_days = 30
+}
+
 resource "aws_lambda_function" "edge" {
   provider         = aws.us-east-1
   function_name    =  "${replace(var.website_domain, ".", "-")}-edge"
@@ -42,14 +48,18 @@ resource "aws_lambda_function" "edge" {
   timeout          = 30
   memory_size      = 512
   publish          = true
+
+  logging_config {
+    log_format = "Text"
+    log_group = aws_cloudwatch_log_group.edge.name
+  }
+
   lifecycle {
     ignore_changes = [
        filename,
     ]
   }
 }
-
-
 
 # Explicit roles to allow logging for Lambda. Not strictly required here due to the full admin access
 # granted in the lambda_admin_role_attach above. But added here to make it easier to fine-tune permissions

--- a/workspaces/templates/packages/lambda-express/infra/aws/lambda.tf
+++ b/workspaces/templates/packages/lambda-express/infra/aws/lambda.tf
@@ -1,4 +1,3 @@
-
 data "archive_file" "empty_lambda" {
   type = "zip"
   output_path = "${path.module}/empty_lambda.zip"
@@ -7,6 +6,11 @@ data "archive_file" "empty_lambda" {
     content = "exports.handler = function() { };"
     filename = "lambda.js"
   }
+}
+
+resource "aws_cloudwatch_log_group" "main" {
+  name              = "/aws/lambda/${var.lambda_name}"
+  retention_in_days = 30
 }
 
 resource "aws_lambda_function" "main" {
@@ -34,6 +38,11 @@ resource "aws_lambda_function" "main" {
       GOLDSTACK_DEPLOYMENT = var.name
       CORS = var.cors
     }
+  }
+
+  logging_config {
+    log_format = "Text"
+    log_group = aws_cloudwatch_log_group.main.name
   }
 }
 

--- a/workspaces/templates/packages/lambda-go-gin/infra/aws/lambda.tf
+++ b/workspaces/templates/packages/lambda-go-gin/infra/aws/lambda.tf
@@ -1,4 +1,3 @@
-
 data "archive_file" "empty_lambda" {
   type = "zip"
   output_path = "${path.module}/empty_lambda.zip"
@@ -7,6 +6,11 @@ data "archive_file" "empty_lambda" {
     content = "exports.handler = function() { };"
     filename = "lambda.js"
   }
+}
+
+resource "aws_cloudwatch_log_group" "main" {
+  name              = "/aws/lambda/${var.lambda_name}"
+  retention_in_days = 30
 }
 
 resource "aws_lambda_function" "main" {
@@ -34,6 +38,11 @@ resource "aws_lambda_function" "main" {
       GOLDSTACK_DEPLOYMENT = var.name
       CORS = var.cors
     }
+  }
+
+  logging_config {
+    log_format = "Text"
+    log_group = aws_cloudwatch_log_group.main.name
   }
 }
 

--- a/workspaces/templates/packages/lambda-python-job/infra/aws/lambda.tf
+++ b/workspaces/templates/packages/lambda-python-job/infra/aws/lambda.tf
@@ -1,4 +1,3 @@
-
 data "archive_file" "empty_lambda" {
   type = "zip"
   output_path = "${path.module}/empty_lambda.zip"
@@ -7,6 +6,11 @@ data "archive_file" "empty_lambda" {
     content = "def handler(event, context):\n  return {\n    'statusCode': '200',\n    'body': 'lambda not defined'\n  }\n"
     filename = "lambda.py"
   }
+}
+
+resource "aws_cloudwatch_log_group" "main" {
+  name              = "/aws/lambda/${var.lambda_name}"
+  retention_in_days = 30
 }
 
 resource "aws_lambda_function" "main" {
@@ -32,6 +36,11 @@ resource "aws_lambda_function" "main" {
     variables = {
       GOLDSTACK_DEPLOYMENT = var.name
     }
+  }
+
+  logging_config {
+    log_format = "Text"
+    log_group = aws_cloudwatch_log_group.main.name
   }
 
   # Configure Dead-letter Queue for Lambda errors if DLQ is created

--- a/workspaces/templates/packages/serverless-api/infra/aws/lambda_routes.tf
+++ b/workspaces/templates/packages/serverless-api/infra/aws/lambda_routes.tf
@@ -39,6 +39,18 @@ resource "aws_lambda_function" "this" {
       NODE_OPTIONS         = "--enable-source-maps"
     }
   }
+
+  logging_config {
+    log_format = "Text"
+    log_group = aws_cloudwatch_log_group.this[each.key].name
+  }
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  for_each = var.lambdas
+
+  name              = "/aws/lambda/${aws_lambda_function.this[each.key].function_name}"
+  retention_in_days = 30
 }
 
 resource "aws_apigatewayv2_route" "this" {
@@ -59,7 +71,7 @@ resource "aws_apigatewayv2_integration" "this" {
   connection_type           = "INTERNET"
   description               = "Dynamic lambda integration"
   integration_method        = "POST"
-  integration_uri           = aws_lambda_function.this[each.key].invoke_arn
+  integration_uri          = aws_lambda_function.this[each.key].invoke_arn
 }
 
 resource "aws_lambda_permission" "this" {

--- a/workspaces/utils/packages/utils-sh/src/utilsSh.ts
+++ b/workspaces/utils/packages/utils-sh/src/utilsSh.ts
@@ -299,7 +299,11 @@ export const execAsync = async (
   return new Promise((resolve, reject) => {
     processAsync(cmd, (err, stdout, stderr) => {
       if (!params?.silent) {
-        console.log(stdout.toString());
+        const output = stdout.toString();
+        // do not log anything if output is empty
+        if (output.trim()) {
+          console.log(output);
+        }
       }
       if (err) {
         console.error('Command failed:', cmd);


### PR DESCRIPTION
This will ensure the log group is deleted when the Lambda is deleted and gives the user more control on how logging works.

This will also default keeping logs for 30 days as opposed to keeping them indefinitely by default.