### PR TITLE
Optimise testing for multiple dynamodb tables

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -3994,6 +3994,7 @@ const RAW_RUNTIME_STATE =
           ["@aws-sdk/lib-dynamodb", "virtual:e6f34f859070556a57f3e28b06868fee5b5297e04d5e68b2366d97af4549101da65ebaaccecfb342d1152c7ee50e1cbf8b22fe8bc8a7ff10d26165a7a93e6196#npm:3.645.0"],\
           ["@goldstack/template-dynamodb", "workspace:workspaces/templates-lib/packages/template-dynamodb"],\
           ["@goldstack/template-dynamodb-cli", "workspace:workspaces/templates-lib/packages/template-dynamodb-cli"],\
+          ["@goldstack/utils-log", "workspace:workspaces/utils/packages/utils-log"],\
           ["@swc/core", "virtual:c517f8da57a5da8bfc1d1e83302c273ecb1d60e68c396bdaba5666ad4b8c39fa57ce0871dbd8f41202827d40cc5eee8ec09cf366499028a5dc8b1c0ecb931dbb#npm:1.9.3"],\
           ["@swc/jest", "virtual:c517f8da57a5da8bfc1d1e83302c273ecb1d60e68c396bdaba5666ad4b8c39fa57ce0871dbd8f41202827d40cc5eee8ec09cf366499028a5dc8b1c0ecb931dbb#npm:0.2.37"],\
           ["@types/ejs", "npm:3.1.1"],\

--- a/workspaces/docs/docs/templates/dynamodb/development.md
+++ b/workspaces/docs/docs/templates/dynamodb/development.md
@@ -188,3 +188,34 @@ await startLocalDynamoDB(8080);
 ```
 
 By default the port `8000` will be used or the value of the environment variable `DYNAMODB_LOCAL_PORT)`.
+
+Since starting local DynamoDB instances takes a long time, it is recommended, to only call the `startLocalDynamoDB` in your tests or test suites.
+
+Then call `stopAllLocalDynamoDB` in a global teardown:
+
+
+`scripts/globalTeardown.ts`:
+
+```typescript
+import { info } from '@goldstack/utils-log';
+import { stopAllLocalDynamoDB } from './../src/table';
+
+export default async () => {
+  info(
+    'Jest global teardown: Stopping all left over local DynamoDB instances.'
+  );
+  await stopAllLocalDynamoDB();
+};
+```
+
+`jest.config.js`:
+
+```javascript
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const base = require('./../../jest.config');
+
+module.exports = {
+  ...base,
+  globalTeardown: '<rootDir>/scripts/globalTeardown.ts',
+};
+```

--- a/workspaces/docs/docs/templates/dynamodb/development.md
+++ b/workspaces/docs/docs/templates/dynamodb/development.md
@@ -156,3 +156,35 @@ const documentClient = new DynamoDB.DocumentClient({
   service: await connect(),
 });
 ```
+
+#### Testing
+
+To run test, you can use the methods `startLocalDynamoDB` and `stopLocalDynamoDB`:
+
+```
+it('Should connect to DynamoDB table', async () => {
+  await startLocalDynamoDB();
+
+  const table = await connect();
+
+  const res = await table.send(
+    new DescribeTableCommand({
+      TableName: await getTableName(),
+    })
+  );
+
+  expect(res.Table?.TableName?.length).toBeGreaterThan(2);
+  expect(table).toBeDefined();
+
+  await stopLocalDynamoDB();
+});
+
+```
+
+You can specify a port where the local DynamoDB server should run:
+
+```
+await startLocalDynamoDB(8080);
+```
+
+By default the port `8000` will be used or the value of the environment variable `DYNAMODB_LOCAL_PORT)`.

--- a/workspaces/templates-lib/packages/template-dynamodb/.gitignore
+++ b/workspaces/templates-lib/packages/template-dynamodb/.gitignore
@@ -1,0 +1,1 @@
+.localInstances.json

--- a/workspaces/templates-lib/packages/template-dynamodb/src/localInstances.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb/src/localInstances.ts
@@ -2,7 +2,6 @@
 import { debug, error } from '@goldstack/utils-log';
 import { DynamoDBInstance } from './localDynamoDB';
 import fs from 'fs';
