### PR TITLE
Upgrade hetzner-vps to Docker Compose V2

### DIFF
--- a/workspaces/templates/packages/hetzner-vps/infra/aws/cloud-init.yml
+++ b/workspaces/templates/packages/hetzner-vps/infra/aws/cloud-init.yml
@@ -14,7 +14,6 @@ packages:
   - jq
   - unzip
   - docker.io
-  - docker-compose
 
 write_files:
   - path: /home/goldstack/deploy.sh

--- a/workspaces/templates/packages/hetzner-vps/server/start.sh
+++ b/workspaces/templates/packages/hetzner-vps/server/start.sh
@@ -14,7 +14,7 @@ source "$APP_DIR/load-secrets.sh"
 echo "Starting server in ${ENVIRONMENT:-development} mode"
 
 
-cd "$APP_DIR" && COMPOSE_PROJECT_NAME=server docker-compose up -d
+cd "$APP_DIR" && COMPOSE_PROJECT_NAME=server docker compose up -d
 
 
 # Clean up images

--- a/workspaces/templates/packages/hetzner-vps/server/stop.sh
+++ b/workspaces/templates/packages/hetzner-vps/server/stop.sh
@@ -9,4 +9,4 @@ fi
 chmod +x "$APP_DIR/load-secrets.sh"
 source "$APP_DIR/load-secrets.sh"
 
-COMPOSE_PROJECT_NAME=server docker-compose down
+COMPOSE_PROJECT_NAME=server docker compose down


### PR DESCRIPTION
## Summary
- Replace `docker-compose` (standalone) with `docker compose` (Compose V2 plugin) in shell scripts
- Remove `docker-compose` package from cloud-init since Docker Compose V2 is built into Docker