### PR TITLE
[Global] Add --ignore-missing-deployments deployment flag for infrastructure operations

### DIFF
--- a/.clinerules/coding.md
+++ b/.clinerules/coding.md
@@ -12,7 +12,7 @@ e.g. don't use `import { getNotionToken } from 'notion-data/src/user/getNotionTo
   - yarn build
   - yarn test (preferred at package folder)
 - For compilation, always prefer to run yarn compile in the project root
-
+- For all Git commands, add --no-pager 
 - To check formatting (uses Biome JS), use `yarn format-check` in the project root
 - To check linting (uses Biome JS), use `yarn lint` in the project root
 - DO NOT use npx to run Biome - only use the commands above

--- a/.clinerules/coding.md
+++ b/.clinerules/coding.md
@@ -11,6 +11,7 @@ e.g. don't use `import { getNotionToken } from 'notion-data/src/user/getNotionTo
   - yarn compile (preferred at project root)
   - yarn build
   - yarn test (preferred at package folder)
+- For compilation, always prefer to run yarn compile in the project root
 
 - To check formatting (uses Biome JS), use `yarn format-check` in the project root
 - To check linting (uses Biome JS), use `yarn lint` in the project root

--- a/workspaces/docs/docs/templates/shared/infrastructure.md
+++ b/workspaces/docs/docs/templates/shared/infrastructure.md
@@ -69,6 +69,14 @@ If you want to interact with the remote backend, you can also provide the `--inj
 yarn infra terraform [deployment] --inject-backend-config init
 ```
 
+By default, if you provide a deployment name that does not exist, the command will fail. In CI environments or for larger projects, it sometimes makes sense to run `yarn infra xx` over the whole project and skip packages for which the deployment is not defined. In that case, you can use the following flag:
+
+```bash
+yarn infra [command] [deployment] --ignore-missing-deployments
+```
+
+Now the CLI will output a warning if the deployment does not exist but not an error.
+
 ### Customizing Terraform
 
 Goldstack templates make it very easy to customize infrastructure to your specific needs. The easiest way to do this is to simply edit the `*.tf` files in the `infra/aws` folder. You can make the changes you need and then run `yarn infra up [deploymentName]` to apply the changes.