-import path from 'path';
 
 /**
  * Interface representing the state that will be persisted to file
@@ -146,7 +145,14 @@ class LocalInstancesManagerImpl implements LocalInstancesManager {
         instance === 'stopped' ? 'stopped' : 'started'
       } on port ${port}. Currently defined instances: ${
         this.startedInstances.size
-      }`
+      }`,
+      {
+        definedInstances: this.startedInstances.size,
+        stoppedInstances: [...this.startedInstances.entries()].filter(
+          (e) => e[1] === 'stopped'
+        ).length,
+        allInstances: [...this.startedInstances.entries()],
+      }
     );
     this.saveState();
   }

--- a/workspaces/templates-lib/packages/template-dynamodb/src/localInstances.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb/src/localInstances.ts
@@ -1,0 +1,96 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { debug } from '@goldstack/utils-log';
+import { DynamoDBInstance } from './localDynamoDB';
+
+/**
+ * Interface for managing local DynamoDB instances and their usage
+ */
+export interface LocalInstancesManager {
+  /** Get an instance for a specific port if it exists and is running */
+  getInstance(port: number): DynamoDBInstance | 'stopped' | undefined;
+  /** Get the first running instance if any exists */
+  getFirstRunningInstance(): DynamoDBInstance | undefined;
+  /** Set an instance for a specific port */
+  setInstance(port: number, instance: DynamoDBInstance | 'stopped'): void;
+  /** Get all running instances */
+  getAllInstances(): Map<number, DynamoDBInstance | 'stopped'>;
+  /** Get number of defined instances */
+  getInstanceCount(): number;
+  /** Increment usage counter for a port */
+  incrementUsageCounter(port: number): void;
+  /** Decrement usage counter for a port */
+  decrementUsageCounter(port: number): number;
+  /** Get current usage count for a port */
+  getUsageCount(port: number): number;
+  /** Remove usage counter for a port */
+  removeUsageCounter(port: number): void;
+}
+
+/**
+ * Implementation of LocalInstancesManager for managing DynamoDB local instances
+ */
+class LocalInstancesManagerImpl implements LocalInstancesManager {
+  // Track instances by port instead of table name
+  private startedInstances: Map<number, DynamoDBInstance | 'stopped'> =
+    new Map();
+  // Track number of active users per port
+  private portUsageCounter: Map<number, number> = new Map();
+
+  getInstance(port: number): DynamoDBInstance | 'stopped' | undefined {
+    return this.startedInstances.get(port);
+  }
+
+  getFirstRunningInstance(): DynamoDBInstance | undefined {
+    for (const [port, instance] of this.startedInstances.entries()) {
+      if (instance !== 'stopped') {
+        debug(`Found existing local DynamoDB instance on port ${port}`);
+        return instance;
+      }
+    }
+    return undefined;
+  }
+
+  setInstance(port: number, instance: DynamoDBInstance | 'stopped'): void {
+    this.startedInstances.set(port, instance);
+    debug(
+      `DynamoDB local instance ${
+        instance === 'stopped' ? 'stopped' : 'started'
+      } on port ${port}. Currently defined instances: ${
+        this.startedInstances.size
+      }`
+    );
+  }
+
+  getAllInstances(): Map<number, DynamoDBInstance | 'stopped'> {
+    return this.startedInstances;
+  }
+
+  getInstanceCount(): number {
+    return this.startedInstances.size;
+  }
+
+  incrementUsageCounter(port: number): void {
+    this.portUsageCounter.set(port, (this.portUsageCounter.get(port) || 0) + 1);
+  }
+
+  decrementUsageCounter(port: number): number {
+    const currentCount = this.portUsageCounter.get(port) || 0;
+    if (currentCount <= 1) {
+      this.portUsageCounter.delete(port);
+      return 0;
+    }
+    this.portUsageCounter.set(port, currentCount - 1);
+    return currentCount - 1;
+  }
+
+  getUsageCount(port: number): number {
+    return this.portUsageCounter.get(port) || 0;
+  }
+
+  removeUsageCounter(port: number): void {
+    this.portUsageCounter.delete(port);
+  }
+}
+
+// Export singleton instance
+export const localInstancesManager = new LocalInstancesManagerImpl();

--- a/workspaces/templates-lib/packages/template-dynamodb/src/localInstances.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb/src/localInstances.ts
@@ -1,6 +1,16 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { debug } from '@goldstack/utils-log';
+import { debug, error } from '@goldstack/utils-log';
 import { DynamoDBInstance } from './localDynamoDB';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Interface representing the state that will be persisted to file
