### PR TITLE
[DynamoDB Template] Stop polluting local logs with DynamoDB

### DIFF
--- a/workspaces/templates-lib/packages/template-dynamodb/src/local/instanceManager.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb/src/local/instanceManager.ts
@@ -17,6 +17,8 @@ interface PersistedState {
   usageCounts: { [port: string]: number };
 }
 
+let localMessageShown = false;
+
 /**
  * Manages DynamoDB instance lifecycle and state
  */
@@ -64,7 +66,11 @@ export class InstanceManager {
           this.setInstance(port, 'stopped');
           continue;
         }
-        debug(`Found existing local DynamoDB instance on port ${port}`);
+        if (!localMessageShown) {
+          debug(`Found existing local DynamoDB instance on port ${port}`);
+          localMessageShown = true;
+        }
+
         return instance;
       }
     }

--- a/workspaces/templates-lib/packages/template-dynamodb/src/local/localDynamoDB.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb/src/local/localDynamoDB.ts
@@ -39,12 +39,17 @@ export type StopAllLocalDynamoDBType = (
   deploymentName?: string,
 ) => Promise<void>;
 
+let localMessageShown = false;
+
 /**
  * Creates a DynamoDB client for a local instance
  */
 async function createClient(instance: DynamoDBInstance): Promise<DynamoDBClient> {
   const endpoint = getEndpointUrl(instance.port);
-  debug(`Connecting to local DynamoDB instance on endpoint: ${endpoint}`);
+  if (!localMessageShown) {
+    debug(`Connecting to local DynamoDB instance on endpoint: ${endpoint}`);
+    localMessageShown = true;
+  }
   return new DynamoDBClient({
     endpoint,
     region: defaultConfig.region,

--- a/workspaces/templates-lib/packages/template-dynamodb/src/local/localInstances.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb/src/local/localInstances.ts
@@ -44,6 +44,8 @@ export interface LocalInstancesManager {
   removeUsageCounter(port: number): void;
 }
 
+let localMessageShown = false;
+
 /**
  * Implementation of LocalInstancesManager for managing DynamoDB local instances
  */
@@ -147,7 +149,10 @@ class LocalInstancesManagerImpl implements LocalInstancesManager {
   getFirstRunningInstance(): DynamoDBInstance | undefined {
     for (const [port, instance] of this.startedInstances.entries()) {
       if (instance !== 'stopped') {
-        debug(`Found existing local DynamoDB instance on port ${port}`);
+        if (localMessageShown === false) {
+          debug(`Found existing local DynamoDB instance on port ${port}`);
+          localMessageShown = true;
+        }
         return instance;
       }
     }

--- a/workspaces/templates-lib/packages/template-dynamodb/src/templateDynamoDBTable.ts
+++ b/workspaces/templates-lib/packages/template-dynamodb/src/templateDynamoDBTable.ts
@@ -119,13 +119,17 @@ export const stopLocalDynamoDB = async (
   coldStart.delete(coldStartKey);
 };
 
+let localMessageShown = false;
+
 const createClient = async (
   packageConfig: EmbeddedPackageConfig<DynamoDBPackage, DynamoDBDeployment>,
   deploymentName: string,
 ): Promise<DynamoDBClient> => {
   if (deploymentName === 'local') {
-    debug('Connecting to local DynamoDB instance');
-    // Suppress ESLint error for dynamic require
+    if (!localMessageShown) {
+      debug('Connecting to local DynamoDB instance');
+      localMessageShown = true;
+    }
 
     const lib = require(excludeInBundle('./local/localDynamoDB')) as {
       localConnect: LocalConnectType;


### PR DESCRIPTION
When testing [trigger lambdas](https://goldstack.party/templates/lambda-node-trigger) triggered by SQS, DynamoDB logs would flood the logs during local testing.

This change will only make it log once when its connected to local successfully.