### PR TITLE
feat(user-management): add state parameter support for preserving deep links during auth

### DIFF
--- a/workspaces/docs/docs/templates/user-management/features.md
+++ b/workspaces/docs/docs/templates/user-management/features.md
@@ -3,3 +3,4 @@
 - Library with convenient methods to authenticate user on the client.
 - Library to validate tokens on the server.
 - Automatically verifies users email addresses.
+- Supports OAuth `state` parameter for preserving deep links during authentication flows.

--- a/workspaces/docs/docs/templates/user-management/getting-started.md
+++ b/workspaces/docs/docs/templates/user-management/getting-started.md
@@ -79,6 +79,41 @@ Authentication also involves requesting a refresh token. The refresh token will 
 
 Note during the sign in process, the user will always be redirected to the callback URL you specified during configuration after a successful sign in.
 
+#### Preserving Deep Links During Authentication
+
+When users access a deep link while unauthenticated (e.g., `/app/automation/xxx/skill/yyy`), you can preserve the destination using the `state` parameter:
+
+```typescript
+import { loginWithRedirect, handleRedirectCallback, getLoggedInUser } from 'user-management';
+
+// Before redirecting to Cognito
+const currentPath = window.location.pathname + window.location.search;
+await loginWithRedirect(undefined, currentPath);
+
+// After Cognito callback: /app?code=abc&state=/app/automation/xxx/skill/yyy
+// handleRedirectCallback extracts state and redirects to the deep link
+const result = await handleRedirectCallback();
+// result.state contains the preserved path
+```
+
+The `state` parameter must be a relative path starting with `/` (e.g., `/app/automation/xxx`). This prevents open redirect vulnerabilities. If an invalid state is provided, a warning will be logged and the user will be redirected to the callback URL instead.
+
+You can also validate state values using the exported `isValidState` function:
+
+```typescript
+import { isValidState } from 'user-management';
+
+if (isValidState(path)) {
+  await loginWithRedirect(undefined, path);
+}
+```
+
+The `state` parameter is also available for `signUpWithRedirect`:
+
+```typescript
+await signUpWithRedirect(undefined, currentPath);
+```
+
 The library also supports logging out users. For this, simply call the method `performLogout`. The user will be redirected to the Cognito hosted UI sign in screen.
 
 ```typescript

--- a/workspaces/docs/docs/templates/user-management/getting-started.md
+++ b/workspaces/docs/docs/templates/user-management/getting-started.md
@@ -84,16 +84,21 @@ Note during the sign in process, the user will always be redirected to the callb
 When users access a deep link while unauthenticated (e.g., `/app/automation/xxx/skill/yyy`), you can preserve the destination using the `state` parameter:
 
 ```typescript
-import { loginWithRedirect, handleRedirectCallback, getLoggedInUser } from 'user-management';
+import { loginWithRedirect, handleRedirectCallback } from 'user-management';
 
 // Before redirecting to Cognito
 const currentPath = window.location.pathname + window.location.search;
 await loginWithRedirect(undefined, currentPath);
+```
 
-// After Cognito callback: /app?code=abc&state=/app/automation/xxx/skill/yyy
-// handleRedirectCallback extracts state and redirects to the deep link
-const result = await handleRedirectCallback();
-// result.state contains the preserved path
+After Cognito redirects back to your callback URL (e.g., `/app?code=abc&state=/app/automation/xxx`), call `handleRedirectCallback` on that page:
+
+```typescript
+// On your callback page (e.g., /app)
+// This will extract the state and redirect to the deep link
+await handleRedirectCallback();
+// Note: In browser environments, this function performs a redirect and never returns.
+// The user will be navigated to the state path or callback URL.
 ```
 
 The `state` parameter must be a relative path starting with `/` (e.g., `/app/automation/xxx`). This prevents open redirect vulnerabilities. If an invalid state is provided, a warning will be logged and the user will be redirected to the callback URL instead.

--- a/workspaces/docs/docs/templates/user-management/getting-started.md
+++ b/workspaces/docs/docs/templates/user-management/getting-started.md
@@ -79,44 +79,50 @@ Authentication also involves requesting a refresh token. The refresh token will 
 
 Note during the sign in process, the user will always be redirected to the callback URL you specified during configuration after a successful sign in.
 
-#### Preserving Deep Links During Authentication
+#### Automatic Deep Link Preservation
 
-When users access a deep link while unauthenticated (e.g., `/app/automation/xxx/skill/yyy`), you can preserve the destination using the `state` parameter:
+By default, the current URL (pathname, search, and hash) is automatically preserved when calling `loginWithRedirect`. After authentication, the user is redirected back to their original location.
 
 ```typescript
 import { loginWithRedirect, handleRedirectCallback } from 'user-management';
 
-// Before redirecting to Cognito
-const currentPath = window.location.pathname + window.location.search;
-await loginWithRedirect(undefined, currentPath);
-```
+// User is on /app/automation/xxx/skill/yyy
+// Current URL is automatically preserved
+await loginWithRedirect();
 
-After Cognito redirects back to your callback URL (e.g., `/app?code=abc&state=/app/automation/xxx`), call `handleRedirectCallback` on that page:
-
-```typescript
-// On your callback page (e.g., /app)
-// This will extract the state and redirect to the deep link
+// After Cognito redirects back to callback URL
+// call handleRedirectCallback on that page:
 await handleRedirectCallback();
-// Note: In browser environments, this function performs a redirect and never returns.
-// The user will be navigated to the state path or callback URL.
+// User is automatically redirected back to /app/automation/xxx/skill/yyy
 ```
 
-The `state` parameter must be a relative path starting with `/` (e.g., `/app/automation/xxx`). This prevents open redirect vulnerabilities. If an invalid state is provided, a warning will be logged and the user will be redirected to the callback URL instead.
+Note: In browser environments, `handleRedirectCallback` performs a redirect and never returns to the caller.
 
-You can also validate state values using the exported `isValidState` function:
+#### Overriding Redirect Behavior
+
+To redirect to a specific URL after authentication instead of the current URL:
 
 ```typescript
-import { isValidState } from 'user-management';
-
-if (isValidState(path)) {
-  await loginWithRedirect(undefined, path);
-}
+await loginWithRedirect({ targetUrl: '/dashboard' });
 ```
 
-The `state` parameter is also available for `signUpWithRedirect`:
+To skip deep link preservation and always use the callback URL:
 
 ```typescript
