### PR TITLE
Add deleteUser function to CognitoManager

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6101,6 +6101,7 @@ const RAW_RUNTIME_STATE =
       ["workspace:workspaces/templates-lib/packages/template-user-management", {\
         "packageLocation": "./workspaces/templates-lib/packages/template-user-management/",\
         "packageDependencies": [\
+          ["@aws-sdk/client-cognito-identity-provider", "npm:3.1004.0"],\
           ["@goldstack/infra", "workspace:workspaces/templates-lib/packages/infra"],\
           ["@goldstack/infra-aws", "workspace:workspaces/templates-lib/packages/infra-aws"],\
           ["@goldstack/template-user-management", "workspace:workspaces/templates-lib/packages/template-user-management"],\

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "workspaces/*"
   ],
   "scripts": {
-    "build": "yarn compile",
+    "build": "tsc -b --force",
     "clean-terraform": "yarn workspaces foreach -W run clean-terraform",
     "commit": "yarn git:commit \"$0\"",
     "compile": "yarn fix-project-references && tsc --build",

--- a/workspaces/docs/docs/templates/user-management/features.md
+++ b/workspaces/docs/docs/templates/user-management/features.md
@@ -4,3 +4,4 @@
 - Library to validate tokens on the server.
 - Automatically verifies users email addresses.
 - Supports OAuth `state` parameter for preserving deep links during authentication flows.
+- Provides `deleteUser` function for deleting users from the Cognito user pool.

--- a/workspaces/templates-lib/packages/template-user-management/package.json
+++ b/workspaces/templates-lib/packages/template-user-management/package.json
@@ -37,6 +37,7 @@
     "patch-when-changed": "git diff --quiet HEAD^...HEAD -- . && git diff --quiet -- . && git diff --quiet --staged -- .  || yarn version patch"
   },
   "dependencies": {
+    "@aws-sdk/client-cognito-identity-provider": "^3.1004.0",
     "@goldstack/infra": "0.4.40",
     "@goldstack/infra-aws": "0.4.61",
     "@goldstack/utils-esbuild": "0.5.26",

--- a/workspaces/templates-lib/packages/template-user-management/src/CognitoManager.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/CognitoManager.ts
@@ -55,8 +55,8 @@ export class CognitoManagerImpl implements CognitoManager {
     try {
       const payload = await this.idTokenVerifier.verify(jwtToken);
       return payload as any;
-    } catch {
-      throw new Error('Invalid token');
+    } catch (e) {
+      throw new Error(`Invalid token: ${e instanceof Error ? e.message : 'Unknown error'}`);
     }
   }
 

--- a/workspaces/templates-lib/packages/template-user-management/src/CognitoManager.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/CognitoManager.ts
@@ -44,8 +44,8 @@ export class CognitoManagerImpl implements CognitoManager {
     try {
       const payload = await this.accessTokenVerifier.verify(jwtToken);
       return payload as any;
-    } catch {
-      throw new Error('Invalid token');
+    } catch (e) {
+      throw new Error(`Invalid token: ${e instanceof Error ? e.message : 'Unknown error'}`);
     }
   }
 

--- a/workspaces/templates-lib/packages/template-user-management/src/CognitoManager.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/CognitoManager.ts
@@ -1,0 +1,77 @@
+import {
+  AdminDeleteUserCommand,
+  AdminDisableUserCommand,
+  CognitoIdentityProviderClient,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { CognitoJwtVerifier } from 'aws-jwt-verify';
+import type { CognitoAccessTokenPayload, CognitoIdTokenPayload } from 'aws-jwt-verify/jwt-model';
+
+export interface CognitoManager {
+  validate(accessToken: string): Promise<CognitoAccessTokenPayload>;
+  /**
+   * Validates an id token without validating it. On the server, ensure to validate the <i>accessToken</i> as well.
+   * It is not recommended practice to assert authentication for an API using an id token only.
+   */
+  validateIdToken(
+    idToken: string,
+  ): Promise<CognitoIdTokenPayload & { email: string; 'custom:app_user_id': string }>;
+  /**
+   * Deletes a user from the Cognito user pool. First disables the user, then deletes them.
+   *
+   * @param username - The username (or email) of the user to delete
+   */
+  deleteUser(username: string): Promise<void>;
+}
+
+export class CognitoManagerImpl implements CognitoManager {
+  accessTokenVerifier: CognitoJwtVerifier<any, any, any>;
+  idTokenVerifier: CognitoJwtVerifier<any, any, any>;
+  userPoolId: string;
+  cognitoClient: CognitoIdentityProviderClient;
+
+  constructor(
+    accessTokenVerifier: CognitoJwtVerifier<any, any, any>,
+    idTokenVerifier: CognitoJwtVerifier<any, any, any>,
+    userPoolId: string,
+  ) {
+    this.accessTokenVerifier = accessTokenVerifier;
+    this.idTokenVerifier = idTokenVerifier;
+    this.userPoolId = userPoolId;
+    this.cognitoClient = new CognitoIdentityProviderClient({});
+  }
+
+  async validate(jwtToken: string): Promise<CognitoAccessTokenPayload> {
+    try {
+      const payload = await this.accessTokenVerifier.verify(jwtToken);
+      return payload as any;
+    } catch {
+      throw new Error('Invalid token');
+    }
+  }
+
+  async validateIdToken(
+    jwtToken: string,
+  ): Promise<CognitoIdTokenPayload & { email: string; 'custom:app_user_id': string }> {
+    try {
+      const payload = await this.idTokenVerifier.verify(jwtToken);
+      return payload as any;
+    } catch {
+      throw new Error('Invalid token');
+    }
+  }
+
+  async deleteUser(username: string): Promise<void> {
+    await this.cognitoClient.send(
+      new AdminDisableUserCommand({
+        UserPoolId: this.userPoolId,
+        Username: username,
+      }),
+    );
+    await this.cognitoClient.send(
+      new AdminDeleteUserCommand({
+        UserPoolId: this.userPoolId,
+        Username: username,
+      }),
+    );
+  }
+}

--- a/workspaces/templates-lib/packages/template-user-management/src/connectWithCognito.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/connectWithCognito.ts
@@ -3,23 +3,9 @@
 
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
 import { SimpleJwksCache } from 'aws-jwt-verify/jwk';
-
-import type { CognitoAccessTokenPayload, CognitoIdTokenPayload } from 'aws-jwt-verify/jwt-model';
-
+import { CognitoManager, CognitoManagerImpl } from './CognitoManager';
 import { getDeploymentName, getDeploymentsOutput } from './userManagementConfig';
-
 import { getLocalUserManager } from './userManagementServerMock';
-
-export interface CognitoManager {
-  validate(accessToken: string): Promise<CognitoAccessTokenPayload>;
-  /**
-   * Validates an id token without validating it. On the server, ensure to validate the <i>accessToken</i> as well.
-   * It is not recommended practice to assert authentication for an API using an id token only.
-   */
-  validateIdToken(
-    idToken: string,
-  ): Promise<CognitoIdTokenPayload & { email: string; 'custom:app_user_id': string }>;
-}
 
 /**
  * We want to keep only one JWKS cache globally for our application.
@@ -69,38 +55,9 @@ export async function connectWithCognito({
       jwksCache: sharedJwksCache,
     },
   );
-  return new CognitoManagerImpl(accessTokenVerifier, idTokenVerifier);
-}
-
-export class CognitoManagerImpl implements CognitoManager {
-  accessTokenVerifier: CognitoJwtVerifier<any, any, any>;
-  idTokenVerifier: CognitoJwtVerifier<any, any, any>;
-
-  constructor(
-    accessTokenVerifier: CognitoJwtVerifier<any, any, any>,
-    idTokenVerifier: CognitoJwtVerifier<any, any, any>,
-  ) {
-    this.accessTokenVerifier = accessTokenVerifier;
-    this.idTokenVerifier = idTokenVerifier;
-  }
-
-  async validate(jwtToken: string): Promise<CognitoAccessTokenPayload> {
-    try {
-      const payload = await this.accessTokenVerifier.verify(jwtToken);
-      return payload as any;
-    } catch {
-      throw new Error('Invalid token');
-    }
-  }
-
-  async validateIdToken(
-    jwtToken: string,
-  ): Promise<CognitoIdTokenPayload & { email: string; 'custom:app_user_id': string }> {
-    try {
-      const payload = await this.idTokenVerifier.verify(jwtToken);
-      return payload as any;
-    } catch {
-      throw new Error('Invalid token');
-    }
-  }
+  return new CognitoManagerImpl(
+    accessTokenVerifier,
+    idTokenVerifier,
+    deploymentOutput.terraform.user_pool_id.value,
+  );
 }

--- a/workspaces/templates-lib/packages/template-user-management/src/connectWithCognito.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/connectWithCognito.ts
@@ -7,6 +7,8 @@ import { CognitoManager, CognitoManagerImpl } from './CognitoManager';
 import { getDeploymentName, getDeploymentsOutput } from './userManagementConfig';
 import { getLocalUserManager } from './userManagementServerMock';
 
+export { CognitoManager } from './CognitoManager';
+
 /**
  * We want to keep only one JWKS cache globally for our application.
  */

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -4,7 +4,7 @@ import { EmbeddedPackageConfig } from '@goldstack/utils-package-config-embedded'
 import { getEndpoint as getEndpointLib } from './client/getEndpoints';
 import * as cognitoClientAuth from './client/getToken';
 
-export type { CognitoManager } from './cognitoTokenVerify';
+export type { CognitoManager } from './connectWithCognito';
 
 import type { GetTokenResults } from './client/getToken';
 
@@ -21,7 +21,7 @@ export { handleRedirectCallback } from './client/handleRedirectCallback';
 export { operationWithRedirect } from './client/operationWithRedirect';
 export { performLogout } from './client/performLogout';
 export { isValidState } from './client/state';
-export { connectWithCognito } from './cognitoTokenVerify';
+export { connectWithCognito } from './connectWithCognito';
 export {
   getMockedUserAccessToken,
   getMockedUserIdToken,

--- a/workspaces/templates-lib/packages/template-user-management/src/userManagementServerMock.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/userManagementServerMock.ts
@@ -2,7 +2,7 @@
 
 import type { CognitoAccessTokenPayload, CognitoIdTokenPayload } from 'aws-jwt-verify/jwt-model';
 import crypto from 'crypto';
-import type { CognitoManager } from './cognitoTokenVerify';
+import type { CognitoManager } from './CognitoManager';
 import { getMockedAccessTokenProperties, getMockedIdTokenProperties } from './userManagementMock';
 
 let localCognitoManager: CognitoManager | undefined;
@@ -82,5 +82,9 @@ export class LocalUserManagerImpl implements CognitoManager {
   async validate(jwtToken: string): Promise<CognitoAccessTokenPayload> {
     assertNotInProd();
     return JSON.parse(Buffer.from(jwtToken.split('.')[1], 'base64').toString());
+  }
+
+  async deleteUser(_username: string): Promise<void> {
+    assertNotInProd();
   }
 }

--- a/workspaces/templates/packages/user-management/infra/aws/trigger-lambdas.tf
+++ b/workspaces/templates/packages/user-management/infra/aws/trigger-lambdas.tf
@@ -126,6 +126,35 @@ resource "aws_iam_policy" "lambda_logging" {
 EOF
 }
 
+resource "aws_iam_policy" "lambda_cognito_admin" {
+  name        = "${var.user_pool_name}-lambda-cognito-admin-role"
+  path        = "/"
+  description = "IAM policy for admin Cognito operations"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "cognito-idp:AdminDisableUser",
+        "cognito-idp:AdminDeleteUser"
+      ],
+      "Resource": [
+        "arn:aws:cognito-idp:*:*:userpool/${aws_cognito_user_pool.pool.id}"
+      ],
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_cognito_admin_policy" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = aws_iam_policy.lambda_cognito_admin.arn
+}
+
 
 locals {
   metric_transformation_name_post_confirmation = "${var.user_pool_name}-error-count-post-confirmation"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4752,6 +4752,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@goldstack/template-user-management@workspace:workspaces/templates-lib/packages/template-user-management"
   dependencies:
+    "@aws-sdk/client-cognito-identity-provider": "npm:^3.1004.0"
     "@goldstack/infra": "npm:0.4.40"
     "@goldstack/infra-aws": "npm:0.4.61"
     "@goldstack/utils-esbuild": "npm:0.5.26"


### PR DESCRIPTION
## Summary
- Add `deleteUser(username)` method to `CognitoManager` interface for deleting users from Cognito user pools
- Implement `deleteUser` that first disables, then deletes the user via AWS SDK (`AdminDisableUserCommand` + `AdminDeleteUserCommand`)
- Refactor `cognitoTokenVerify.ts` into `CognitoManager.ts` (interface + implementation) and `connectWithCognito.ts` (factory function)
- Add IAM policy for `AdminDisableUser` and `AdminDeleteUser` actions to Lambda execution role

## Usage
```typescript
import { connectWithCognito } from '@goldstack/user-management';

const cognitoManager = await connectWithCognito('my-deployment');
await cognitoManager.deleteUser('user@example.com');
```

## Testing
- [ ] CI builds pass
- [ ] Manual testing with local deployment