### PR TITLE
[All Templates]: Improving way command line arguments are parsed - using Yargs

### DIFF
--- a/workspaces/templates-lib/packages/template-docker-image-aws/src/infraAwsDockerImage.ts
+++ b/workspaces/templates-lib/packages/template-docker-image-aws/src/infraAwsDockerImage.ts
@@ -125,7 +125,7 @@ export const infraAwsDockerImageCli = async (
     deploymentName,
     targetVersion,
     confirm,
-    command: commandArgs,
+    commandArguments: commandArgs,
     ignoreMissingDeployments: false,
     skipConfirmations: false,
     options: undefined,

--- a/workspaces/templates-lib/packages/template-docker-image-aws/src/infraAwsDockerImage.ts
+++ b/workspaces/templates-lib/packages/template-docker-image-aws/src/infraAwsDockerImage.ts
@@ -106,5 +106,28 @@ export const infraAwsDockerImageCli = async (
     return;
   }
 
-  await terraformAwsCli(args);
+  const infraOperation = args[0];
+  const deploymentName = deployment.name;
+  let targetVersion: string | undefined;
+  let confirm: boolean | undefined;
+  let commandArgs: string[] | undefined;
+
+  if (infraOperation === 'upgrade') {
+    targetVersion = args[1];
+  } else if (infraOperation === 'terraform') {
+    commandArgs = args.slice(1);
+  } else if (infraOperation === 'destroy') {
+    confirm = args.includes('-y');
+  }
+
+  await terraformAwsCli({
+    infraOperation,
+    deploymentName,
+    targetVersion,
+    confirm,
+    command: commandArgs,
+    ignoreMissingDeployments: false,
+    skipConfirmations: false,
+    options: undefined,
+  });
 };

