### PR TITLE
Add deleteCognitoUser function for deleting users

### DIFF
--- a/workspaces/docs/docs/templates/user-management/getting-started.md
+++ b/workspaces/docs/docs/templates/user-management/getting-started.md
@@ -162,6 +162,28 @@ export const handler: SSRHandler = async (event, context) => {
 };
 ```
 
+#### Deleting Users
+
+To delete a user from the Cognito user pool, use the `deleteCognitoUser` function:
+
+```typescript
+import { connectWithCognito, deleteCognitoUser, CognitoManager } from 'user-management';
+
+export const handler: SSRHandler = async (event, context) => {
+  const cookies = getCookies((event.cookies || []).join(';'));
+  if (cookies.goldstack_access_token) {
+    const cognito: CognitoManager = await connectWithCognito();
+    await cognito.validate(cookies.goldstack_access_token);
+
+    // Delete a user
+    await deleteCognitoUser({
+      cognitoManager: cognito,
+      username: 'user-to-delete@example.com',
+    });
+  }
+};
+```
+
 Note that it is recommended we [always](https://auth0.com/blog/id-token-access-token-what-is-the-difference/) validate the _access token_. We validate the _id token_ in the above as well to determine the user's email address, since the access token only contains the _username_, which in our case is a cognito generated id.
 
 This template is not designed to support authorization. If you have authorization needs, consider implementing this with [DynamoDB](https://build.diligent.com/fast-authorization-with-dynamodb-cd1f133437e3) using the [DynamoDB template](https://goldstack.party/templates/dynamodb).

--- a/workspaces/docs/docs/templates/user-management/getting-started.md
+++ b/workspaces/docs/docs/templates/user-management/getting-started.md
@@ -176,9 +176,10 @@ export const handler: SSRHandler = async (event, context) => {
     await cognito.validate(cookies.goldstack_access_token);
 
     // Delete a user
+    // IMPORTANT: Ensure the authenticated user has permission to perform this action
     await deleteCognitoUser({
       cognitoManager: cognito,
-      username: 'user-to-delete@example.com',
+      username: 'user-to-delete@example.com', // Replace with dynamic username
     });
   }
 };

--- a/workspaces/templates-lib/packages/template-user-management/src/deleteCognitoUser.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/deleteCognitoUser.ts
@@ -1,0 +1,23 @@
+/* esbuild-ignore ui */
+
+import type { CognitoManager } from './connectWithCognito';
+
+export interface DeleteCognitoUserParams {
+  /**
+   * An authenticated CognitoManager instance, obtained from connectWithCognito()
+   */
+  cognitoManager: CognitoManager;
+  /**
+   * The username (or email) of the user to delete
+   */
+  username: string;
+}
+
+/**
+ * Deletes a user from the Cognito user pool. First disables the user, then deletes them.
+ *
+ * @param params - Object containing the CognitoManager and username
+ */
+export async function deleteCognitoUser(params: DeleteCognitoUserParams): Promise<void> {
+  await params.cognitoManager.deleteUser(params.username);
+}

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -22,6 +22,8 @@ export { operationWithRedirect } from './client/operationWithRedirect';
 export { performLogout } from './client/performLogout';
 export { isValidState } from './client/state';
 export { connectWithCognito } from './connectWithCognito';
+export type { DeleteCognitoUserParams } from './deleteCognitoUser';
+export { deleteCognitoUser } from './deleteCognitoUser';
 export {
   getMockedUserAccessToken,
   getMockedUserIdToken,
@@ -37,7 +39,6 @@ export {
 
 import type UserManagementPackage from './types/UserManagementPackage';
 import type { UserManagementDeployment } from './types/UserManagementPackage';
-import { getDeploymentName } from './userManagementConfig';
 
 export type Endpoint =
   | 'authorize' // https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html

--- a/workspaces/templates/packages/user-management/src/users.ts
+++ b/workspaces/templates/packages/user-management/src/users.ts
@@ -1,11 +1,13 @@
 import {
   type ClientAuthResult,
   type CognitoManager,
+  type DeleteCognitoUserParams,
   type Endpoint,
   type GetCookieSettingsResult,
   isValidState,
   type LoginOptions,
   connectWithCognito as templateConnect,
+  deleteCognitoUser as templateDeleteCognitoUser,
   getCookieSettings as templateGetCookieSettings,
   getEndpoint as templateGetEndpoint,
   handleRedirectCallback as templateHandleRedirectCallback,
@@ -28,7 +30,11 @@ function parseRedirectArgs(
   return { options: deploymentNameOrOptions };
 }
 
-export type { ClientAuthResult, LoginOptions } from '@goldstack/template-user-management';
+export type {
+  ClientAuthResult,
+  DeleteCognitoUserParams,
+  LoginOptions,
+} from '@goldstack/template-user-management';
 export {
   generateTestAccessToken,
   generateTestIdToken,
@@ -178,6 +184,15 @@ export async function connectWithCognito(deploymentName?: string): Promise<Cogni
     deploymentsOutput,
     deploymentName,
   });
+}
+
+/**
+ * Deletes a user from the Cognito user pool. First disables the user, then deletes them.
+ *
+ * @param params - Object containing the CognitoManager and username
+ */
+export async function deleteCognitoUser(params: DeleteCognitoUserParams): Promise<void> {
+  return templateDeleteCognitoUser(params);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `deleteCognitoUser` function to user-management template
- Function disables and then deletes a user from Cognito user pool
- Includes documentation for deleting users in getting-started guide

## Changes
- New `deleteCognitoUser.ts` in template-user-management
- Export `DeleteCognitoUserParams` type and `deleteCognitoUser` function
- Update users.ts wrapper to expose the new function
- Add getting-started documentation for deleting users