### PR TITLE
[Global] Support `--ignore-missing-deployments` for deploy command

### DIFF
--- a/workspaces/docs/docs/templates/shared/deployment.md
+++ b/workspaces/docs/docs/templates/shared/deployment.md
@@ -3,3 +3,5 @@ This template can be packaged up and deployed to the deployments specified in `g
 ```bash
 yarn deploy [deploymentName]
 ```
+
+This command supports the flag `--ignore-missing-deployments`. If this is not provided, the command will fail if the deployment does not exist. If the flag is provided, only a warning will be shown. This is useful if not all components of an application are required for all deployments.

--- a/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
@@ -4,6 +4,7 @@ import type {
   DynamoDBPackage,
 } from '@goldstack/template-dynamodb';
 import { wrapCli } from '@goldstack/utils-cli';
+import { warn } from '@goldstack/utils-log';
 import { buildCli, buildDeployCommands } from '@goldstack/utils-package';
 import { PackageConfig } from '@goldstack/utils-package-config';
 import { infraCommands } from '@goldstack/utils-terraform';
@@ -75,7 +76,18 @@ export const run = async ({
     }
 
     if (command === 'deploy') {
-      await dynamoDBCli(migrations, ['init', opArgs[0]]);
+      const deploymentName = opArgs[0];
+      if (!packageConfig.hasDeployment(deploymentName)) {
+        if (argv['ignore-missing-deployments']) {
+          warn(
+            `Deployment '${deploymentName}' does not exist. Skipping deploy due to --ignore-missing-deployments flag.`,
+          );
+          return;
+        } else {
+          throw new Error(`Cannot find configuration for deployment '${deploymentName}'`);
+        }
+      }
+      await dynamoDBCli(migrations, ['init', deploymentName]);
       return;
     }
 

--- a/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
@@ -67,6 +67,17 @@ export const run = async ({
     const [, , , ...opArgs] = args;
 
     if (command === 'infra') {
+      const deploymentName = opArgs[1];
+      if (!packageConfig.hasDeployment(deploymentName)) {
+        if (argv['ignore-missing-deployments']) {
+          warn(
+            `Deployment '${deploymentName}' does not exist. Skipping infra due to --ignore-missing-deployments flag.`,
+          );
+          return;
+        } else {
+          throw new Error(`Cannot find configuration for deployment '${deploymentName}'`);
+        }
+      }
       await dynamoDBCli(migrations, ['init', opArgs[1]]);
       await terraformAwsCli(opArgs);
       if (opArgs[0] === 'destroy') {

--- a/workspaces/templates-lib/packages/template-lambda-api-cli/src/templateLambdaApiCli.ts
+++ b/workspaces/templates-lib/packages/template-lambda-api-cli/src/templateLambdaApiCli.ts
@@ -112,10 +112,21 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'deploy') {
+      const deploymentName = opArgs[0];
+      if (!packageConfig.hasDeployment(deploymentName)) {
+        if (argv['ignore-missing-deployments']) {
+          warn(
+            `Deployment '${deploymentName}' does not exist. Skipping deploy due to --ignore-missing-deployments flag.`,
+          );
+          return;
+        } else {
+          throw new Error(`Cannot find configuration for deployment '${deploymentName}'`);
+        }
+      }
       await deployFunctions({
         routesPath: defaultRoutesPath,
-        configuration: packageConfig.getDeployment(opArgs[0]).configuration,
-        deployment: packageConfig.getDeployment(opArgs[0]),
+        configuration: packageConfig.getDeployment(deploymentName).configuration,
+        deployment: packageConfig.getDeployment(deploymentName),
         config: filteredLambdaRoutes,
         packageRootFolder: pwd(),
       });

--- a/workspaces/templates-lib/packages/template-lambda-cli/src/templateLambdaCli.ts
+++ b/workspaces/templates-lib/packages/template-lambda-cli/src/templateLambdaCli.ts
@@ -1,4 +1,5 @@
 import { wrapCli } from '@goldstack/utils-cli';
+import { warn } from '@goldstack/utils-log';
 import { buildCli, buildDeployCommands } from '@goldstack/utils-package';
 import { PackageConfig } from '@goldstack/utils-package-config';
 import { infraCommands } from '@goldstack/utils-terraform';
@@ -36,7 +37,18 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'deploy') {
-      await deployCli(packageConfig.getDeployment(opArgs[0]));
+      const deploymentName = opArgs[0];
+      if (!packageConfig.hasDeployment(deploymentName)) {
+        if (argv['ignore-missing-deployments']) {
+          warn(
+            `Deployment '${deploymentName}' does not exist. Skipping deploy due to --ignore-missing-deployments flag.`,
+          );
+          return;
+        } else {
+          throw new Error(`Cannot find configuration for deployment '${deploymentName}'`);
+        }
+      }
+      await deployCli(packageConfig.getDeployment(deploymentName));
       return;
     }
 

--- a/workspaces/templates-lib/packages/template-lambda-http-cli/src/templateLambdaHttp.ts
+++ b/workspaces/templates-lib/packages/template-lambda-http-cli/src/templateLambdaHttp.ts
@@ -1,5 +1,6 @@
 import { deployLambda } from '@goldstack/template-lambda-cli';
 import { wrapCli } from '@goldstack/utils-cli';
+import { warn } from '@goldstack/utils-log';
 import { buildCli, buildDeployCommands } from '@goldstack/utils-package';
 import { PackageConfig } from '@goldstack/utils-package-config';
 import { infraCommands } from '@goldstack/utils-terraform';
@@ -34,7 +35,18 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'deploy') {
-      await deployLambda(packageConfig.getDeployment(opArgs[0]));
+      const deploymentName = opArgs[0];
+      if (!packageConfig.hasDeployment(deploymentName)) {
+        if (argv['ignore-missing-deployments']) {
+          warn(
+            `Deployment '${deploymentName}' does not exist. Skipping deploy due to --ignore-missing-deployments flag.`,
+          );
+          return;
+        } else {
+          throw new Error(`Cannot find configuration for deployment '${deploymentName}'`);
+        }
+      }
+      await deployLambda(packageConfig.getDeployment(deploymentName));
       return;
     }
 

--- a/workspaces/templates-lib/packages/template-s3-cli/src/templateS3Cli.ts
+++ b/workspaces/templates-lib/packages/template-s3-cli/src/templateS3Cli.ts
@@ -1,5 +1,6 @@
 import type { S3Deployment, S3Package } from '@goldstack/template-s3';
 import { wrapCli } from '@goldstack/utils-cli';
+import { warn } from '@goldstack/utils-log';
 import { buildCli, buildDeployCommands } from '@goldstack/utils-package';
 import { PackageConfig } from '@goldstack/utils-package-config';
 import { infraCommands } from '@goldstack/utils-terraform';
@@ -30,6 +31,17 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'deploy') {
+      const deploymentName = opArgs[0];
+      if (!packageConfig.hasDeployment(deploymentName)) {
+        if (argv['ignore-missing-deployments']) {
+          warn(
+            `Deployment '${deploymentName}' does not exist. Skipping deploy due to --ignore-missing-deployments flag.`,
+          );
+          return;
+        } else {
+          throw new Error(`Cannot find configuration for deployment '${deploymentName}'`);
+        }
+      }
       await deployCli(config, ['deploy', ...opArgs]);
       return;
     }

--- a/workspaces/templates-lib/packages/template-static-website-aws/src/templateStaticWebsiteAws.ts
+++ b/workspaces/templates-lib/packages/template-static-website-aws/src/templateStaticWebsiteAws.ts
@@ -1,5 +1,5 @@
 import { wrapCli } from '@goldstack/utils-cli';
-import { fatal } from '@goldstack/utils-log';
+import { fatal, warn } from '@goldstack/utils-log';
 import { infraAwsStaticWebsiteCli } from './infraAwsStaticWebsite';
 import type {
   AWSStaticWebsiteConfiguration,
@@ -53,6 +53,17 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'deploy') {
+      const deploymentName = opArgs[0];
+      if (!packageConfig.hasDeployment(deploymentName)) {
+        if (argv['ignore-missing-deployments']) {
+          warn(
+            `Deployment '${deploymentName}' does not exist. Skipping deploy due to --ignore-missing-deployments flag.`,
+          );
+          return;
+        } else {
+          throw new Error(`Cannot find configuration for deployment '${deploymentName}'`);
+        }
+      }
       await infraAwsStaticWebsiteCli(config, ['deploy', ...opArgs]);
       return;
     }

--- a/workspaces/templates-lib/packages/template-user-management-cli/src/templateUserManagementCli.ts
+++ b/workspaces/templates-lib/packages/template-user-management-cli/src/templateUserManagementCli.ts
@@ -3,6 +3,7 @@ import type {
   UserManagementPackage,
 } from '@goldstack/template-user-management';
 import { wrapCli } from '@goldstack/utils-cli';
+import { warn } from '@goldstack/utils-log';
 import { buildCli, buildDeployCommands } from '@goldstack/utils-package';
 import { PackageConfig } from '@goldstack/utils-package-config';
 import { infraCommands } from '@goldstack/utils-terraform';
@@ -33,7 +34,18 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'deploy') {
-      await deployCli(config, packageConfig.getDeployment(opArgs[0]));
+      const deploymentName = opArgs[0];
+      if (!packageConfig.hasDeployment(deploymentName)) {
+        if (argv['ignore-missing-deployments']) {
+          warn(
+            `Deployment '${deploymentName}' does not exist. Skipping deploy due to --ignore-missing-deployments flag.`,
+          );
+          return;
+        } else {
+          throw new Error(`Cannot find configuration for deployment '${deploymentName}'`);
+        }
+      }
+      await deployCli(config, packageConfig.getDeployment(deploymentName));
       return;
     }
 

--- a/workspaces/templates-lib/packages/utils-package-config-embedded/src/utilsPackageConfigEmbedded.ts
+++ b/workspaces/templates-lib/packages/utils-package-config-embedded/src/utilsPackageConfigEmbedded.ts
@@ -38,4 +38,11 @@ export class EmbeddedPackageConfig<PackageType extends Package, DeploymentType e
 
     return deployment as DeploymentType;
   }
+
+  hasDeployment(deploymentName: string): boolean {
+    const deployment = this.goldstackJson.deployments.find(
+      (deployment) => deployment.name === deploymentName,
+    );
+    return !!deployment;
+  }
 }

--- a/workspaces/templates-lib/packages/utils-package-config/src/utilsPackageConfig.ts
+++ b/workspaces/templates-lib/packages/utils-package-config/src/utilsPackageConfig.ts
@@ -50,4 +50,11 @@ export class PackageConfig<PackageType extends Package, DeploymentType extends D
 
     return deployment as DeploymentType;
   }
+
+  hasDeployment(deploymentName: string): boolean {
+    const deployment = this.goldstackJson.deployments.find(
+      (deployment) => deployment.name === deploymentName,
+    );
+    return !!deployment;
+  }
 }

--- a/workspaces/templates-lib/packages/utils-package/src/utilsPackage.ts
+++ b/workspaces/templates-lib/packages/utils-package/src/utilsPackage.ts
@@ -57,10 +57,17 @@ export const buildCli = (params: BuildCliParams): Argv<any> => {
 
 export const buildDeployCommands = () => {
   return (yargs: Argv<any>): Argv<any> => {
-    return yargs.positional('deployment', {
-      description: 'Name of the deployment where the package should be deployed to.',
-      type: 'string',
-      demandOption: true,
-    });
+    return yargs
+      .positional('deployment', {
+        description: 'Name of the deployment where the package should be deployed to.',
+        type: 'string',
+        demandOption: true,
+      })
+      .option('ignore-missing-deployments', {
+        description: 'If the deployment does not exist, show a warning instead of failing.',
+        default: false,
+        demandOption: false,
+        type: 'boolean',
+      });
   };
 };

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformBuild.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformBuild.ts
@@ -366,7 +366,7 @@ export class TerraformBuild {
         silent: true,
       }).trim();
 
-      console.log('Terraform Output:', res);
+      info(`Terraform Output:\n${res}`);
       const deploymentState = readDeploymentState('./../../', deploymentName, {
         createIfNotExist: true,
       });


### PR DESCRIPTION
If this is not provided, the command will fail if the deployment does not exist. If the flag is provided, only a warning will be shown. This is useful if not all components of an application are required for all deployments.