--- a/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
@@ -97,7 +97,7 @@ export const run = async ({
         deploymentName,
         targetVersion,
         confirm,
-        command: commandArgs,
+        commandArguments: commandArgs,
         ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
         skipConfirmations: argv.yes || false,
         options: undefined,

--- a/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
@@ -79,23 +79,22 @@ export const run = async ({
         }
       }
       await dynamoDBCli(migrations, ['init', deploymentName]);
-      const infraOperation = opArgs[0];
-      const deploymentNameParsed = opArgs[1];
+      const infraOperation = argv._[1] as string;
       let targetVersion: string | undefined;
       let confirm: boolean | undefined;
       let commandArgs: string[] | undefined;
 
       if (infraOperation === 'upgrade') {
-        targetVersion = opArgs[2];
+        targetVersion = argv.targetVersion;
       } else if (infraOperation === 'terraform') {
         commandArgs = opArgs.slice(2);
       } else if (infraOperation === 'destroy') {
-        confirm = argv.yes || opArgs.includes('-y');
+        confirm = argv.yes;
       }
 
       await terraformAwsCli({
         infraOperation,
-        deploymentName: deploymentNameParsed,
+        deploymentName,
         targetVersion,
         confirm,
         command: commandArgs,
@@ -103,7 +102,7 @@ export const run = async ({
         skipConfirmations: argv.yes || false,
         options: undefined,
       });
-      if (opArgs[0] === 'destroy') {
+      if (infraOperation === 'destroy') {
         await dynamoDBCli(migrations, ['delete', deploymentName]);
       }
       return;

--- a/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
@@ -79,7 +79,30 @@ export const run = async ({
         }
       }
       await dynamoDBCli(migrations, ['init', deploymentName]);
-      await terraformAwsCli(opArgs);
+      const infraOperation = opArgs[0];
+      const deploymentNameParsed = opArgs[1];
+      let targetVersion: string | undefined;
+      let confirm: boolean | undefined;
+      let commandArgs: string[] | undefined;
+
+      if (infraOperation === 'upgrade') {
+        targetVersion = opArgs[2];
+      } else if (infraOperation === 'terraform') {
+        commandArgs = opArgs.slice(2);
+      } else if (infraOperation === 'destroy') {
+        confirm = argv.yes || opArgs.includes('-y');
+      }
+
+      await terraformAwsCli({
+        infraOperation,
+        deploymentName: deploymentNameParsed,
+        targetVersion,
+        confirm,
+        command: commandArgs,
+        ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
+        skipConfirmations: argv.yes || false,
+        options: undefined,
+      });
       if (opArgs[0] === 'destroy') {
         await dynamoDBCli(migrations, ['delete', deploymentName]);
       }

--- a/workspaces/templates-lib/packages/template-email-send-cli/src/templateEmailSendCli.ts
+++ b/workspaces/templates-lib/packages/template-email-send-cli/src/templateEmailSendCli.ts
@@ -20,22 +20,22 @@ export const run = async (args: string[]): Promise<void> => {
       packagePath: './',
     });
     const config = packageConfig.getConfig();
-    const command = argv._[0];
     const [, , , ...opArgs] = args;
+    const command = argv._[0];
 
     if (command === 'infra') {
-      const infraOperation = opArgs[0];
-      const deploymentName = opArgs[1];
+      const infraOperation = argv._[1] as string;
+      const deploymentName = argv.deployment;
       let targetVersion: string | undefined;
       let confirm: boolean | undefined;
       let commandArgs: string[] | undefined;
 
       if (infraOperation === 'upgrade') {
-        targetVersion = opArgs[2];
+        targetVersion = argv.targetVersion;
       } else if (infraOperation === 'terraform') {
         commandArgs = opArgs.slice(2);
       } else if (infraOperation === 'destroy') {
-        confirm = argv.yes || opArgs.includes('-y');
+        confirm = argv.yes;
       }
 
       await terraformAwsCli({

--- a/workspaces/templates-lib/packages/template-email-send-cli/src/templateEmailSendCli.ts
+++ b/workspaces/templates-lib/packages/template-email-send-cli/src/templateEmailSendCli.ts
@@ -24,7 +24,30 @@ export const run = async (args: string[]): Promise<void> => {
     const [, , , ...opArgs] = args;
 
     if (command === 'infra') {
-      await terraformAwsCli(opArgs);
+      const infraOperation = opArgs[0];
+      const deploymentName = opArgs[1];
+      let targetVersion: string | undefined;
+      let confirm: boolean | undefined;
+      let commandArgs: string[] | undefined;
+
+      if (infraOperation === 'upgrade') {
+        targetVersion = opArgs[2];
+      } else if (infraOperation === 'terraform') {
+        commandArgs = opArgs.slice(2);
+      } else if (infraOperation === 'destroy') {
+        confirm = argv.yes || opArgs.includes('-y');
+      }
+
+      await terraformAwsCli({
+        infraOperation,
+        deploymentName,
+        targetVersion,
+        confirm,
+        command: commandArgs,
+        ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
+        skipConfirmations: argv.yes || false,
+        options: undefined,
+      });
       return;
     }
 

--- a/workspaces/templates-lib/packages/template-email-send-cli/src/templateEmailSendCli.ts
+++ b/workspaces/templates-lib/packages/template-email-send-cli/src/templateEmailSendCli.ts
@@ -43,7 +43,7 @@ export const run = async (args: string[]): Promise<void> => {
         deploymentName,
         targetVersion,
         confirm,
-        command: commandArgs,
+        commandArguments: commandArgs,
         ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
         skipConfirmations: argv.yes || false,
         options: undefined,

--- a/workspaces/templates-lib/packages/template-hetzner-vps-cli/src/templateHetznerVPSCli.ts
+++ b/workspaces/templates-lib/packages/template-hetzner-vps-cli/src/templateHetznerVPSCli.ts
@@ -39,7 +39,7 @@ export const run = async (args: string[]): Promise<void> => {
 
     if (command === 'deploy') {
       info('Starting deployment to Hetzner VPS.');
-      const deploymentName = opArgs[0];
+      const deploymentName = argv.deployment;
       if (!packageConfig.hasDeployment(deploymentName)) {
         if (argv['ignore-missing-deployments']) {
           warn(
@@ -58,26 +58,27 @@ export const run = async (args: string[]): Promise<void> => {
 
     if (command === 'infra') {
       const ignoreMissingDeployments = argv['ignore-missing-deployments'];
+      const deploymentName = argv.deployment;
       let deployment: HetznerVPSDeployment;
 
       try {
-        deployment = packageConfig.getDeployment(opArgs[1]);
+        deployment = packageConfig.getDeployment(deploymentName);
       } catch (e) {
         if (ignoreMissingDeployments) {
           warn(
-            `Deployment '${opArgs[1]}' does not exist. Skipping operation due to --ignore-missing-deployments flag.`,
+            `Deployment '${deploymentName}' does not exist. Skipping operation due to --ignore-missing-deployments flag.`,
           );
           return;
         }
         throw e;
       }
 
-      const infrastructureOp = opArgs[0];
+      const infrastructureOp = argv._[1] as string;
       info(`Running infrastructure operation ${infrastructureOp} for ${deployment.name}`);
       // use remote managed state from Terraform
       await terraformAwsCli({
         infraOperation: 'create-state',
-        deploymentName: opArgs[1],
+        deploymentName,
         ignoreMissingDeployments,
         skipConfirmations: false,
         options: undefined,
@@ -86,7 +87,7 @@ export const run = async (args: string[]): Promise<void> => {
       if (infrastructureOp === 'destroy-state') {
         await terraformAwsCli({
           infraOperation: 'destroy-state',
-          deploymentName: opArgs[1],
+          deploymentName,
           ignoreMissingDeployments,
           skipConfirmations: false,
           options: undefined,
@@ -94,7 +95,7 @@ export const run = async (args: string[]): Promise<void> => {
         return;
       }
 
-      const { awsProvider } = await initTerraformEnvironment(opArgs[1]);
+      const { awsProvider } = await initTerraformEnvironment(deploymentName);
       await terraformHetznerCli(opArgs, awsProvider);
 
       return;

--- a/workspaces/templates-lib/packages/template-hetzner-vps-cli/src/templateHetznerVPSCli.ts
+++ b/workspaces/templates-lib/packages/template-hetzner-vps-cli/src/templateHetznerVPSCli.ts
@@ -75,14 +75,26 @@ export const run = async (args: string[]): Promise<void> => {
       const infrastructureOp = opArgs[0];
       info(`Running infrastructure operation ${infrastructureOp} for ${deployment.name}`);
       // use remote managed state from Terraform
-      await terraformAwsCli(['create-state', opArgs[1]]);
+      await terraformAwsCli({
+        infraOperation: 'create-state',
+        deploymentName: opArgs[1],
+        ignoreMissingDeployments,
+        skipConfirmations: false,
+        options: undefined,
+      });
 
       if (infrastructureOp === 'destroy-state') {
-        await terraformAwsCli(['destroy-state', opArgs[1]]);
+        await terraformAwsCli({
+          infraOperation: 'destroy-state',
+          deploymentName: opArgs[1],
+          ignoreMissingDeployments,
+          skipConfirmations: false,
+          options: undefined,
+        });
         return;
       }
 
-      const { awsProvider } = await initTerraformEnvironment(opArgs);
+      const { awsProvider } = await initTerraformEnvironment(opArgs[1]);
       await terraformHetznerCli(opArgs, awsProvider);
 
       return;

--- a/workspaces/templates-lib/packages/template-lambda-api-cli/src/templateLambdaApiCli.ts
+++ b/workspaces/templates-lib/packages/template-lambda-api-cli/src/templateLambdaApiCli.ts
@@ -66,7 +66,7 @@ export const run = async (args: string[]): Promise<void> => {
 
     const command = argv._[0] as string;
     const deploymentName = argv._[1] as string;
-    const routeFilterArg = argv._[2] as string;
+    const routeFilterArg = argv._[2] ? (argv._[2] as string) : undefined;
     const routeFilter = routeFilterArg ? `*${routeFilterArg}*` : undefined;
 
     if (routeFilter && (command === 'build' || command === 'deploy')) {
@@ -91,7 +91,7 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'infra') {
-      await terraformAwsCli(argv._.slice(1), {
+      await terraformAwsCli(argv._.slice(1) as string[], {
         // temporary workaround for https://github.com/goldstack/goldstack/issues/40
         parallelism: 1,
       });
@@ -99,7 +99,7 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'build') {
-      if (!packageConfig.hasDeployment(deploymentName)) {
+      if (argv.ignoreMissingDeployments && !packageConfig.hasDeployment(deploymentName)) {
         warn(`Deployment '${deploymentName}' does not exist. Skipping build.`);
         return;
       }
@@ -118,7 +118,7 @@ export const run = async (args: string[]): Promise<void> => {
 
     if (command === 'deploy') {
       if (!packageConfig.hasDeployment(deploymentName)) {
-        if (argv['ignore-missing-deployments']) {
+        if (argv.ignoreMissingDeployments) {
           warn(
             `Deployment '${deploymentName}' does not exist. Skipping deploy due to --ignore-missing-deployments flag.`,
           );

--- a/workspaces/templates-lib/packages/template-lambda-api-cli/src/templateLambdaApiCli.ts
+++ b/workspaces/templates-lib/packages/template-lambda-api-cli/src/templateLambdaApiCli.ts
@@ -111,18 +111,18 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'infra') {
-      const infraOperation = opArgs[0];
-      const deploymentName = opArgs[1];
+      const infraOperation = argv._[1] as string;
+      const deploymentName = argv.deployment;
       let targetVersion: string | undefined;
       let confirm: boolean | undefined;
       let commandArgs: string[] | undefined;
 
       if (infraOperation === 'upgrade') {
-        targetVersion = opArgs[2];
+        targetVersion = argv.targetVersion;
       } else if (infraOperation === 'terraform') {
         commandArgs = opArgs.slice(2);
       } else if (infraOperation === 'destroy') {
-        confirm = argv.yes || opArgs.includes('-y');
+        confirm = argv.yes;
       }
 
       await terraformAwsCli({

--- a/workspaces/templates-lib/packages/template-lambda-api-cli/src/templateLambdaApiCli.ts
+++ b/workspaces/templates-lib/packages/template-lambda-api-cli/src/templateLambdaApiCli.ts
@@ -111,9 +111,32 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'infra') {
-      await terraformAwsCli(opArgs, {
-        // temporary workaround for https://github.com/goldstack/goldstack/issues/40
-        parallelism: 1,
+      const infraOperation = opArgs[0];
+      const deploymentName = opArgs[1];
+      let targetVersion: string | undefined;
+      let confirm: boolean | undefined;
+      let commandArgs: string[] | undefined;
+
+      if (infraOperation === 'upgrade') {
+        targetVersion = opArgs[2];
+      } else if (infraOperation === 'terraform') {
+        commandArgs = opArgs.slice(2);
+      } else if (infraOperation === 'destroy') {
+        confirm = argv.yes || opArgs.includes('-y');
+      }
+
+      await terraformAwsCli({
+        infraOperation,
+        deploymentName,
+        targetVersion,
+        confirm,
+        command: commandArgs,
+        ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
+        skipConfirmations: argv.yes || false,
+        options: {
+          // temporary workaround for https://github.com/goldstack/goldstack/issues/40
+          parallelism: 1,
+        },
       });
       return;
     }

--- a/workspaces/templates-lib/packages/template-lambda-api-cli/src/templateLambdaApiCli.ts
+++ b/workspaces/templates-lib/packages/template-lambda-api-cli/src/templateLambdaApiCli.ts
@@ -130,7 +130,7 @@ export const run = async (args: string[]): Promise<void> => {
         deploymentName,
         targetVersion,
         confirm,
-        command: commandArgs,
+        commandArguments: commandArgs,
         ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
         skipConfirmations: argv.yes || false,
         options: {

--- a/workspaces/templates-lib/packages/template-lambda-cli/src/templateLambdaCli.ts
+++ b/workspaces/templates-lib/packages/template-lambda-cli/src/templateLambdaCli.ts
@@ -32,15 +32,8 @@ export const run = async (args: string[]): Promise<void> => {
     const command = argv._[0];
 
     if (command === 'infra') {
-      if (opArgs.length < 1 || !opArgs[0]) {
-        throw new Error('No infrastructure operation provided');
-      }
-      if (opArgs.length < 2 || !opArgs[1]) {
-        throw new Error('No deployment provided');
-      }
-
-      const infraOperation = opArgs[0];
-      const deploymentName = opArgs[1];
+      const infraOperation = argv._[1] as string;
+      const deploymentName = argv.deployment;
       let targetVersion: string | undefined;
       let confirm: boolean | undefined;
       let commandArgs: string[] | undefined;

--- a/workspaces/templates-lib/packages/template-lambda-cli/src/templateLambdaCli.ts
+++ b/workspaces/templates-lib/packages/template-lambda-cli/src/templateLambdaCli.ts
@@ -39,7 +39,30 @@ export const run = async (args: string[]): Promise<void> => {
         throw new Error('No deployment provided');
       }
 
-      await terraformAwsCli(opArgs);
+      const infraOperation = opArgs[0];
+      const deploymentName = opArgs[1];
+      let targetVersion: string | undefined;
+      let confirm: boolean | undefined;
+      let commandArgs: string[] | undefined;
+
+      if (infraOperation === 'upgrade') {
+        targetVersion = opArgs[2];
+      } else if (infraOperation === 'terraform') {
+        commandArgs = opArgs.slice(2);
+      } else if (infraOperation === 'destroy') {
+        confirm = argv.yes || opArgs.includes('-y');
+      }
+
+      await terraformAwsCli({
+        infraOperation,
+        deploymentName,
+        targetVersion,
+        confirm,
+        command: commandArgs,
+        ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
+        skipConfirmations: argv.yes || false,
+        options: undefined,
+      });
       return;
     }
 

--- a/workspaces/templates-lib/packages/template-lambda-cli/src/templateLambdaCli.ts
+++ b/workspaces/templates-lib/packages/template-lambda-cli/src/templateLambdaCli.ts
@@ -51,7 +51,7 @@ export const run = async (args: string[]): Promise<void> => {
         deploymentName,
         targetVersion,
         confirm,
-        command: commandArgs,
+        commandArguments: commandArgs,
         ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
         skipConfirmations: argv.yes || false,
         options: undefined,

--- a/workspaces/templates-lib/packages/template-lambda-http-cli/src/templateLambdaHttp.ts
+++ b/workspaces/templates-lib/packages/template-lambda-http-cli/src/templateLambdaHttp.ts
@@ -30,7 +30,30 @@ export const run = async (args: string[]): Promise<void> => {
     const [, , , ...opArgs] = args;
 
     if (command === 'infra') {
-      await terraformAwsCli(opArgs);
+      const infraOperation = opArgs[0];
+      const deploymentName = opArgs[1];
+      let targetVersion: string | undefined;
+      let confirm: boolean | undefined;
+      let commandArgs: string[] | undefined;
+
+      if (infraOperation === 'upgrade') {
+        targetVersion = opArgs[2];
+      } else if (infraOperation === 'terraform') {
+        commandArgs = opArgs.slice(2);
+      } else if (infraOperation === 'destroy') {
+        confirm = argv.yes || opArgs.includes('-y');
+      }
+
+      await terraformAwsCli({
+        infraOperation,
+        deploymentName,
+        targetVersion,
+        confirm,
+        command: commandArgs,
+        ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
+        skipConfirmations: argv.yes || false,
+        options: undefined,
+      });
       return;
     }
 

--- a/workspaces/templates-lib/packages/template-lambda-http-cli/src/templateLambdaHttp.ts
+++ b/workspaces/templates-lib/packages/template-lambda-http-cli/src/templateLambdaHttp.ts
@@ -49,7 +49,7 @@ export const run = async (args: string[]): Promise<void> => {
         deploymentName,
         targetVersion,
         confirm,
-        command: commandArgs,
+        commandArguments: commandArgs,
         ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
         skipConfirmations: argv.yes || false,
         options: undefined,

--- a/workspaces/templates-lib/packages/template-lambda-http-cli/src/templateLambdaHttp.ts
+++ b/workspaces/templates-lib/packages/template-lambda-http-cli/src/templateLambdaHttp.ts
@@ -26,22 +26,22 @@ export const run = async (args: string[]): Promise<void> => {
     });
 
     const config = packageConfig.getConfig();
-    const command = argv._[0];
     const [, , , ...opArgs] = args;
+    const command = argv._[0];
 
     if (command === 'infra') {
-      const infraOperation = opArgs[0];
-      const deploymentName = opArgs[1];
+      const infraOperation = argv._[1] as string;
+      const deploymentName = argv.deployment;
       let targetVersion: string | undefined;
       let confirm: boolean | undefined;
       let commandArgs: string[] | undefined;
 
       if (infraOperation === 'upgrade') {
-        targetVersion = opArgs[2];
+        targetVersion = argv.targetVersion;
       } else if (infraOperation === 'terraform') {
         commandArgs = opArgs.slice(2);
       } else if (infraOperation === 'destroy') {
-        confirm = argv.yes || opArgs.includes('-y');
+        confirm = argv.yes;
       }
 
       await terraformAwsCli({
@@ -58,7 +58,7 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'deploy') {
-      const deploymentName = opArgs[0];
+      const deploymentName = argv.deployment;
       if (!packageConfig.hasDeployment(deploymentName)) {
         if (argv['ignore-missing-deployments']) {
           warn(

--- a/workspaces/templates-lib/packages/template-s3-cli/src/templateS3Cli.ts
+++ b/workspaces/templates-lib/packages/template-s3-cli/src/templateS3Cli.ts
@@ -45,7 +45,7 @@ export const run = async (args: string[]): Promise<void> => {
         deploymentName,
         targetVersion,
         confirm,
-        command: commandArgs,
+        commandArguments: commandArgs,
         ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
         skipConfirmations: argv.yes || false,
         options: undefined,

--- a/workspaces/templates-lib/packages/template-s3-cli/src/templateS3Cli.ts
+++ b/workspaces/templates-lib/packages/template-s3-cli/src/templateS3Cli.ts
@@ -26,7 +26,30 @@ export const run = async (args: string[]): Promise<void> => {
     const [, , , ...opArgs] = args;
 
     if (command === 'infra') {
-      await terraformAwsCli(opArgs);
+      const infraOperation = opArgs[0];
+      const deploymentName = opArgs[1];
+      let targetVersion: string | undefined;
+      let confirm: boolean | undefined;
+      let commandArgs: string[] | undefined;
+
+      if (infraOperation === 'upgrade') {
+        targetVersion = opArgs[2];
+      } else if (infraOperation === 'terraform') {
+        commandArgs = opArgs.slice(2);
+      } else if (infraOperation === 'destroy') {
+        confirm = argv.yes || opArgs.includes('-y');
+      }
+
+      await terraformAwsCli({
+        infraOperation,
+        deploymentName,
+        targetVersion,
+        confirm,
+        command: commandArgs,
+        ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
+        skipConfirmations: argv.yes || false,
+        options: undefined,
+      });
       return;
     }
 

--- a/workspaces/templates-lib/packages/template-s3-cli/src/templateS3Cli.ts
+++ b/workspaces/templates-lib/packages/template-s3-cli/src/templateS3Cli.ts
@@ -22,22 +22,22 @@ export const run = async (args: string[]): Promise<void> => {
       packagePath: './',
     });
     const config = packageConfig.getConfig();
-    const command = argv._[0];
     const [, , , ...opArgs] = args;
+    const command = argv._[0];
 
     if (command === 'infra') {
-      const infraOperation = opArgs[0];
-      const deploymentName = opArgs[1];
+      const infraOperation = argv._[1] as string;
+      const deploymentName = argv.deployment;
       let targetVersion: string | undefined;
       let confirm: boolean | undefined;
       let commandArgs: string[] | undefined;
 
       if (infraOperation === 'upgrade') {
-        targetVersion = opArgs[2];
+        targetVersion = argv.targetVersion;
       } else if (infraOperation === 'terraform') {
         commandArgs = opArgs.slice(2);
       } else if (infraOperation === 'destroy') {
-        confirm = argv.yes || opArgs.includes('-y');
+        confirm = argv.yes;
       }
 
       await terraformAwsCli({
@@ -54,7 +54,7 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'deploy') {
-      const deploymentName = opArgs[0];
+      const deploymentName = argv.deployment;
       if (!packageConfig.hasDeployment(deploymentName)) {
         if (argv['ignore-missing-deployments']) {
           warn(
@@ -65,7 +65,7 @@ export const run = async (args: string[]): Promise<void> => {
           throw new Error(`Cannot find configuration for deployment '${deploymentName}'`);
         }
       }
-      await deployCli(config, ['deploy', ...opArgs]);
+      await deployCli(config, ['deploy', deploymentName]);
       return;
     }
 

--- a/workspaces/templates-lib/packages/template-ssr-cli/src/templateSSRCli.ts
+++ b/workspaces/templates-lib/packages/template-ssr-cli/src/templateSSRCli.ts
@@ -113,9 +113,32 @@ export const run = async (args: string[], buildConfig: BuildConfiguration): Prom
     }
 
     if (command === 'infra') {
-      await terraformAwsCli(opArgs, {
-        // temporary workaround for https://github.com/goldstack/goldstack/issues/40
-        parallelism: 1,
+      const infraOperation = opArgs[0];
+      const deploymentName = opArgs[1];
+      let targetVersion: string | undefined;
+      let confirm: boolean | undefined;
+      let commandArgs: string[] | undefined;
+
+      if (infraOperation === 'upgrade') {
+        targetVersion = opArgs[2];
+      } else if (infraOperation === 'terraform') {
+        commandArgs = opArgs.slice(2);
+      } else if (infraOperation === 'destroy') {
+        confirm = opArgs.includes('-y');
+      }
+
+      await terraformAwsCli({
+        infraOperation,
+        deploymentName,
+        targetVersion,
+        confirm,
+        command: commandArgs,
+        ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
+        skipConfirmations: false,
+        options: {
+          // temporary workaround for https://github.com/goldstack/goldstack/issues/40
+          parallelism: 1,
+        },
       });
       return;
     }

--- a/workspaces/templates-lib/packages/template-ssr-cli/src/templateSSRCli.ts
+++ b/workspaces/templates-lib/packages/template-ssr-cli/src/templateSSRCli.ts
@@ -132,7 +132,7 @@ export const run = async (args: string[], buildConfig: BuildConfiguration): Prom
         deploymentName,
         targetVersion,
         confirm,
-        command: commandArgs,
+        commandArguments: commandArgs,
         ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
         skipConfirmations: false,
         options: {

--- a/workspaces/templates-lib/packages/template-ssr-cli/src/templateSSRCli.ts
+++ b/workspaces/templates-lib/packages/template-ssr-cli/src/templateSSRCli.ts
@@ -71,6 +71,11 @@ export const run = async (args: string[], buildConfig: BuildConfiguration): Prom
             });
         },
       )
+      .option('ignore-missing-deployments', {
+        type: 'boolean',
+        describe: 'Ignore missing deployments',
+        default: false,
+      })
       .help()
       .parse();
 
@@ -116,6 +121,10 @@ export const run = async (args: string[], buildConfig: BuildConfiguration): Prom
     }
 
     if (command === 'build') {
+      if (argv['ignore-missing-deployments'] && !packageConfig.hasDeployment(opArgs[0])) {
+        warn(`Deployment '${opArgs[0]}' does not exist. Skipping build.`);
+        return;
+      }
       const deployment = packageConfig.getDeployment(opArgs[0]);
       let routeFilter: undefined | string;
       if (opArgs.length === 2) {
@@ -146,6 +155,12 @@ export const run = async (args: string[], buildConfig: BuildConfiguration): Prom
     }
 
     if (command === 'deploy') {
+      if (argv['ignore-missing-deployments'] && !packageConfig.hasDeployment(opArgs[0])) {
+        warn(
+          `Deployment '${opArgs[0]}' does not exist. Skipping deploy due to --ignore-missing-deployments flag.`,
+        );
+        return;
+      }
       const deployment = packageConfig.getDeployment(opArgs[0]);
       const config = deployment.configuration;
 

--- a/workspaces/templates-lib/packages/template-ssr-cli/src/templateSSRCli.ts
+++ b/workspaces/templates-lib/packages/template-ssr-cli/src/templateSSRCli.ts
@@ -144,11 +144,14 @@ export const run = async (args: string[], buildConfig: BuildConfiguration): Prom
     }
 
     if (command === 'build') {
-      if (argv['ignore-missing-deployments'] && !packageConfig.hasDeployment(argv.deployment)) {
+      if (
+        argv['ignore-missing-deployments'] &&
+        !packageConfig.hasDeployment(argv.deployment as string)
+      ) {
         warn(`Deployment '${argv.deployment}' does not exist. Skipping build.`);
         return;
       }
-      const deployment = packageConfig.getDeployment(argv.deployment);
+      const deployment = packageConfig.getDeployment(argv.deployment as string);
       let routeFilter: undefined | string;
       if (argv.route) {
         routeFilter = `*${argv.route}*`;

--- a/workspaces/templates-lib/packages/template-static-website-aws/src/infraAwsStaticWebsite.ts
+++ b/workspaces/templates-lib/packages/template-static-website-aws/src/infraAwsStaticWebsite.ts
@@ -57,5 +57,28 @@ export const infraAwsStaticWebsiteCli = async (
     return;
   }
 
-  await terraformAwsCli(args);
+  const infraOperation = args[0];
+  const deploymentName = args[1];
+  let targetVersion: string | undefined;
+  let confirm: boolean | undefined;
+  let commandArgs: string[] | undefined;
+
+  if (infraOperation === 'upgrade') {
+    targetVersion = args[2];
+  } else if (infraOperation === 'terraform') {
+    commandArgs = args.slice(2);
+  } else if (infraOperation === 'destroy') {
+    confirm = args.includes('-y');
+  }
+
+  await terraformAwsCli({
+    infraOperation,
+    deploymentName,
+    targetVersion,
+    confirm,
+    command: commandArgs,
+    ignoreMissingDeployments: false,
+    skipConfirmations: false,
+    options: undefined,
+  });
 };

--- a/workspaces/templates-lib/packages/template-static-website-aws/src/infraAwsStaticWebsite.ts
+++ b/workspaces/templates-lib/packages/template-static-website-aws/src/infraAwsStaticWebsite.ts
@@ -76,7 +76,7 @@ export const infraAwsStaticWebsiteCli = async (
     deploymentName,
     targetVersion,
     confirm,
-    command: commandArgs,
+    commandArguments: commandArgs,
     ignoreMissingDeployments: false,
     skipConfirmations: false,
     options: undefined,

--- a/workspaces/templates-lib/packages/template-user-management-cli/src/templateUserManagementCli.ts
+++ b/workspaces/templates-lib/packages/template-user-management-cli/src/templateUserManagementCli.ts
@@ -29,7 +29,30 @@ export const run = async (args: string[]): Promise<void> => {
     const [, , , ...opArgs] = args;
 
     if (command === 'infra') {
-      await terraformAwsCli(opArgs);
+      const infraOperation = opArgs[0];
+      const deploymentName = opArgs[1];
+      let targetVersion: string | undefined;
+      let confirm: boolean | undefined;
+      let commandArgs: string[] | undefined;
+
+      if (infraOperation === 'upgrade') {
+        targetVersion = opArgs[2];
+      } else if (infraOperation === 'terraform') {
+        commandArgs = opArgs.slice(2);
+      } else if (infraOperation === 'destroy') {
+        confirm = argv.yes || opArgs.includes('-y');
+      }
+
+      await terraformAwsCli({
+        infraOperation,
+        deploymentName,
+        targetVersion,
+        confirm,
+        command: commandArgs,
+        ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
+        skipConfirmations: argv.yes || false,
+        options: undefined,
+      });
       return;
     }
 

--- a/workspaces/templates-lib/packages/template-user-management-cli/src/templateUserManagementCli.ts
+++ b/workspaces/templates-lib/packages/template-user-management-cli/src/templateUserManagementCli.ts
@@ -48,7 +48,7 @@ export const run = async (args: string[]): Promise<void> => {
         deploymentName,
         targetVersion,
         confirm,
-        command: commandArgs,
+        commandArguments: commandArgs,
         ignoreMissingDeployments: argv['ignore-missing-deployments'] || false,
         skipConfirmations: argv.yes || false,
         options: undefined,

--- a/workspaces/templates-lib/packages/template-user-management-cli/src/templateUserManagementCli.ts
+++ b/workspaces/templates-lib/packages/template-user-management-cli/src/templateUserManagementCli.ts
@@ -25,12 +25,12 @@ export const run = async (args: string[]): Promise<void> => {
       packagePath: './',
     });
     const config = packageConfig.getConfig();
-    const command = argv._[0];
     const [, , , ...opArgs] = args;
+    const command = argv._[0];
 
     if (command === 'infra') {
-      const infraOperation = opArgs[0];
-      const deploymentName = opArgs[1];
+      const infraOperation = argv._[1] as string;
+      const deploymentName = argv.deployment;
       let targetVersion: string | undefined;
       let confirm: boolean | undefined;
       let commandArgs: string[] | undefined;
@@ -57,7 +57,7 @@ export const run = async (args: string[]): Promise<void> => {
     }
 
     if (command === 'deploy') {
-      const deploymentName = opArgs[0];
+      const deploymentName = argv.deployment;
       if (!packageConfig.hasDeployment(deploymentName)) {
         if (argv['ignore-missing-deployments']) {
           warn(

--- a/workspaces/templates-lib/packages/utils-terraform-aws/src/utilsTerraformAws.ts
+++ b/workspaces/templates-lib/packages/utils-terraform-aws/src/utilsTerraformAws.ts
@@ -117,6 +117,9 @@ export interface TerraformAWSCliParams {
   options?: TerraformOptions;
   deploymentName: string;
   skipConfirmations: boolean;
+  targetVersion?: string;
+  confirm?: boolean;
+  command?: string[];
 }
 
 export const terraformAwsCli = async (params: TerraformAWSCliParams): Promise<void> => {
@@ -188,9 +191,12 @@ export const terraformAwsCli = async (params: TerraformAWSCliParams): Promise<vo
     return;
   }
 
-  terraformCli(args, {
-    ...params.options,
-    provider: awsProvider,
+  terraformCli({
+    ...params,
+    options: {
+      ...params.options,
+      provider: awsProvider,
+    },
   });
 };
 

--- a/workspaces/templates-lib/packages/utils-terraform-aws/src/utilsTerraformAws.ts
+++ b/workspaces/templates-lib/packages/utils-terraform-aws/src/utilsTerraformAws.ts
@@ -119,7 +119,7 @@ export interface TerraformAWSCliParams {
   skipConfirmations: boolean;
   targetVersion?: string;
   confirm?: boolean;
-  command?: string[];
+  commandArguments?: string[];
 }
 
 export const terraformAwsCli = async (params: TerraformAWSCliParams): Promise<void> => {

--- a/workspaces/templates-lib/packages/utils-terraform-aws/src/utilsTerraformAws.ts
+++ b/workspaces/templates-lib/packages/utils-terraform-aws/src/utilsTerraformAws.ts
@@ -111,11 +111,16 @@ const prompt = (message: string) => {
   return spawnSync(cmd, args, opts).stdout.toString().trim();
 };
 
-export const terraformAwsCli = async (
-  args: string[],
-  options?: TerraformOptions,
-): Promise<void> => {
-  const ignoreMissingDeployments = args.includes('--ignore-missing-deployments');
+export interface TerraformAWSCliParams {
+  ignoreMissingDeployments: boolean;
+  infraOperation: string;
+  options?: TerraformOptions;
+  deploymentName: string;
+  skipConfirmations: boolean;
+}
+
+export const terraformAwsCli = async (params: TerraformAWSCliParams): Promise<void> => {
+  const ignoreMissingDeployments = params.ignoreMissingDeployments;
 
   let awsTerraformConfig: AWSTerraformState;
   let deployment: AWSDeployment;
@@ -123,11 +128,13 @@ export const terraformAwsCli = async (
   let awsProvider: AWSCloudProvider;
 
   try {
-    const envResult = await initTerraformEnvironment(args);
+    const envResult = await initTerraformEnvironment(params.deploymentName);
     ({ awsTerraformConfig, deployment, credentials, awsProvider } = envResult);
   } catch (e) {
     if (ignoreMissingDeployments) {
-      console.warn(`Warning: Deployment '${args[1]}' does not exist. Skipping operation.`);
+      console.warn(
+        `Warning: Deployment '${params.deploymentName}' does not exist. Skipping operation.`,
+      );
       return;
     }
     throw e;
@@ -148,9 +155,9 @@ export const terraformAwsCli = async (
     writeTerraformConfig(awsTerraformConfig);
   }
 
-  const [operation] = args;
+  const operation = params.infraOperation;
   if (operation === 'destroy-state') {
-    const ciConfirmed = args.find((str) => str === '-y');
+    const ciConfirmed = params.skipConfirmations;
     if (!ciConfirmed) {
       const value = prompt(
         'Are you sure to destroy your remote deployment state? If yes, please type `y` and enter.\n' +
@@ -182,14 +189,12 @@ export const terraformAwsCli = async (
   }
 
   terraformCli(args, {
-    ...options,
+    ...params.options,
     provider: awsProvider,
   });
 };
 
-export async function initTerraformEnvironment(args: string[]) {
-  const deploymentName = args[1];
-
+export async function initTerraformEnvironment(deploymentName: string) {
   const deployment = readDeploymentFromPackageConfig({
     deploymentName,
   });

--- a/workspaces/templates-lib/packages/utils-terraform-hetzner/src/utilsTerraformHetzner.ts
+++ b/workspaces/templates-lib/packages/utils-terraform-hetzner/src/utilsTerraformHetzner.ts
@@ -36,7 +36,19 @@ export const terraformHetznerCli = async (
   options?: TerraformOptions,
 ): Promise<void> => {
   const ignoreMissingDeployments = args.includes('--ignore-missing-deployments');
+  const infraOperation = args[0];
   const deploymentName = args[1];
+  let targetVersion: string | undefined;
+  let confirm: boolean | undefined;
+  let commandArgs: string[] | undefined;
+
+  if (infraOperation === 'upgrade') {
+    targetVersion = args[2];
+  } else if (infraOperation === 'terraform') {
+    commandArgs = args.slice(2);
+  } else if (infraOperation === 'destroy') {
+    confirm = args.includes('-y');
+  }
 
   let deployment: any;
 
@@ -54,8 +66,15 @@ export const terraformHetznerCli = async (
 
   const user = await getHetznerUser(deployment.hetznerUser);
 
-  terraformCli(args, {
-    ...options,
-    provider: new HetznerCloudProvider(user.config.token, provider),
+  terraformCli({
+    infraOperation,
+    deploymentName,
+    targetVersion,
+    confirm,
+    command: commandArgs,
+    options: {
+      ...options,
+      provider: new HetznerCloudProvider(user.config.token, provider),
+    },
   });
 };

--- a/workspaces/templates-lib/packages/utils-terraform-hetzner/src/utilsTerraformHetzner.ts
+++ b/workspaces/templates-lib/packages/utils-terraform-hetzner/src/utilsTerraformHetzner.ts
@@ -71,7 +71,7 @@ export const terraformHetznerCli = async (
     deploymentName,
     targetVersion,
     confirm,
-    command: commandArgs,
+    commandArguments: commandArgs,
     options: {
       ...options,
       provider: new HetznerCloudProvider(user.config.token, provider),

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformBuild.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformBuild.ts
@@ -20,27 +20,27 @@ import type {
 import type { TerraformOptions } from './utilsTerraform';
 
 /**
- * Parameters for initializing a Terraform deployment.
+ * Base parameters for Terraform operations that require a deployment name.
  */
-export interface InitParams {
-  /** The name of the deployment to initialize. */
+export interface BaseTerraformParams {
+  /** The name of the deployment. */
   deploymentName: string;
 }
+
+/**
+ * Parameters for initializing a Terraform deployment.
+ */
+export interface InitParams extends BaseTerraformParams {}
 
 /**
  * Parameters for planning a Terraform deployment.
  */
-export interface PlanParams {
-  /** The name of the deployment to plan. */
-  deploymentName: string;
-}
+export interface PlanParams extends BaseTerraformParams {}
 
 /**
  * Parameters for applying a Terraform deployment.
  */
-export interface ApplyParams {
-  /** The name of the deployment to apply. */
-  deploymentName: string;
+export interface ApplyParams extends BaseTerraformParams {
   /** Optional Terraform options for the apply operation. */
   options?: TerraformOptions;
 }
@@ -48,9 +48,7 @@ export interface ApplyParams {
 /**
  * Parameters for destroying a Terraform deployment.
  */
-export interface DestroyParams {
-  /** The name of the deployment to destroy. */
-  deploymentName: string;
+export interface DestroyParams extends BaseTerraformParams {
   /** Whether to skip confirmation prompt (equivalent to -y flag). */
   confirm?: boolean;
 }
@@ -58,9 +56,7 @@ export interface DestroyParams {
 /**
  * Parameters for upgrading Terraform version for a deployment.
  */
-export interface UpgradeParams {
-  /** The name of the deployment to upgrade. */
-  deploymentName: string;
+export interface UpgradeParams extends BaseTerraformParams {
   /** The target Terraform version to upgrade to. */
   targetVersion: string;
 }
@@ -68,17 +64,12 @@ export interface UpgradeParams {
 /**
  * Parameters for checking if a deployment is up.
  */
-export interface IsUpParams {
-  /** The name of the deployment to check. */
-  deploymentName: string;
-}
+export interface IsUpParams extends BaseTerraformParams {}
 
 /**
  * Parameters for running arbitrary Terraform commands.
  */
-export interface TerraformParams {
-  /** The name of the deployment. */
-  deploymentName: string;
+export interface TerraformParams extends BaseTerraformParams {
   /** The Terraform command arguments to execute. */
   command: string[];
   /** Whether to inject variables into the command. */

--- a/workspaces/templates-lib/packages/utils-terraform/src/utilsTerraform.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/utilsTerraform.ts
@@ -132,50 +132,66 @@ export interface TerraformOptions {
   provider?: CloudProvider;
 }
 
-export const terraformCli = (args: string[], options: TerraformOptions): void => {
-  if (!options.provider) {
+export type TerraformCliParams = {
+  options: TerraformOptions;
+  infraOperation: string;
+  deploymentName: string;
+  targetVersion?: string;
+  confirm?: boolean;
+  command?: string[];
+  injectVariables?: boolean;
+  injectBackendConfig?: boolean;
+};
+
+export const terraformCli = (params: TerraformCliParams): void => {
+  if (!params.options.provider) {
     throw new Error('Cloud provider not defined');
   }
-  const [operation, ...opArgs] = args;
+  const operation = params.infraOperation;
 
-  const build = new TerraformBuild(options.provider);
+  const build = new TerraformBuild(params.options.provider);
 
   if (operation === 'up') {
-    build.init(opArgs);
-    build.plan(opArgs);
-    build.apply(opArgs, options);
+    build.init({ deploymentName: params.deploymentName });
+    build.plan({ deploymentName: params.deploymentName });
+    build.apply({ deploymentName: params.deploymentName, options: params.options });
     return;
   }
 
   if (operation === 'init') {
-    build.init(opArgs);
+    build.init({ deploymentName: params.deploymentName });
     return;
   }
   if (operation === 'plan') {
-    build.plan(opArgs);
+    build.plan({ deploymentName: params.deploymentName });
     return;
   }
   if (operation === 'apply') {
-    build.apply(opArgs);
+    build.apply({ deploymentName: params.deploymentName, options: params.options });
     return;
   }
 
   if (operation === 'destroy') {
-    build.destroy(opArgs);
+    build.destroy({ deploymentName: params.deploymentName, confirm: params.confirm });
     return;
   }
 
   if (operation === 'is-up') {
-    build.isUp(opArgs);
+    build.isUp({ deploymentName: params.deploymentName });
     return;
   }
 
   if (operation === 'upgrade') {
-    build.upgrade(opArgs);
+    build.upgrade({ deploymentName: params.deploymentName, targetVersion: params.targetVersion! });
     return;
   }
   if (operation === 'terraform') {
-    build.terraform(opArgs);
+    build.terraform({
+      deploymentName: params.deploymentName,
+      command: params.command!,
+      injectVariables: params.injectVariables,
+      injectBackendConfig: params.injectBackendConfig,
+    });
     return;
   }
   if (operation === 'destroy-state') {

--- a/workspaces/templates-lib/packages/utils-terraform/src/utilsTerraform.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/utilsTerraform.ts
@@ -138,7 +138,7 @@ export type TerraformCliParams = {
   deploymentName: string;
   targetVersion?: string;
   confirm?: boolean;
-  command?: string[];
+  commandArguments?: string[];
   injectVariables?: boolean;
   injectBackendConfig?: boolean;
 };
@@ -188,7 +188,7 @@ export const terraformCli = (params: TerraformCliParams): void => {
   if (operation === 'terraform') {
     build.terraform({
       deploymentName: params.deploymentName,
-      command: params.command!,
+      command: params.commandArguments!,
       injectVariables: params.injectVariables,
       injectBackendConfig: params.injectBackendConfig,
     });

--- a/workspaces/templates/packages/serverless-api/goldstack.json
+++ b/workspaces/templates/packages/serverless-api/goldstack.json
@@ -45,8 +45,7 @@
           }
         }
       },
-      "tfStateKey": "lambda-api-template-prod-9d3d0e0a2d6a51e5308a.tfstate",
-      "tfVersion": "1.7"
+      "tfStateKey": "lambda-api-template-prod-9d3d0e0a2d6a51e5308a.tfstate"
     }
   ]
 }

--- a/workspaces/templates/packages/serverless-api/src/state/deployments.json
+++ b/workspaces/templates/packages/serverless-api/src/state/deployments.json
@@ -1,5 +1,12 @@
 [
   {
-    "name": "prod"
+    "name": "prod",
+    "terraform": {
+      "gateway_url": {
+        "sensitive": false,
+        "type": "string",
+        "value": "https://mc0tdwn9l8.execute-api.us-west-2.amazonaws.com"
+      }
+    }
   }
 ]

--- a/workspaces/utils/packages/utils-cli/src/utilsCli.ts
+++ b/workspaces/utils/packages/utils-cli/src/utilsCli.ts
@@ -97,7 +97,7 @@ export const wrapCli = async (func: AsyncFunction<any>): Promise<void> => {
       console.error(e);
       throw e;
     } else {
-      logger().info(
+      logger().error(
         {},
         '❌ Error while executing CLI command:' +
           e.message +


### PR DESCRIPTION
Initially, yargs was only used for validating the command but not to extract the parsed values.

With these changes, we use the data as it is extract by yargs.

This works better for more complex scenarios, as for the new `--ignore-missing-deplyments` flag