-await signUpWithRedirect(undefined, currentPath);
+await loginWithRedirect({ doNotPreservePath: true });
+```
+
+To specify a deployment along with options:
+
+```typescript
+await loginWithRedirect('prod', { targetUrl: '/dashboard' });
+```
+
+The same options work for `signUpWithRedirect`:
+
+```typescript
+await signUpWithRedirect(); // Auto-preserve current URL
+await signUpWithRedirect({ targetUrl: '/welcome' }); // Redirect to specific URL
 ```
 
 The library also supports logging out users. For this, simply call the method `performLogout`. The user will be redirected to the Cognito hosted UI sign in screen.

--- a/workspaces/templates-lib/packages/template-user-management/src/client/getEndpoints.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/getEndpoints.ts
@@ -13,6 +13,7 @@ export async function getEndpoint(args: {
   packageSchema: any;
   deploymentsOutput: any;
   deploymentName?: string;
+  state?: string;
 }): Promise<string> {
   const deploymentName = getDeploymentName(args.deploymentName);
 
@@ -38,7 +39,8 @@ export async function getEndpoint(args: {
         `&client_id=${deploymentOutput.terraform.user_pool_client_id.value}` +
         `&redirect_uri=${deployment.configuration.callbackUrl}` +
         '&code_challenge_method=S256' +
-        `&code_challenge=${await getCodeChallenge()}`
+        `&code_challenge=${await getCodeChallenge()}` +
+        (args.state ? `&state=${encodeURIComponent(args.state)}` : '')
       );
     case 'signup':
       return (
@@ -46,7 +48,8 @@ export async function getEndpoint(args: {
         `&client_id=${deploymentOutput.terraform.user_pool_client_id.value}` +
         `&redirect_uri=${deployment.configuration.callbackUrl}` +
         '&code_challenge_method=S256' +
-        `&code_challenge=${await getCodeChallenge()}`
+        `&code_challenge=${await getCodeChallenge()}` +
+        (args.state ? `&state=${encodeURIComponent(args.state)}` : '')
       );
     case 'token':
       return `${baseUrl}/oauth2/token`;

--- a/workspaces/templates-lib/packages/template-user-management/src/client/getLoggedInUser.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/getLoggedInUser.ts
@@ -5,6 +5,7 @@
 export interface ClientAuthResult {
   accessToken: string;
   idToken: string;
+  state?: string;
 }
 
 import { forceLogout } from './state';

--- a/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
@@ -7,7 +7,11 @@ import type { ClientAuthResult } from './getLoggedInUser';
 import { isValidState } from './state';
 
 /**
- * Handles the redirect callback from the authentication provider
+ * Handles the redirect callback from the authentication provider.
+ *
+ * Note: In browser environments, this function performs a redirect and never returns
+ * to the caller. The return value is only relevant for Jest test environments and
+ * server-side rendering contexts where redirects are not performed.
  */
 export async function handleRedirectCallback(args: {
   goldstackConfig: any;
@@ -33,37 +37,32 @@ export async function handleRedirectCallback(args: {
     packageSchema: args.packageSchema,
   });
 
+  // Determine the redirect URL based on deployment type and state
+  let redirectUrl: string;
   if (deploymentName === 'local') {
-    let redirectUrl = window.location.href.replace('?code=dummy-local-client-code', '');
-    if (state) {
-      if (isValidState(state)) {
-        redirectUrl = state;
-      } else {
-        console.warn(
-          `Invalid state parameter received: "${state}". ` +
-            `State must be a relative path starting with '/'. ` +
-            `Redirecting to local callback URL instead.`,
-        );
-      }
-    }
-    window.location.href = redirectUrl;
+    redirectUrl = window.location.href.replace('?code=dummy-local-client-code', '');
   } else {
     const deployment = packageConfig.getDeployment(deploymentName);
-    if (state) {
-      if (isValidState(state)) {
-        window.location.href = state;
-      } else {
-        console.warn(
-          `Invalid state parameter received: "${state}". ` +
-            `State must be a relative path starting with '/'. ` +
-            `Redirecting to callback URL instead.`,
-        );
-        window.location.href = deployment.configuration.callbackUrl;
-      }
+    redirectUrl = deployment.configuration.callbackUrl;
+  }
+
+  // Apply state redirection if valid
+  if (state) {
+    if (isValidState(state)) {
+      redirectUrl = state;
     } else {
-      window.location.href = deployment.configuration.callbackUrl;
+      console.warn(
+        `Invalid state parameter received: "${state}". ` +
+          `State must be a relative path starting with '/'. ` +
+          `Redirecting to callback URL instead.`,
+      );
     }
   }
+
+  // In browser environments, this redirect causes navigation and the function
+  // never returns to the caller. The code below only executes in Jest tests.
+  window.location.href = redirectUrl;
+
   if (!token) {
     return;
   }

--- a/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
@@ -4,6 +4,7 @@ import type { UserManagementDeployment } from '../types/UserManagementPackage';
 import { getDeploymentName } from '../userManagementConfig';
 import { getAndPersistToken } from './getAndPersistToken';
 import type { ClientAuthResult } from './getLoggedInUser';
+import { isValidState } from './state';
 
 /**
  * Handles the redirect callback from the authentication provider
@@ -14,8 +15,6 @@ export async function handleRedirectCallback(args: {
   deploymentsOutput: any;
   deploymentName?: string;
 }): Promise<ClientAuthResult | undefined> {
-  // if running on the server, such as for rendering a page for SSR, client auth
-  // cannot be performed
   if (typeof window === 'undefined') {
     return;
   }
@@ -25,6 +24,7 @@ export async function handleRedirectCallback(args: {
   if (!code) {
     return;
   }
+  const state = params.get('state');
   const deploymentName = getDeploymentName(args.deploymentName);
 
   const token = await getAndPersistToken({ ...args, code });
@@ -34,10 +34,27 @@ export async function handleRedirectCallback(args: {
   });
 
   if (deploymentName === 'local') {
-    window.location.href = window.location.href.replace('?code=dummy-local-client-code', '');
+    let redirectUrl = window.location.href.replace('?code=dummy-local-client-code', '');
+    if (state) {
+      redirectUrl = state;
+    }
+    window.location.href = redirectUrl;
   } else {
     const deployment = packageConfig.getDeployment(deploymentName);
-    window.location.href = deployment.configuration.callbackUrl;
+    if (state) {
+      if (isValidState(state)) {
+        window.location.href = state;
+      } else {
+        console.warn(
+          `Invalid state parameter received: "${state}". ` +
+            `State must be a relative path starting with '/'. ` +
+            `Redirecting to callback URL instead.`,
+        );
+        window.location.href = deployment.configuration.callbackUrl;
+      }
+    } else {
+      window.location.href = deployment.configuration.callbackUrl;
+    }
   }
   if (!token) {
     return;
@@ -45,5 +62,6 @@ export async function handleRedirectCallback(args: {
   return {
     accessToken: token.accessToken,
     idToken: token.idToken,
+    state: state || undefined,
   };
 }

--- a/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
@@ -40,7 +40,7 @@ export async function handleRedirectCallback(args: {
   // Determine the redirect URL based on deployment type and state
   let redirectUrl: string;
   if (deploymentName === 'local') {
-    redirectUrl = window.location.href.replace('?code=dummy-local-client-code', '');
+    redirectUrl = window.location.href.split('?')[0];
   } else {
     const deployment = packageConfig.getDeployment(deploymentName);
     redirectUrl = deployment.configuration.callbackUrl;

--- a/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
@@ -42,6 +42,14 @@ export async function handleRedirectCallback(args: {
         console.warn(
           `Invalid state parameter received: "${state}". ` +
             `State must be a relative path starting with '/'. ` +
+            `Redirecting to local callback URL instead.`,
+        );
+      }
+        redirectUrl = state;
+      } else {
+        console.warn(
+          `Invalid state parameter received: "${state}". ` +
+            `State must be a relative path starting with '/'. ` +
             `Redirecting to original URL instead.`,
         );
       }

--- a/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
@@ -34,11 +34,21 @@ export async function handleRedirectCallback(args: {
   });
 
   if (deploymentName === 'local') {
-    let redirectUrl = window.location.href.replace('?code=dummy-local-client-code', '');
+    const redirectUrl = window.location.href.replace('?code=dummy-local-client-code', '');
     if (state) {
       if (isValidState(state)) {
-        redirectUrl = state;
+        window.location.href = state;
       } else {
+        console.warn(
+          `Invalid state parameter received: "${state}". ` +
+            `State must be a relative path starting with '/'. ` +
+            `Redirecting to callback URL instead.`,
+        );
+        window.location.href = redirectUrl;
+      }
+    } else {
+      window.location.href = redirectUrl;
+        redirectUrl = state;
         console.warn(
           `Invalid state parameter received: "${state}". ` +
             `State must be a relative path starting with '/'. ` +

--- a/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
@@ -34,33 +34,15 @@ export async function handleRedirectCallback(args: {
   });
 
   if (deploymentName === 'local') {
-    const redirectUrl = window.location.href.replace('?code=dummy-local-client-code', '');
+    let redirectUrl = window.location.href.replace('?code=dummy-local-client-code', '');
     if (state) {
       if (isValidState(state)) {
-        window.location.href = state;
-      } else {
-        console.warn(
-          `Invalid state parameter received: "${state}". ` +
-            `State must be a relative path starting with '/'. ` +
-            `Redirecting to callback URL instead.`,
-        );
-        window.location.href = redirectUrl;
-      }
-    } else {
-      window.location.href = redirectUrl;
         redirectUrl = state;
+      } else {
         console.warn(
           `Invalid state parameter received: "${state}". ` +
             `State must be a relative path starting with '/'. ` +
             `Redirecting to local callback URL instead.`,
-        );
-      }
-        redirectUrl = state;
-      } else {
-        console.warn(
-          `Invalid state parameter received: "${state}". ` +
-            `State must be a relative path starting with '/'. ` +
-            `Redirecting to original URL instead.`,
         );
       }
     }

--- a/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/handleRedirectCallback.ts
@@ -36,7 +36,15 @@ export async function handleRedirectCallback(args: {
   if (deploymentName === 'local') {
     let redirectUrl = window.location.href.replace('?code=dummy-local-client-code', '');
     if (state) {
-      redirectUrl = state;
+      if (isValidState(state)) {
+        redirectUrl = state;
+      } else {
+        console.warn(
+          `Invalid state parameter received: "${state}". ` +
+            `State must be a relative path starting with '/'. ` +
+            `Redirecting to original URL instead.`,
+        );
+      }
     }
     window.location.href = redirectUrl;
   } else {

--- a/workspaces/templates-lib/packages/template-user-management/src/client/operationWithRedirect.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/operationWithRedirect.ts
@@ -16,6 +16,7 @@ export async function operationWithRedirect(args: {
   deploymentsOutput: any;
   deploymentName?: string;
   operation: 'authorize' | 'signup';
+  state?: string;
 }): Promise<ClientAuthResult | undefined> {
   if (forceLogout) {
     return;
@@ -54,7 +55,11 @@ export async function operationWithRedirect(args: {
     if (getMockedUserAccessToken() === undefined) {
       return;
     }
-    window.location.href = '?code=dummy-local-client-code';
+    let redirectUrl = '?code=dummy-local-client-code';
+    if (args.state) {
+      redirectUrl = args.state;
+    }
+    window.location.href = redirectUrl;
     return;
   }
 

--- a/workspaces/templates-lib/packages/template-user-management/src/client/operationWithRedirect.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/operationWithRedirect.ts
@@ -57,7 +57,7 @@ export async function operationWithRedirect(args: {
     }
     let redirectUrl = '?code=dummy-local-client-code';
     if (args.state) {
-      redirectUrl = args.state;
+      redirectUrl += `&state=${encodeURIComponent(args.state)}`;
     }
     window.location.href = redirectUrl;
     return;

--- a/workspaces/templates-lib/packages/template-user-management/src/client/state.spec.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/state.spec.ts
@@ -1,0 +1,47 @@
+import assert from 'assert';
+import { isValidState } from './state';
+
+describe('isValidState', () => {
+  it('should accept valid relative paths', () => {
+    assert(isValidState('/app'));
+    assert(isValidState('/app/automation/xxx'));
+    assert(isValidState('/app/automation/019d17e5-xxx/skill/019d17e5-xxx'));
+    assert(isValidState('/app?query=value'));
+    assert(isValidState('/app#anchor'));
+  });
+
+  it('should reject protocol-relative URLs', () => {
+    assert(!isValidState('//example.com'));
+    assert(!isValidState('//example.com/path'));
+  });
+
+  it('should reject absolute URLs', () => {
+    assert(!isValidState('https://example.com'));
+    assert(!isValidState('http://example.com'));
+    assert(!isValidState('ftp://example.com'));
+  });
+
+  it('should reject paths without leading slash', () => {
+    assert(!isValidState('app/path'));
+    assert(!isValidState('relative'));
+  });
+
+  it('should reject empty string', () => {
+    assert(!isValidState(''));
+  });
+
+  it('should accept root path', () => {
+    assert(isValidState('/'));
+  });
+
+  it('should accept paths with special characters', () => {
+    assert(isValidState('/app/test%20space'));
+    assert(isValidState('/app/test?a=1&b=2'));
+    assert(isValidState('/app/test#section'));
+  });
+
+  it('should reject URLs with colon-slash-slash anywhere', () => {
+    assert(!isValidState('/app/https://evil.com'));
+    assert(!isValidState('/path/http://example.com'));
+  });
+});

--- a/workspaces/templates-lib/packages/template-user-management/src/client/state.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/state.ts
@@ -12,3 +12,15 @@ export function setForceLogout(value: boolean) {
 export function setRefreshTokenStorage(token: string | undefined) {
   refreshTokenStorage = token;
 }
+
+/**
+ * Validates that a state parameter is a safe relative path.
+ * Prevents open redirect vulnerabilities by rejecting absolute URLs
+ * and protocol-relative URLs.
+ *
+ * @param state - The state value to validate
+ * @returns true if the state is a valid relative path
+ */
+export function isValidState(state: string): boolean {
+  return state.startsWith('/') && !state.startsWith('//') && !state.includes('://');
+}

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -108,8 +108,9 @@ function determineTargetUrl(
     if (window.location.pathname === callbackPath) {
       return undefined;
     }
-  } catch {
+  } catch (e) {
     // If we can't parse callback URL, proceed with auto-capture
+    console.warn('Could not parse callback URL from configuration. Proceeding with auto-capture.', e);
   }
 
   return currentUrl || undefined;

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -177,7 +177,9 @@ async function performRedirect(args: RedirectArgs): Promise<ClientAuthResult | u
   });
 }
 
-export async function loginWithRedirect(args: RedirectArgs): Promise<ClientAuthResult | undefined> {
+export async function loginWithRedirect(
+  args: Omit<RedirectArgs, 'operation'>,
+): Promise<ClientAuthResult | undefined> {
   return performRedirect({ ...args, operation: 'authorize' });
 }
 
@@ -203,7 +205,7 @@ export async function loginWithRedirect(args: RedirectArgs): Promise<ClientAuthR
  * await signUpWithRedirect({ ...args, options: { doNotPreservePath: true } });
  */
 export async function signUpWithRedirect(
-  args: RedirectArgs,
+  args: Omit<RedirectArgs, 'operation'>,
 ): Promise<ClientAuthResult | undefined> {
   return performRedirect({ ...args, operation: 'signup' });
 }

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -6,6 +6,7 @@ import * as cognitoClientAuth from './client/getToken';
 export type { CognitoManager } from './cognitoTokenVerify';
 
 import type { GetTokenResults } from './client/getToken';
+
 export type { GetTokenResults };
 
 import type { ClientAuthResult } from './client/getLoggedInUser';
@@ -18,6 +19,7 @@ export { getLoggedInUser, isAuthenticated } from './client/getLoggedInUser';
 export { handleRedirectCallback } from './client/handleRedirectCallback';
 export { operationWithRedirect } from './client/operationWithRedirect';
 export { performLogout } from './client/performLogout';
+export { isValidState } from './client/state';
 export { connectWithCognito } from './cognitoTokenVerify';
 export {
   getMockedUserAccessToken,
@@ -44,6 +46,7 @@ export async function getEndpoint(args: {
   packageSchema: any;
   deploymentsOutput: any;
   deploymentName?: string;
+  state?: string;
 }): Promise<string> {
   return getEndpointLib(args);
 }
@@ -64,12 +67,18 @@ export async function getToken(args: {
  * <p>Will redirect to Cognito hosted UI for sign in if required.
  * <p>Sets client-side cookies and session variables.
  * <p>For more control on what gets persisted on the client-side, use the method <code>getToken</code>.
+ *
+ * @param args.state - Optional state parameter to preserve through the authentication flow.
+ *                     Must be a relative path starting with '/' (e.g., '/app/automation/xxx').
+ *                     After authentication, the user will be redirected to this path instead of the callback URL.
+ *                     Used for preserving deep links when users need to authenticate before accessing protected routes.
  */
 export async function loginWithRedirect(args: {
   goldstackConfig: any;
   packageSchema: any;
   deploymentsOutput: any;
   deploymentName?: string;
+  state?: string;
 }): Promise<ClientAuthResult | undefined> {
   return operationWithRedirect({ ...args, operation: 'authorize' });
 }
@@ -79,12 +88,18 @@ export async function loginWithRedirect(args: {
  * <p>Will redirect to Cognito hosted UI for signing up if required.
  * <p>Sets client-side cookies and session variables.
  * <p>For more control on what gets persisted on the client-side, use the method <code>getToken</code>.
+ *
+ * @param args.state - Optional state parameter to preserve through the authentication flow.
+ *                     Must be a relative path starting with '/' (e.g., '/app/automation/xxx').
+ *                     After authentication, the user will be redirected to this path instead of the callback URL.
+ *                     Used for preserving deep links when users need to authenticate before accessing protected routes.
  */
 export async function signUpWithRedirect(args: {
   goldstackConfig: any;
   packageSchema: any;
   deploymentsOutput: any;
   deploymentName?: string;
+  state?: string;
 }): Promise<ClientAuthResult | undefined> {
   return operationWithRedirect({ ...args, operation: 'signup' });
 }

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -1,5 +1,6 @@
 export * from './types/UserManagementPackage';
 
+import { EmbeddedPackageConfig } from '@goldstack/utils-package-config-embedded';
 import { getEndpoint as getEndpointLib } from './client/getEndpoints';
 import * as cognitoClientAuth from './client/getToken';
 
@@ -34,11 +35,98 @@ export {
   setLocalUserManager,
 } from './userManagementServerMock';
 
+import type UserManagementPackage from './types/UserManagementPackage';
+import type { UserManagementDeployment } from './types/UserManagementPackage';
+import { getDeploymentName } from './userManagementConfig';
+
 export type Endpoint =
   | 'authorize' // https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html
   | 'signup'
   | 'token' // https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html
   | 'logout'; // https://docs.aws.amazon.com/cognito/latest/developerguide/logout-endpoint.html
+
+/**
+ * Options for login and signup redirect operations.
+ */
+export interface LoginOptions {
+  /**
+   * Override the URL to redirect to after authentication.
+   * By default, the current URL (pathname + search + hash) is preserved.
+   * Must be a relative path starting with '/' (e.g., '/app/dashboard').
+   */
+  targetUrl?: string;
+  /**
+   * If true, redirect to the callback URL instead of preserving the current path.
+   * Useful when you want to always redirect to a default page after authentication.
+   */
+  doNotPreservePath?: boolean;
+}
+
+/**
+ * Internal arguments for redirect operations.
+ */
+export interface RedirectArgs {
+  goldstackConfig: any;
+  packageSchema: any;
+  deploymentsOutput: any;
+  deploymentName?: string;
+  options?: LoginOptions;
+  operation: 'authorize' | 'signup';
+}
+
+/**
+ * Parses the flexible first argument to extract deployment name and options.
+ */
+function parseRedirectArgs(
+  deploymentNameOrOptions?: string | LoginOptions,
+  options?: LoginOptions,
+): { deploymentName?: string; options?: LoginOptions } {
+  if (typeof deploymentNameOrOptions === 'string') {
+    return { deploymentName: deploymentNameOrOptions, options };
+  }
+  return { deploymentName: undefined, options: deploymentNameOrOptions };
+}
+
+/**
+ * Determines the target URL after authentication.
+ * Auto-captures current URL unless doNotPreservePath is set.
+ * Excludes callback URL from auto-capture.
+ */
+function determineTargetUrl(
+  options: LoginOptions | undefined,
+  deploymentName: string | undefined,
+  packageConfig: EmbeddedPackageConfig<UserManagementPackage, UserManagementDeployment>,
+): string | undefined {
+  if (options?.doNotPreservePath) {
+    return undefined;
+  }
+
+  if (options?.targetUrl) {
+    return options.targetUrl;
+  }
+
+  // Auto-capture current URL
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  const currentUrl = window.location.pathname + window.location.search + window.location.hash;
+
+  // Exclude callback URL from auto-capture
+  try {
+    const deployment = packageConfig.getDeployment(deploymentName || 'default');
+    const callbackUrl = deployment.configuration.callbackUrl;
+    const callbackPath = new URL(callbackUrl).pathname;
+
+    if (currentUrl === callbackPath || currentUrl.startsWith(callbackUrl)) {
+      return undefined;
+    }
+  } catch {
+    // If we can't parse callback URL, proceed with auto-capture
+  }
+
+  return currentUrl || undefined;
+}
 
 export async function getEndpoint(args: {
   goldstackConfig: any;
@@ -63,43 +151,91 @@ export async function getToken(args: {
 }
 
 /**
- * <p>Performs client-side authentication.
- * <p>Will redirect to Cognito hosted UI for sign in if required.
- * <p>Sets client-side cookies and session variables.
- * <p>For more control on what gets persisted on the client-side, use the method <code>getToken</code>.
+ * Performs client-side authentication.
+ * Will redirect to Cognito hosted UI for sign in if required.
+ * Sets client-side cookies and session variables.
  *
- * @param args.state - Optional state parameter to preserve through the authentication flow.
- *                     Must be a relative path starting with '/' (e.g., '/app/automation/xxx').
- *                     After authentication, the user will be redirected to this path instead of the callback URL.
- *                     Used for preserving deep links when users need to authenticate before accessing protected routes.
+ * By default, the current URL (pathname + search + hash) is automatically preserved
+ * and the user will be redirected back after authentication.
+ *
+ * @example
+ * // Auto-preserve current URL
+ * await loginWithRedirect(args);
+ *
+ * // Specify deployment
+ * await loginWithRedirect({ ...args, deploymentName: 'prod' });
+ *
+ * // Redirect to specific URL after auth
+ * await loginWithRedirect({ ...args, options: { targetUrl: '/dashboard' } });
+ *
+ * // Skip path preservation
+ * await loginWithRedirect({ ...args, options: { doNotPreservePath: true } });
  */
-export async function loginWithRedirect(args: {
-  goldstackConfig: any;
-  packageSchema: any;
-  deploymentsOutput: any;
-  deploymentName?: string;
-  state?: string;
-}): Promise<ClientAuthResult | undefined> {
-  return operationWithRedirect({ ...args, operation: 'authorize' });
+export async function loginWithRedirect(args: RedirectArgs): Promise<ClientAuthResult | undefined> {
+  const { deploymentName, options } = {
+    deploymentName: args.deploymentName,
+    options: args.options,
+  };
+
+  const packageConfig = new EmbeddedPackageConfig<UserManagementPackage, UserManagementDeployment>({
+    goldstackJson: args.goldstackConfig,
+    packageSchema: args.packageSchema,
+  });
+
+  const state = determineTargetUrl(options, deploymentName, packageConfig);
+
+  return operationWithRedirect({
+    goldstackConfig: args.goldstackConfig,
+    packageSchema: args.packageSchema,
+    deploymentsOutput: args.deploymentsOutput,
+    deploymentName: args.deploymentName,
+    operation: args.operation,
+    state,
+  });
 }
 
 /**
- * <p>Performs client-side authentication.
- * <p>Will redirect to Cognito hosted UI for signing up if required.
- * <p>Sets client-side cookies and session variables.
- * <p>For more control on what gets persisted on the client-side, use the method <code>getToken</code>.
+ * Performs client-side sign up.
+ * Will redirect to Cognito hosted UI for signing up if required.
+ * Sets client-side cookies and session variables.
  *
- * @param args.state - Optional state parameter to preserve through the authentication flow.
- *                     Must be a relative path starting with '/' (e.g., '/app/automation/xxx').
- *                     After authentication, the user will be redirected to this path instead of the callback URL.
- *                     Used for preserving deep links when users need to authenticate before accessing protected routes.
+ * By default, the current URL (pathname + search + hash) is automatically preserved
+ * and the user will be redirected back after authentication.
+ *
+ * @example
+ * // Auto-preserve current URL
+ * await signUpWithRedirect(args);
+ *
+ * // Specify deployment
+ * await signUpWithRedirect({ ...args, deploymentName: 'prod' });
+ *
+ * // Redirect to specific URL after auth
+ * await signUpWithRedirect({ ...args, options: { targetUrl: '/dashboard' } });
+ *
+ * // Skip path preservation
+ * await signUpWithRedirect({ ...args, options: { doNotPreservePath: true } });
  */
-export async function signUpWithRedirect(args: {
-  goldstackConfig: any;
-  packageSchema: any;
-  deploymentsOutput: any;
-  deploymentName?: string;
-  state?: string;
-}): Promise<ClientAuthResult | undefined> {
-  return operationWithRedirect({ ...args, operation: 'signup' });
+export async function signUpWithRedirect(
+  args: RedirectArgs,
+): Promise<ClientAuthResult | undefined> {
+  const { deploymentName, options } = {
+    deploymentName: args.deploymentName,
+    options: args.options,
+  };
+
+  const packageConfig = new EmbeddedPackageConfig<UserManagementPackage, UserManagementDeployment>({
+    goldstackJson: args.goldstackConfig,
+    packageSchema: args.packageSchema,
+  });
+
+  const state = determineTargetUrl(options, deploymentName, packageConfig);
+
+  return operationWithRedirect({
+    goldstackConfig: args.goldstackConfig,
+    packageSchema: args.packageSchema,
+    deploymentsOutput: args.deploymentsOutput,
+    deploymentName: args.deploymentName,
+    operation: args.operation,
+    state,
+  });
 }

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -105,7 +105,7 @@ function determineTargetUrl(
     const callbackUrl = deployment.configuration.callbackUrl;
     const callbackPath = new URL(callbackUrl).pathname;
 
-    if (currentUrl === callbackPath || currentUrl.startsWith(callbackUrl)) {
+    if (window.location.pathname === callbackPath) {
       return undefined;
     }
   } catch {

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -103,7 +103,7 @@ function determineTargetUrl(
   try {
     const deployment = packageConfig.getDeployment(deploymentName || 'default');
     const callbackUrl = deployment.configuration.callbackUrl;
-    const callbackPath = new URL(callbackUrl).pathname;
+    const callbackPath = new URL(callbackUrl, window.location.origin).pathname;
 
     if (window.location.pathname === callbackPath) {
       return undefined;

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -75,19 +75,6 @@ export interface RedirectArgs {
 }
 
 /**
- * Parses the flexible first argument to extract deployment name and options.
- */
-function parseRedirectArgs(
-  deploymentNameOrOptions?: string | LoginOptions,
-  options?: LoginOptions,
-): { deploymentName?: string; options?: LoginOptions } {
-  if (typeof deploymentNameOrOptions === 'string') {
-    return { deploymentName: deploymentNameOrOptions, options };
-  }
-  return { deploymentName: undefined, options: deploymentNameOrOptions };
-}
-
-/**
  * Determines the target URL after authentication.
  * Auto-captures current URL unless doNotPreservePath is set.
  * Excludes callback URL from auto-capture.
@@ -171,18 +158,13 @@ export async function getToken(args: {
  * // Skip path preservation
  * await loginWithRedirect({ ...args, options: { doNotPreservePath: true } });
  */
-export async function loginWithRedirect(args: RedirectArgs): Promise<ClientAuthResult | undefined> {
-  const { deploymentName, options } = {
-    deploymentName: args.deploymentName,
-    options: args.options,
-  };
-
+async function performRedirect(args: RedirectArgs): Promise<ClientAuthResult | undefined> {
   const packageConfig = new EmbeddedPackageConfig<UserManagementPackage, UserManagementDeployment>({
     goldstackJson: args.goldstackConfig,
     packageSchema: args.packageSchema,
   });
 
-  const state = determineTargetUrl(options, deploymentName, packageConfig);
+  const state = determineTargetUrl(args.options, args.deploymentName, packageConfig);
 
   return operationWithRedirect({
     goldstackConfig: args.goldstackConfig,
@@ -192,6 +174,10 @@ export async function loginWithRedirect(args: RedirectArgs): Promise<ClientAuthR
     operation: args.operation,
     state,
   });
+}
+
+export async function loginWithRedirect(args: RedirectArgs): Promise<ClientAuthResult | undefined> {
+  return performRedirect({ ...args, operation: 'authorize' });
 }
 
 /**
@@ -218,24 +204,5 @@ export async function loginWithRedirect(args: RedirectArgs): Promise<ClientAuthR
 export async function signUpWithRedirect(
   args: RedirectArgs,
 ): Promise<ClientAuthResult | undefined> {
-  const { deploymentName, options } = {
-    deploymentName: args.deploymentName,
-    options: args.options,
-  };
-
-  const packageConfig = new EmbeddedPackageConfig<UserManagementPackage, UserManagementDeployment>({
-    goldstackJson: args.goldstackConfig,
-    packageSchema: args.packageSchema,
-  });
-
-  const state = determineTargetUrl(options, deploymentName, packageConfig);
-
-  return operationWithRedirect({
-    goldstackConfig: args.goldstackConfig,
-    packageSchema: args.packageSchema,
-    deploymentsOutput: args.deploymentsOutput,
-    deploymentName: args.deploymentName,
-    operation: args.operation,
-    state,
-  });
+  return performRedirect({ ...args, operation: 'signup' });
 }

--- a/workspaces/templates/packages/user-management/src/users.ts
+++ b/workspaces/templates/packages/user-management/src/users.ts
@@ -77,9 +77,12 @@ export async function signUpWithRedirect(deploymentName?: string, state?: string
  * Handles the redirect callback from Cognito after authentication.
  * This function should be called on the page that Cognito redirects to after login/signup.
  *
+ * Note: In browser environments, this function performs a page redirect and never returns
+ * to the caller. The user will be navigated to the state path (if valid) or the callback URL.
+ * The return value is only relevant for Jest test environments.
+ *
  * @param deploymentName - Optional name of the deployment to use. If not provided,
  *                         uses the deployment specified in environment variables.
- * @returns A promise that resolves with the authentication result, including the state parameter if present.
  */
 export async function handleRedirectCallback(deploymentName?: string) {
   return templateHandleRedirectCallback({

--- a/workspaces/templates/packages/user-management/src/users.ts
+++ b/workspaces/templates/packages/user-management/src/users.ts
@@ -1,4 +1,5 @@
 import {
+  type ClientAuthResult,
   type CognitoManager,
   type Endpoint,
   type GetCookieSettingsResult,
@@ -72,7 +73,7 @@ export {
 export async function loginWithRedirect(
   deploymentNameOrOptions?: string | LoginOptions,
   options?: LoginOptions,
-) {
+): Promise<ClientAuthResult | undefined> {
   const { deploymentName, options: opts } = parseRedirectArgs(deploymentNameOrOptions, options);
 
   return templateLoginWithRedirect({
@@ -115,7 +116,7 @@ export async function loginWithRedirect(
 export async function signUpWithRedirect(
   deploymentNameOrOptions?: string | LoginOptions,
   options?: LoginOptions,
-) {
+): Promise<ClientAuthResult | undefined> {
   const { deploymentName, options: opts } = parseRedirectArgs(deploymentNameOrOptions, options);
 
   return templateSignUpWithRedirect({

--- a/workspaces/templates/packages/user-management/src/users.ts
+++ b/workspaces/templates/packages/user-management/src/users.ts
@@ -82,7 +82,6 @@ export async function loginWithRedirect(
     deploymentsOutput,
     deploymentName,
     options: opts,
-    operation: 'authorize',
   });
 }
 
@@ -125,7 +124,6 @@ export async function signUpWithRedirect(
     deploymentsOutput,
     deploymentName,
     options: opts,
-    operation: 'signup',
   });
 }
 

--- a/workspaces/templates/packages/user-management/src/users.ts
+++ b/workspaces/templates/packages/user-management/src/users.ts
@@ -17,6 +17,16 @@ import goldstackConfig from './../goldstack.json';
 import packageSchema from './../schemas/package.schema.json';
 import deploymentsOutput from './state/deployments.json';
 
+function parseRedirectArgs(
+  deploymentNameOrOptions?: string | LoginOptions,
+  options?: LoginOptions,
+): { deploymentName?: string; options?: LoginOptions } {
+  if (typeof deploymentNameOrOptions === 'string') {
+    return { deploymentName: deploymentNameOrOptions, options };
+  }
+  return { options: deploymentNameOrOptions };
+}
+
 export type { ClientAuthResult, LoginOptions } from '@goldstack/template-user-management';
 export {
   generateTestAccessToken,
@@ -63,15 +73,7 @@ export async function loginWithRedirect(
   deploymentNameOrOptions?: string | LoginOptions,
   options?: LoginOptions,
 ) {
-  let deploymentName: string | undefined;
-  let opts: LoginOptions | undefined;
-
-  if (typeof deploymentNameOrOptions === 'string') {
-    deploymentName = deploymentNameOrOptions;
-    opts = options;
-  } else {
-    opts = deploymentNameOrOptions;
-  }
+  const { deploymentName, options: opts } = parseRedirectArgs(deploymentNameOrOptions, options);
 
   return templateLoginWithRedirect({
     goldstackConfig,
@@ -114,15 +116,7 @@ export async function signUpWithRedirect(
   deploymentNameOrOptions?: string | LoginOptions,
   options?: LoginOptions,
 ) {
-  let deploymentName: string | undefined;
-  let opts: LoginOptions | undefined;
-
-  if (typeof deploymentNameOrOptions === 'string') {
-    deploymentName = deploymentNameOrOptions;
-    opts = options;
-  } else {
-    opts = deploymentNameOrOptions;
-  }
+  const { deploymentName, options: opts } = parseRedirectArgs(deploymentNameOrOptions, options);
 
   return templateSignUpWithRedirect({
     goldstackConfig,

--- a/workspaces/templates/packages/user-management/src/users.ts
+++ b/workspaces/templates/packages/user-management/src/users.ts
@@ -3,6 +3,7 @@ import {
   type Endpoint,
   type GetCookieSettingsResult,
   isValidState,
+  type LoginOptions,
   connectWithCognito as templateConnect,
   getCookieSettings as templateGetCookieSettings,
   getEndpoint as templateGetEndpoint,
@@ -16,7 +17,7 @@ import goldstackConfig from './../goldstack.json';
 import packageSchema from './../schemas/package.schema.json';
 import deploymentsOutput from './state/deployments.json';
 
-export type { ClientAuthResult } from '@goldstack/template-user-management';
+export type { ClientAuthResult, LoginOptions } from '@goldstack/template-user-management';
 export {
   generateTestAccessToken,
   generateTestIdToken,
@@ -34,42 +35,102 @@ export {
 /**
  * Initiates the login process by redirecting the user to the Cognito hosted UI.
  *
- * @param deploymentName - Optional name of the deployment to use. If not provided,
- *                         uses the deployment specified in environment variables.
- * @param state - Optional state parameter to preserve through the authentication flow.
- *                Must be a relative path starting with '/' (e.g., '/app/automation/xxx').
- *                After authentication, the user will be redirected to this path instead of the callback URL.
- *                Used for preserving deep links when users need to authenticate before accessing protected routes.
- * @returns A promise that resolves when the redirect is initiated.
+ * By default, the current URL (pathname + search + hash) is automatically preserved
+ * and the user will be redirected back after authentication.
+ *
+ * @param deploymentNameOrOptions - Either:
+ *   - A string specifying the deployment name
+ *   - A LoginOptions object with targetUrl or doNotPreservePath
+ * @param options - Options if first parameter is deployment name string
+ *
+ * @example
+ * // Auto-preserve current URL
+ * await loginWithRedirect();
+ *
+ * // Specify deployment
+ * await loginWithRedirect('prod');
+ *
+ * // Redirect to specific URL after auth
+ * await loginWithRedirect({ targetUrl: '/dashboard' });
+ *
+ * // Skip path preservation, use callback URL
+ * await loginWithRedirect({ doNotPreservePath: true });
+ *
+ * // Specify deployment and options
+ * await loginWithRedirect('prod', { targetUrl: '/dashboard' });
  */
-export async function loginWithRedirect(deploymentName?: string, state?: string) {
+export async function loginWithRedirect(
+  deploymentNameOrOptions?: string | LoginOptions,
+  options?: LoginOptions,
+) {
+  let deploymentName: string | undefined;
+  let opts: LoginOptions | undefined;
+
+  if (typeof deploymentNameOrOptions === 'string') {
+    deploymentName = deploymentNameOrOptions;
+    opts = options;
+  } else {
+    opts = deploymentNameOrOptions;
+  }
+
   return templateLoginWithRedirect({
     goldstackConfig,
     packageSchema,
     deploymentsOutput,
     deploymentName,
-    state,
+    options: opts,
+    operation: 'authorize',
   });
 }
 
 /**
  * Initiates the sign-up process by redirecting the user to the Cognito hosted UI.
  *
- * @param deploymentName - Optional name of the deployment to use. If not provided,
- *                         uses the deployment specified in environment variables.
- * @param state - Optional state parameter to preserve through the authentication flow.
- *                Must be a relative path starting with '/' (e.g., '/app/automation/xxx').
- *                After authentication, the user will be redirected to this path instead of the callback URL.
- *                Used for preserving deep links when users need to authenticate before accessing protected routes.
- * @returns A promise that resolves when the redirect is initiated.
+ * By default, the current URL (pathname + search + hash) is automatically preserved
+ * and the user will be redirected back after authentication.
+ *
+ * @param deploymentNameOrOptions - Either:
+ *   - A string specifying the deployment name
+ *   - A LoginOptions object with targetUrl or doNotPreservePath
+ * @param options - Options if first parameter is deployment name string
+ *
+ * @example
+ * // Auto-preserve current URL
+ * await signUpWithRedirect();
+ *
+ * // Specify deployment
+ * await signUpWithRedirect('prod');
+ *
+ * // Redirect to specific URL after auth
+ * await signUpWithRedirect({ targetUrl: '/dashboard' });
+ *
+ * // Skip path preservation, use callback URL
+ * await signUpWithRedirect({ doNotPreservePath: true });
+ *
+ * // Specify deployment and options
+ * await signUpWithRedirect('prod', { targetUrl: '/dashboard' });
  */
-export async function signUpWithRedirect(deploymentName?: string, state?: string) {
+export async function signUpWithRedirect(
+  deploymentNameOrOptions?: string | LoginOptions,
+  options?: LoginOptions,
+) {
+  let deploymentName: string | undefined;
+  let opts: LoginOptions | undefined;
+
+  if (typeof deploymentNameOrOptions === 'string') {
+    deploymentName = deploymentNameOrOptions;
+    opts = options;
+  } else {
+    opts = deploymentNameOrOptions;
+  }
+
   return templateSignUpWithRedirect({
     goldstackConfig,
     packageSchema,
     deploymentsOutput,
     deploymentName,
-    state,
+    options: opts,
+    operation: 'signup',
   });
 }
 
@@ -78,7 +139,8 @@ export async function signUpWithRedirect(deploymentName?: string, state?: string
  * This function should be called on the page that Cognito redirects to after login/signup.
  *
  * Note: In browser environments, this function performs a page redirect and never returns
- * to the caller. The user will be navigated to the state path (if valid) or the callback URL.
+ * to the caller. The user will be navigated to the original URL (auto-preserved) or
+ * the callback URL if doNotPreservePath was specified.
  * The return value is only relevant for Jest test environments.
  *
  * @param deploymentName - Optional name of the deployment to use. If not provided,
@@ -131,22 +193,15 @@ export async function connectWithCognito(deploymentName?: string): Promise<Cogni
  * @param endpoint - The type of endpoint to retrieve (e.g., 'authorize', 'token', 'logout').
  * @param deploymentName - Optional name of the deployment to use. If not provided,
  *                         uses the deployment specified in environment variables.
- * @param state - Optional state parameter to include in the authorization URL.
- *                Must be a relative path starting with '/' (e.g., '/app/automation/xxx').
  * @returns A promise that resolves with the endpoint URL string.
  */
-export async function getEndpoint(
-  endpoint: Endpoint,
-  deploymentName?: string,
-  state?: string,
-): Promise<string> {
+export async function getEndpoint(endpoint: Endpoint, deploymentName?: string): Promise<string> {
   return templateGetEndpoint({
     endpoint,
     goldstackConfig,
     packageSchema,
     deploymentsOutput,
     deploymentName,
-    state,
   });
 }
 

--- a/workspaces/templates/packages/user-management/src/users.ts
+++ b/workspaces/templates/packages/user-management/src/users.ts
@@ -2,6 +2,7 @@ import {
   type CognitoManager,
   type Endpoint,
   type GetCookieSettingsResult,
+  isValidState,
   connectWithCognito as templateConnect,
   getCookieSettings as templateGetCookieSettings,
   getEndpoint as templateGetEndpoint,
@@ -24,6 +25,7 @@ export {
   getMockedUserAccessToken,
   getMockedUserIdToken,
   isAuthenticated,
+  isValidState,
   setLocalUserManager,
   setMockedUserAccessToken,
   setMockedUserIdToken,
@@ -34,14 +36,19 @@ export {
  *
  * @param deploymentName - Optional name of the deployment to use. If not provided,
  *                         uses the deployment specified in environment variables.
+ * @param state - Optional state parameter to preserve through the authentication flow.
+ *                Must be a relative path starting with '/' (e.g., '/app/automation/xxx').
+ *                After authentication, the user will be redirected to this path instead of the callback URL.
+ *                Used for preserving deep links when users need to authenticate before accessing protected routes.
  * @returns A promise that resolves when the redirect is initiated.
  */
-export async function loginWithRedirect(deploymentName?: string) {
+export async function loginWithRedirect(deploymentName?: string, state?: string) {
   return templateLoginWithRedirect({
     goldstackConfig,
     packageSchema,
     deploymentsOutput,
     deploymentName,
+    state,
   });
 }
 
@@ -50,14 +57,19 @@ export async function loginWithRedirect(deploymentName?: string) {
  *
  * @param deploymentName - Optional name of the deployment to use. If not provided,
  *                         uses the deployment specified in environment variables.
+ * @param state - Optional state parameter to preserve through the authentication flow.
+ *                Must be a relative path starting with '/' (e.g., '/app/automation/xxx').
+ *                After authentication, the user will be redirected to this path instead of the callback URL.
+ *                Used for preserving deep links when users need to authenticate before accessing protected routes.
  * @returns A promise that resolves when the redirect is initiated.
  */
-export async function signUpWithRedirect(deploymentName?: string) {
+export async function signUpWithRedirect(deploymentName?: string, state?: string) {
   return templateSignUpWithRedirect({
     goldstackConfig,
     packageSchema,
     deploymentsOutput,
     deploymentName,
+    state,
   });
 }
 
@@ -67,7 +79,7 @@ export async function signUpWithRedirect(deploymentName?: string) {
  *
  * @param deploymentName - Optional name of the deployment to use. If not provided,
  *                         uses the deployment specified in environment variables.
- * @returns A promise that resolves with the authentication result.
+ * @returns A promise that resolves with the authentication result, including the state parameter if present.
  */
 export async function handleRedirectCallback(deploymentName?: string) {
   return templateHandleRedirectCallback({
@@ -116,15 +128,22 @@ export async function connectWithCognito(deploymentName?: string): Promise<Cogni
  * @param endpoint - The type of endpoint to retrieve (e.g., 'authorize', 'token', 'logout').
  * @param deploymentName - Optional name of the deployment to use. If not provided,
  *                         uses the deployment specified in environment variables.
+ * @param state - Optional state parameter to include in the authorization URL.
+ *                Must be a relative path starting with '/' (e.g., '/app/automation/xxx').
  * @returns A promise that resolves with the endpoint URL string.
  */
-export async function getEndpoint(endpoint: Endpoint, deploymentName?: string): Promise<string> {
+export async function getEndpoint(
+  endpoint: Endpoint,
+  deploymentName?: string,
+  state?: string,
+): Promise<string> {
   return templateGetEndpoint({
     endpoint,
     goldstackConfig,
     packageSchema,
     deploymentsOutput,
     deploymentName,
+    state,
   });
 }
 


### PR DESCRIPTION
## Summary

Add OAuth 2.0 `state` parameter support to `loginWithRedirect` and `signUpWithRedirect` functions. This enables preservation of deep links when users need to authenticate before accessing protected routes.

## Changes

- Add `state` parameter to `loginWithRedirect`, `signUpWithRedirect`, and `getEndpoint` functions
- Extract and validate state from Cognito callback, redirecting to state path if valid
- Add `isValidState()` utility to prevent open redirect vulnerabilities
- Include `state` in `ClientAuthResult` return type
- Export `isValidState` function for consumer validation
- Update documentation with usage examples
- Add unit tests for `isValidState` validation

## Usage

```typescript
// Before redirecting to Cognito
const currentPath = window.location.pathname + window.location.search;
await loginWithRedirect(undefined, currentPath);

// After Cognito callback, handleRedirectCallback extracts state and redirects
const result = await handleRedirectCallback();
// result.state contains the preserved path
```

## Security

- State values are validated to be relative paths starting with `/`
- Invalid state values log a warning and redirect to callback URL instead
- Prevents open redirect vulnerabilities by rejecting `//` and `://` patterns