### PR TITLE
Fix start script for lambda-express template

### DIFF
--- a/workspaces/templates/packages/lambda-express/package.json
+++ b/workspaces/templates/packages/lambda-express/package.json
@@ -14,7 +14,7 @@
     "deploy": "yarn build && yarn template deploy \"$@\"",
     "deploy-ts": "yarn build && yarn template-ts deploy",
     "infra": "yarn template infra \"$@\"",
-    "start": "yarn compile && yarn node dist/local.js",
+    "start": "yarn compile && yarn node dist/src/local.js",
     "template": "yarn template-ts",
     "template-ts": "ts-node --swc scripts/template.ts",
     "test": "TEST_SERVER_PORT=5030 CORS=http://localhost:3000 GOLDSTACK_DEPLOYMENT=local jest --passWithNoTests --config=jest.config.js --runInBand",


### PR DESCRIPTION
Without this fix I cannot start lambda-express template server in local environment. 

Here is error:
```
yarn start

node:internal/modules/run_main:122
    triggerUncaughtException(
    ^
Error: Qualified path resolution failed: we looked for the following paths, but none could be accessed.


Source path: /media/mrav/04dd3316-73b0-46dc-b25c-f4b5591c1623/projects/test/packages/lambda-express/dist/local.js
Not found: /media/mrav/04dd3316-73b0-46dc-b25c-f4b5591c1623/projects/test/packages/lambda-express/dist/local.js

    at makeError (/media/mrav/04dd3316-73b0-46dc-b25c-f4b5591c1623/projects/test/.pnp.cjs:19624:34)
    at resolveUnqualified (/media/mrav/04dd3316-73b0-46dc-b25c-f4b5591c1623/projects/test/.pnp.cjs:21356:13)
    at resolveRequest (/media/mrav/04dd3316-73b0-46dc-b25c-f4b5591c1623/projects/test/.pnp.cjs:21396:14)
    at Object.resolveRequest (/media/mrav/04dd3316-73b0-46dc-b25c-f4b5591c1623/projects/test/.pnp.cjs:21452:26)
    at resolve$1 (file:///media/mrav/04dd3316-73b0-46dc-b25c-f4b5591c1623/projects/test/.pnp.loader.mjs:2043:21)
    at nextResolve (node:internal/modules/esm/hooks:748:28)
    at Hooks.resolve (node:internal/modules/esm/hooks:240:30)
    at MessagePort.handleMessage (node:internal/modules/esm/worker:199:24)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:827:20)
    at MessagePort.<anonymous> (node:internal/per_context/messageport:23:28)

Node.js v22.13.0
```

`local.ts` is not in root folder but in `src`. So with simple change of start script, everything is working. 