--- a/workspaces/templates-lib/packages/infra-aws/src/infraAws.ts
+++ b/workspaces/templates-lib/packages/infra-aws/src/infraAws.ts
@@ -58,20 +58,16 @@ process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
 export interface ReadDeploymentFromPackageConfigOptions {
   deploymentName: string;
   path?: string;
-  ignoreMissing?: boolean;
 }
 
 export const readDeploymentFromPackageConfig = (
   options: ReadDeploymentFromPackageConfigOptions,
-): AWSDeployment | null => {
-  const { deploymentName, path, ignoreMissing } = options;
+): AWSDeployment => {
+  const { deploymentName, path } = options;
   const packageConfig = readPackageConfig(path);
 
   const deployment = packageConfig.deployments.find((d) => d.name === deploymentName);
   if (!deployment) {
-    if (ignoreMissing) {
-      return null;
-    }
     throw new Error('Cannot find deployment with name: ' + deploymentName);
   }
 

--- a/workspaces/templates-lib/packages/infra-aws/src/infraAws.ts
+++ b/workspaces/templates-lib/packages/infra-aws/src/infraAws.ts
@@ -58,11 +58,15 @@ process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
 export const readDeploymentFromPackageConfig = (
   deploymentName: string,
   path?: string,
-): AWSDeployment => {
+  ignoreMissing?: boolean,
+): AWSDeployment | null => {
   const packageConfig = readPackageConfig(path);
 
   const deployment = packageConfig.deployments.find((d) => d.name === deploymentName);
   if (!deployment) {
+    if (ignoreMissing) {
+      return null;
+    }
     throw new Error('Cannot find deployment with name: ' + deploymentName);
   }
 

--- a/workspaces/templates-lib/packages/infra-aws/src/infraAws.ts
+++ b/workspaces/templates-lib/packages/infra-aws/src/infraAws.ts
@@ -55,11 +55,16 @@ export type {
 // deactivate warning message while v3 upgrade in process
 process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
 
+export interface ReadDeploymentFromPackageConfigOptions {
+  deploymentName: string;
+  path?: string;
+  ignoreMissing?: boolean;
+}
+
 export const readDeploymentFromPackageConfig = (
-  deploymentName: string,
-  path?: string,
-  ignoreMissing?: boolean,
+  options: ReadDeploymentFromPackageConfigOptions,
 ): AWSDeployment | null => {
+  const { deploymentName, path, ignoreMissing } = options;
   const packageConfig = readPackageConfig(path);
 
   const deployment = packageConfig.deployments.find((d) => d.name === deploymentName);

--- a/workspaces/templates-lib/packages/infra-hetzner/src/infraHetzner.ts
+++ b/workspaces/templates-lib/packages/infra-hetzner/src/infraHetzner.ts
@@ -15,11 +15,15 @@ export type { HetznerUser, HetznerDeployment };
 export const readDeploymentFromPackageConfig = (
   deploymentName: string,
   path?: string,
-): HetznerDeployment => {
+  ignoreMissing?: boolean,
+): HetznerDeployment | null => {
   const packageConfig = readPackageConfig(path);
 
   const deployment = packageConfig.deployments.find((d) => d.name === deploymentName);
   if (!deployment) {
+    if (ignoreMissing) {
+      return null;
+    }
     throw new Error('Cannot find deployment with name: ' + deploymentName);
   }
 

--- a/workspaces/templates-lib/packages/infra-hetzner/src/infraHetzner.ts
+++ b/workspaces/templates-lib/packages/infra-hetzner/src/infraHetzner.ts
@@ -12,11 +12,16 @@ import type { HetznerDeployment } from './types/HetznerDeployment';
 
 export type { HetznerUser, HetznerDeployment };
 
+export interface ReadDeploymentFromPackageConfigOptions {
+  deploymentName: string;
+  path?: string;
+  ignoreMissing?: boolean;
+}
+
 export const readDeploymentFromPackageConfig = (
-  deploymentName: string,
-  path?: string,
-  ignoreMissing?: boolean,
+  options: ReadDeploymentFromPackageConfigOptions,
 ): HetznerDeployment | null => {
+  const { deploymentName, path, ignoreMissing } = options;
   const packageConfig = readPackageConfig(path);
 
   const deployment = packageConfig.deployments.find((d) => d.name === deploymentName);

--- a/workspaces/templates-lib/packages/infra-hetzner/src/infraHetzner.ts
+++ b/workspaces/templates-lib/packages/infra-hetzner/src/infraHetzner.ts
@@ -15,20 +15,16 @@ export type { HetznerUser, HetznerDeployment };
 export interface ReadDeploymentFromPackageConfigOptions {
   deploymentName: string;
   path?: string;
-  ignoreMissing?: boolean;
 }
 
 export const readDeploymentFromPackageConfig = (
   options: ReadDeploymentFromPackageConfigOptions,
-): HetznerDeployment | null => {
-  const { deploymentName, path, ignoreMissing } = options;
+): HetznerDeployment => {
+  const { deploymentName, path } = options;
   const packageConfig = readPackageConfig(path);
 
   const deployment = packageConfig.deployments.find((d) => d.name === deploymentName);
   if (!deployment) {
-    if (ignoreMissing) {
-      return null;
-    }
     throw new Error('Cannot find deployment with name: ' + deploymentName);
   }
 

--- a/workspaces/templates-lib/packages/template-docker-image-aws/src/templateDockerImageAws.ts
+++ b/workspaces/templates-lib/packages/template-docker-image-aws/src/templateDockerImageAws.ts
@@ -77,7 +77,21 @@ export const run = async (args: string[]): Promise<void> => {
 
     if (command === 'infra') {
       const deploymentName = opArgs[1];
-      const deployment = packageConfig.getDeployment(deploymentName);
+      const ignoreMissingDeployments = args.includes('--ignore-missing-deployments');
+      let deployment: AWSDockerImageDeployment | undefined;
+
+      try {
+        deployment = packageConfig.getDeployment(deploymentName);
+      } catch (e) {
+        if (ignoreMissingDeployments) {
+          console.warn(
+            `Warning: Deployment '${deploymentName}' does not exist. Skipping operation.`,
+          );
+          return;
+        }
+        throw e;
+      }
+
       await infraAwsDockerImageCli(config, deployment, opArgs);
       return;
     }

--- a/workspaces/templates-lib/packages/template-docker-image-aws/src/templateDockerImageAws.ts
+++ b/workspaces/templates-lib/packages/template-docker-image-aws/src/templateDockerImageAws.ts
@@ -78,7 +78,8 @@ export const run = async (args: string[]): Promise<void> => {
     if (command === 'infra') {
       const deploymentName = opArgs[1];
       const ignoreMissingDeployments = args.includes('--ignore-missing-deployments');
-      let deployment: AWSDockerImageDeployment | undefined;
+
+      let deployment: AWSDockerImageDeployment;
 
       try {
         deployment = packageConfig.getDeployment(deploymentName);

--- a/workspaces/templates-lib/packages/template-hetzner-vps-cli/src/templateHetznerVPSCli.ts
+++ b/workspaces/templates-lib/packages/template-hetzner-vps-cli/src/templateHetznerVPSCli.ts
@@ -47,7 +47,7 @@ export const run = async (args: string[]): Promise<void> => {
 
     if (command === 'infra') {
       const ignoreMissingDeployments = args.includes('--ignore-missing-deployments');
-      let deployment: HetznerVPSDeployment | undefined;
+      let deployment: HetznerVPSDeployment;
 
       try {
         deployment = packageConfig.getDeployment(opArgs[1]);
@@ -69,12 +69,7 @@ export const run = async (args: string[]): Promise<void> => {
         return;
       }
 
-      const envResult = await initTerraformEnvironment(opArgs, ignoreMissingDeployments);
-      if (!envResult) {
-        console.warn(`Warning: Deployment '${opArgs[1]}' does not exist. Skipping operation.`);
-        return;
-      }
-      const { awsProvider } = envResult;
+      const { awsProvider } = await initTerraformEnvironment(opArgs);
       await terraformHetznerCli(opArgs, awsProvider);
 
       return;

--- a/workspaces/templates-lib/packages/utils-terraform-aws/src/utilsTerraformAws.ts
+++ b/workspaces/templates-lib/packages/utils-terraform-aws/src/utilsTerraformAws.ts
@@ -187,11 +187,10 @@ export const terraformAwsCli = async (
 export async function initTerraformEnvironment(args: string[], ignoreMissingDeployments?: boolean) {
   const deploymentName = args[1];
 
-  const deployment = readDeploymentFromPackageConfig(
+  const deployment = readDeploymentFromPackageConfig({
     deploymentName,
-    undefined,
-    ignoreMissingDeployments,
-  );
+    ignoreMissing: ignoreMissingDeployments,
+  });
 
   if (!deployment && ignoreMissingDeployments) {
     // Deployment doesn't exist and we're ignoring missing deployments

--- a/workspaces/templates-lib/packages/utils-terraform-hetzner/src/utilsTerraformHetzner.ts
+++ b/workspaces/templates-lib/packages/utils-terraform-hetzner/src/utilsTerraformHetzner.ts
@@ -35,9 +35,24 @@ export const terraformHetznerCli = async (
   provider: AWSCloudProvider,
   options?: TerraformOptions,
 ): Promise<void> => {
+  const ignoreMissingDeployments = args.includes('--ignore-missing-deployments');
   const deploymentName = args[1];
 
-  const deployment = readDeploymentFromPackageConfig(deploymentName);
+  const deployment = readDeploymentFromPackageConfig(
+    deploymentName,
+    undefined,
+    ignoreMissingDeployments,
+  );
+
+  if (!deployment && ignoreMissingDeployments) {
+    // Deployment doesn't exist and we're ignoring missing deployments
+    console.warn(`Warning: Deployment '${deploymentName}' does not exist. Skipping operation.`);
+    return;
+  }
+
+  if (!deployment) {
+    throw new Error('Cannot find deployment: ' + deploymentName);
+  }
 
   const user = await getHetznerUser(deployment.hetznerUser);
 

--- a/workspaces/templates-lib/packages/utils-terraform-hetzner/src/utilsTerraformHetzner.ts
+++ b/workspaces/templates-lib/packages/utils-terraform-hetzner/src/utilsTerraformHetzner.ts
@@ -38,19 +38,18 @@ export const terraformHetznerCli = async (
   const ignoreMissingDeployments = args.includes('--ignore-missing-deployments');
   const deploymentName = args[1];
 
-  const deployment = readDeploymentFromPackageConfig({
-    deploymentName,
-    ignoreMissing: ignoreMissingDeployments,
-  });
+  let deployment: any;
 
-  if (!deployment && ignoreMissingDeployments) {
-    // Deployment doesn't exist and we're ignoring missing deployments
-    console.warn(`Warning: Deployment '${deploymentName}' does not exist. Skipping operation.`);
-    return;
-  }
-
-  if (!deployment) {
-    throw new Error('Cannot find deployment: ' + deploymentName);
+  try {
+    deployment = readDeploymentFromPackageConfig({
+      deploymentName,
+    });
+  } catch (e) {
+    if (ignoreMissingDeployments) {
+      console.warn(`Warning: Deployment '${deploymentName}' does not exist. Skipping operation.`);
+      return;
+    }
+    throw e;
   }
 
   const user = await getHetznerUser(deployment.hetznerUser);

--- a/workspaces/templates-lib/packages/utils-terraform-hetzner/src/utilsTerraformHetzner.ts
+++ b/workspaces/templates-lib/packages/utils-terraform-hetzner/src/utilsTerraformHetzner.ts
@@ -38,11 +38,10 @@ export const terraformHetznerCli = async (
   const ignoreMissingDeployments = args.includes('--ignore-missing-deployments');
   const deploymentName = args[1];
 
-  const deployment = readDeploymentFromPackageConfig(
+  const deployment = readDeploymentFromPackageConfig({
     deploymentName,
-    undefined,
-    ignoreMissingDeployments,
-  );
+    ignoreMissing: ignoreMissingDeployments,
+  });
 
   if (!deployment && ignoreMissingDeployments) {
     // Deployment doesn't exist and we're ignoring missing deployments

--- a/workspaces/templates-lib/packages/utils-terraform/src/utilsTerraform.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/utilsTerraform.ts
@@ -23,33 +23,41 @@ export const infraCommands = (): any => {
       demandOption: true,
     });
   };
+
+  const ignoreMissingDeploymentsOption = (yargs: Argv<any>): Argv<any> => {
+    return yargs.option('ignore-missing-deployments', {
+      description: 'If the deployment does not exist, show a warning instead of failing.',
+      default: false,
+      demandOption: false,
+      type: 'boolean',
+    });
+  };
+
   return (yargs: Argv<any>): Argv<any> => {
     return yargs
       .command(
         'up <deployment>',
         'Stands up infrastructure for the specified deployment',
-        deploymentPositional,
+        (yargs) => deploymentPositional(ignoreMissingDeploymentsOption(yargs)),
       )
       .command(
         'init <deployment>',
         'Initialises Terraform working directory for deployment',
-        deploymentPositional,
+        (yargs) => deploymentPositional(ignoreMissingDeploymentsOption(yargs)),
       )
-      .command(
-        'plan <deployment>',
-        'Creates a Terraform execution plan for deployment',
-        deploymentPositional,
+      .command('plan <deployment>', 'Creates a Terraform execution plan for deployment', (yargs) =>
+        deploymentPositional(ignoreMissingDeploymentsOption(yargs)),
       )
       .command(
         'apply <deployment>',
         'Applies the last Terraform execution plan calculated using `infra plan`',
-        deploymentPositional,
+        (yargs) => deploymentPositional(ignoreMissingDeploymentsOption(yargs)),
       )
       .command(
         'destroy <deployment>',
         'DANGER: Destroys all deployed infrastructure for the deployment',
         (yargs) => {
-          return deploymentPositional(yargs).option('yes', {
+          return deploymentPositional(ignoreMissingDeploymentsOption(yargs)).option('yes', {
             alias: 'y',
             description:
               'DANGER: If provided, confirmation for deleting infrastructure resources will be skipped.',
@@ -62,13 +70,13 @@ export const infraCommands = (): any => {
       .command(
         'is-up <deployment>',
         'Checks whether infrastructure for a deployment is currently provisioned.',
-        deploymentPositional,
+        (yargs) => deploymentPositional(ignoreMissingDeploymentsOption(yargs)),
       )
       .command(
         'destroy-state <deployment>',
         'DANGER: Destroys the remote state stored for this deployment.',
         (yargs) => {
-          return deploymentPositional(yargs).option('yes', {
+          return deploymentPositional(ignoreMissingDeploymentsOption(yargs)).option('yes', {
             alias: 'y',
             description:
               'DANGER: If provided, confirmation for deleting remote state will be skipped.',
@@ -81,24 +89,27 @@ export const infraCommands = (): any => {
       .command(
         'create-state <deployment>',
         'Creates a remote state for this deployment if it does not already exist.',
-        deploymentPositional,
+        (yargs) => deploymentPositional(ignoreMissingDeploymentsOption(yargs)),
       )
       .command(
         'upgrade <deployment> <targetVersion>',
         'Upgrades Terraform version to a new target version (experimental)',
         (yargs) => {
-          return deploymentPositional(yargs).positional('targetVersion', {
-            type: 'string',
-            description: 'Provides the target Terraform version that should be migrated to.',
-            demandOption: true,
-          });
+          return deploymentPositional(ignoreMissingDeploymentsOption(yargs)).positional(
+            'targetVersion',
+            {
+              type: 'string',
+              description: 'Provides the target Terraform version that should be migrated to.',
+              demandOption: true,
+            },
+          );
         },
       )
       .command(
         'terraform <deployment> [command..]',
         'Runs an arbitrary Terraform CLI command',
         (yargs) => {
-          return deploymentPositional(yargs)
+          return deploymentPositional(ignoreMissingDeploymentsOption(yargs))
             .option('inject-variables', {
               description: 'Injects variables into the Terraform CLI command.',
               default: false,

--- a/workspaces/templates-management/packages/utils-template-test/src/tests/IgnoreMissingDeploymentsTest.ts
+++ b/workspaces/templates-management/packages/utils-template-test/src/tests/IgnoreMissingDeploymentsTest.ts
@@ -1,0 +1,38 @@
+import { read } from '@goldstack/utils-sh';
+import { yarn } from '@goldstack/utils-yarn';
+import path from 'path';
+import type { RunTestParams, TemplateTest } from '../types/TemplateTest';
+
+export class IgnoreMissingDeploymentsTest implements TemplateTest {
+  getName(): string {
+    return 'ignore-missing-deployments-test';
+  }
+
+  async runTest(params: RunTestParams): Promise<void> {
+    const packageJsonPath = path.join(params.packageDir, 'package.json');
+    const packageJson = JSON.parse(read(packageJsonPath));
+    const fakeDeploymentName = 'non-existent-deployment-test';
+
+    // Test without flag - should fail
+    let failedAsExpected = false;
+    try {
+      yarn(params.projectDir, `workspace ${packageJson.name} infra plan ${fakeDeploymentName}`);
+    } catch (e) {
+      failedAsExpected = true;
+      console.log('Command failed as expected without --ignore-missing-deployments flag');
+    }
+
+    if (!failedAsExpected) {
+      throw new Error(
+        'Expected command to fail without --ignore-missing-deployments flag, but it succeeded',
+      );
+    }
+
+    // Test with flag - should succeed with warning
+    yarn(
+      params.projectDir,
+      `workspace ${packageJson.name} infra plan ${fakeDeploymentName} --ignore-missing-deployments`,
+    );
+    console.log('Command succeeded with --ignore-missing-deployments flag');
+  }
+}

--- a/workspaces/templates-management/packages/utils-template-test/src/utilsTemplateTest.ts
+++ b/workspaces/templates-management/packages/utils-template-test/src/utilsTemplateTest.ts
@@ -15,6 +15,7 @@ import { AssertWebsiteTest } from './tests/AssertWebsiteTest';
 import { DeployTest } from './tests/DeployTest';
 import { DestroyStateTest } from './tests/DestroyStateTest';
 import { EnsureBabelRcDoesNotExist } from './tests/EnsureBabelRcDoesNotExist';
+import { IgnoreMissingDeploymentsTest } from './tests/IgnoreMissingDeploymentsTest';
 import { InfraDestroyTest } from './tests/InfraDestroyTest';
 import { InfraPlanTest } from './tests/InfraPlanTest';
 import { InfraUpTest } from './tests/InfraUpTest';
@@ -77,6 +78,7 @@ export const getTemplateTests = (): TemplateTest[] => {
     new AssertApplicationTest(),
     new AssertWebsiteTest(),
     new EnsureBabelRcDoesNotExist(),
+    new IgnoreMissingDeploymentsTest(),
   ];
 };
 

--- a/workspaces/templates/packages/template-metadata/src/deploySets/noInfra.ts
+++ b/workspaces/templates/packages/template-metadata/src/deploySets/noInfra.ts
@@ -72,7 +72,7 @@ export const createNoInfraBuildSetConfig = async (): Promise<DeploySetConfig> =>
             packageName: 's3-1',
             configuration: {},
             deployments: [],
-            packageTests: ['assert-package-files'],
+            packageTests: ['assert-package-files', 'ignore-missing-deployments-test'],
             packageCleanUp: [],
           },
           {


### PR DESCRIPTION
By default, if you provide a deployment name that does not exist, the command will fail. In CI environments or for larger projects, it sometimes makes sense to run `yarn infra xx` over the whole project and skip packages for which the deployment is not defined. In that case, you can use the following flag:

```bash
yarn infra [command] [deployment] --ignore-missing-deployments
```

Now the CLI will output a warning if the deployment does not exist but not an error.