### PR TITLE
Fix duration for GetSessionTokenCommand

### DIFF
--- a/workspaces/templates-lib/packages/infra-aws/src/awsAuthUtils.ts
+++ b/workspaces/templates-lib/packages/infra-aws/src/awsAuthUtils.ts
@@ -33,7 +33,7 @@ export async function getAWSCredentials(
 
   const client = new STSClient({ credentials: provider });
   const input = {
-    DurationSeconds: 600,
+    DurationSeconds: 900,
   };
   const command = new GetSessionTokenCommand(input);
   const response = await client.send(command);


### PR DESCRIPTION
As per latest aws-sdk [documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-sts/Class/GetSessionTokenCommand/) durationSeconds minimal value is 900. Currently in goldstack value that we are using is 600. This lead to this error when I try to deploy application from local machine by executing command `yarn infra up prod`: 

Error while executing CLI command:1 validation error detected: Value '600' at 'durationSeconds' failed to satisfy constraint: Member must have value greater than or equal to 900