+ */
+interface PersistedState {
+  instances: { [port: string]: 'stopped' | { port: number } };
+  usageCounts: { [port: string]: number };
+}
 
 /**
  * Interface for managing local DynamoDB instances and their usage
@@ -30,11 +40,77 @@ export interface LocalInstancesManager {
  * Implementation of LocalInstancesManager for managing DynamoDB local instances
  */
 class LocalInstancesManagerImpl implements LocalInstancesManager {
+  private readonly stateFile = '.localInstances.json';
   // Track instances by port instead of table name
   private startedInstances: Map<number, DynamoDBInstance | 'stopped'> =
     new Map();
   // Track number of active users per port
   private portUsageCounter: Map<number, number> = new Map();
+
+  constructor() {
+    this.loadState();
+  }
+
+  private loadState(): void {
+    try {
+      const data = fs.readFileSync(this.stateFile, 'utf8');
+      const state: PersistedState = JSON.parse(data);
+
+      // Clear existing maps
+      this.startedInstances.clear();
+      this.portUsageCounter.clear();
+
+      // Restore instances
+      Object.entries(state.instances).forEach(([port, instance]) => {
+        const portNum = parseInt(port);
+        if (instance === 'stopped') {
+          this.startedInstances.set(portNum, 'stopped');
+        } else {
+          // Create a dummy instance that will be replaced when actually started
+          this.startedInstances.set(portNum, {
+            port: portNum,
+            stop: async () => {
+              // no-op since this is just a placeholder
+            },
+          });
+        }
+      });
+
+      // Restore usage counts
+      Object.entries(state.usageCounts).forEach(([port, count]) => {
+        this.portUsageCounter.set(parseInt(port), count);
+      });
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        error('Failed to load local instances state:', err);
+      }
+      // File doesn't exist yet, that's fine
+    }
+  }
+
+  private saveState(): void {
+    try {
+      const state: PersistedState = {
+        instances: {},
+        usageCounts: {},
+      };
+
+      // Save instances
+      this.startedInstances.forEach((instance, port) => {
+        state.instances[port] =
+          instance === 'stopped' ? 'stopped' : { port: instance.port };
+      });
+
+      // Save usage counts
+      this.portUsageCounter.forEach((count, port) => {
+        state.usageCounts[port] = count;
+      });
+
+      fs.writeFileSync(this.stateFile, JSON.stringify(state, null, 2));
+    } catch (err) {
+      error('Failed to save local instances state:', err);
+    }
+  }
 
   getInstance(port: number): DynamoDBInstance | 'stopped' | undefined {
     return this.startedInstances.get(port);
@@ -59,6 +135,7 @@ class LocalInstancesManagerImpl implements LocalInstancesManager {
         this.startedInstances.size
       }`
     );
+    this.saveState();
   }
 
   getAllInstances(): Map<number, DynamoDBInstance | 'stopped'> {
@@ -71,15 +148,18 @@ class LocalInstancesManagerImpl implements LocalInstancesManager {
 
   incrementUsageCounter(port: number): void {
     this.portUsageCounter.set(port, (this.portUsageCounter.get(port) || 0) + 1);
+    this.saveState();
   }
 
   decrementUsageCounter(port: number): number {
     const currentCount = this.portUsageCounter.get(port) || 0;
     if (currentCount <= 1) {
       this.portUsageCounter.delete(port);
+      this.saveState();
       return 0;
     }
     this.portUsageCounter.set(port, currentCount - 1);
+    this.saveState();
     return currentCount - 1;
   }
 
@@ -89,6 +169,7 @@ class LocalInstancesManagerImpl implements LocalInstancesManager {
 
   removeUsageCounter(port: number): void {
     this.portUsageCounter.delete(port);
+    this.saveState();
   }
 }
 

--- a/workspaces/templates-lib/packages/template-dynamodb/src/templateDynamoDBTable.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb/src/templateDynamoDBTable.ts
@@ -56,7 +56,7 @@ export const getTableName = async (
 export const startLocalDynamoDB = async (
   goldstackConfig: DynamoDBPackage | any,
   packageSchema: any,
-  port: number,
+  port?: number,
   deploymentName?: string
 ): Promise<void> => {
   deploymentName = getDeploymentName(deploymentName);
@@ -73,7 +73,16 @@ export const startLocalDynamoDB = async (
   const lib = require(excludeInBundle('./localDynamoDB')) as {
     startLocalDynamoDB: StartLocalDynamoDBType;
   };
-  await lib.startLocalDynamoDB(packageConfig, { port }, deploymentName);
+  const portToUse =
+    port ||
+    (process.env.DYNAMODB_LOCAL_PORT &&
+      parseInt(process.env.DYNAMODB_LOCAL_PORT)) ||
+    8000;
+  await lib.startLocalDynamoDB(
+    packageConfig,
+    { port: portToUse },
+    deploymentName
+  );
 };
 
 export const stopLocalDynamoDB = async (

--- a/workspaces/templates-lib/packages/template-ssr-server-compile-bundle/tsconfig.json
+++ b/workspaces/templates-lib/packages/template-ssr-server-compile-bundle/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../../../utils/packages/utils-esbuild"
     },
     {
+      "path": "../../../utils/packages/utils-log"
+    },
+    {
       "path": "../utils-package"
     },
     {

--- a/workspaces/templates/packages/dynamodb/.gitignore
+++ b/workspaces/templates/packages/dynamodb/.gitignore
@@ -1,0 +1,1 @@
+.localInstances.json

--- a/workspaces/templates/packages/dynamodb/jest.config.js
+++ b/workspaces/templates/packages/dynamodb/jest.config.js
@@ -3,4 +3,5 @@ const base = require('./../../jest.config');
 
 module.exports = {
   ...base,
+  globalTeardown: '<rootDir>/scripts/globalTeardown.ts',
 };

--- a/workspaces/templates/packages/dynamodb/package.json
+++ b/workspaces/templates/packages/dynamodb/package.json
@@ -27,6 +27,7 @@
     "@aws-sdk/client-dynamodb": "^3.645.0",
     "@aws-sdk/lib-dynamodb": "^3.645.0",
     "@goldstack/template-dynamodb": "0.3.30",
+    "@goldstack/utils-log": "0.3.16",
     "dynamodb-toolbox": "^1.11.8",
     "umzug": "^3.8.2"
   },

--- a/workspaces/templates/packages/dynamodb/scripts/globalTeardown.ts
+++ b/workspaces/templates/packages/dynamodb/scripts/globalTeardown.ts
@@ -1,0 +1,9 @@
+import { info } from '@goldstack/utils-log';
+import { stopAllLocalDynamoDB } from './../src/table';
+
+export default async () => {
+  info(
+    'Jest global teardown: Stopping all left over local DynamoDB instances.'
+  );
+  await stopAllLocalDynamoDB();
+};

--- a/workspaces/templates/packages/dynamodb/src/table.spec.ts
+++ b/workspaces/templates/packages/dynamodb/src/table.spec.ts
@@ -178,6 +178,7 @@ describe('DynamoDB Table', () => {
   });
 
   afterAll(async () => {
-    await stopLocalDynamoDB();
+    // no need for us to do this, we rely on `scripts/globalTeardown.ts`
+    // await stopLocalDynamoDB();
   });
 });

--- a/workspaces/templates/packages/dynamodb/src/table.ts
+++ b/workspaces/templates/packages/dynamodb/src/table.ts
@@ -3,6 +3,7 @@ import {
   getTableName as templateGetTableName,
   startLocalDynamoDB as templateStartLocalDynamoDB,
   stopLocalDynamoDB as templateStopLocalDynamoDB,
+  stopAllLocalDynamoDB as templateStopAllLocalDynamoDB,
   migrateDownTo as templateMigrateDownTo,
 } from '@goldstack/template-dynamodb';
 
@@ -84,14 +85,27 @@ export const startLocalDynamoDB = async (
 };
 
 export const stopLocalDynamoDB = async (
+  port?: string,
   deploymentName?: string
 ): Promise<void> => {
   return await templateStopLocalDynamoDB(
     goldstackConfig,
     goldstackSchema,
+    port,
     deploymentName
   );
 };
+
+export const stopAllLocalDynamoDB = async (
+  deploymentName?: string
+): Promise<void> => {
+  return await templateStopAllLocalDynamoDB(
+    goldstackConfig,
+    goldstackSchema,
+    deploymentName
+  );
+};
+
 export const getTableName = async (
   deploymentName?: string
 ): Promise<string> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2745,6 +2745,7 @@ __metadata:
     "@aws-sdk/lib-dynamodb": "npm:^3.645.0"
     "@goldstack/template-dynamodb": "npm:0.3.30"
     "@goldstack/template-dynamodb-cli": "npm:0.6.31"
+    "@goldstack/utils-log": "npm:0.3.16"
     "@swc/core": "npm:^1.9.3"
     "@swc/jest": "npm:^0.2.37"
     "@types/ejs": "npm:^3"


### PR DESCRIPTION
Now we try to only ever create one DynamoDB local instance.

Also added utilities and instructions to allow not needing to stop instances at the end of tests, but instead just stop the instance at the end through a global hook.