### PR TITLE
[DynamoDB Template] Do not run migratons on destroy

### DIFF
--- a/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb-cli/src/templateDynamoDBCli.ts
@@ -78,8 +78,10 @@ export const run = async ({
           throw new Error(`Cannot find configuration for deployment '${deploymentName}'`);
         }
       }
-      await dynamoDBCli(migrations, ['init', deploymentName]);
       const infraOperation = argv._[1] as string;
+      if (infraOperation !== 'destroy') {
+        await dynamoDBCli(migrations, ['init', deploymentName]);
+      }
       let targetVersion: string | undefined;
       let confirm: boolean | undefined;
       let commandArgs: string[] | undefined;


### PR DESCRIPTION
It's not necessary to run migrations when we want to 'destroy' the table.

Now they are skipped.