### PR TITLE
[Next.js Templates]: Enable versioning and lifecycle rules for static website S3 buckets

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6601,6 +6601,7 @@ const RAW_RUNTIME_STATE =
           ["@goldstack/infra", "workspace:workspaces/templates-lib/packages/infra"],\
           ["@goldstack/infra-aws", "workspace:workspaces/templates-lib/packages/infra-aws"],\
           ["@goldstack/template-static-website-aws", "workspace:workspaces/templates-lib/packages/template-static-website-aws"],\
+          ["@goldstack/utils-aws-cli", "workspace:workspaces/templates-lib/packages/utils-aws-cli"],\
           ["@goldstack/utils-cli", "workspace:workspaces/utils/packages/utils-cli"],\
           ["@goldstack/utils-config", "workspace:workspaces/templates-lib/packages/utils-config"],\
           ["@goldstack/utils-log", "workspace:workspaces/utils/packages/utils-log"],\

--- a/workspaces/apps/packages/goldstack-home/infra/aws/main.tf
+++ b/workspaces/apps/packages/goldstack-home/infra/aws/main.tf
@@ -41,7 +41,7 @@ resource "aws_route53_record" "wildcard_validation" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-   # Skips the domain if it doesn't contain a wildcard
+    # Skips the domain if it doesn't contain a wildcard
     if length(regexall("\\*\\..+", dvo.domain_name)) > 0
   }
 
@@ -57,7 +57,7 @@ resource "aws_route53_record" "wildcard_validation" {
 # Required to force ACM wildcard certificate validation
 # see https://kopi.cloud/blog/2021/terraform-aws_acm_certificate-wildcards/
 resource "aws_acm_certificate_validation" "wildcard_cert" {
-  provider = aws.us-east-1
+  provider        = aws.us-east-1
   certificate_arn = aws_acm_certificate.wildcard_website.arn
 
   validation_record_fqdns = concat(
@@ -87,6 +87,6 @@ data "aws_acm_certificate" "wildcard_website" {
 
 # Id used for unique resource names
 resource "random_id" "id" {
-	  byte_length = 8
+  byte_length = 8
 }
 

--- a/workspaces/apps/packages/goldstack-home/infra/aws/output.tf
+++ b/workspaces/apps/packages/goldstack-home/infra/aws/output.tf
@@ -5,5 +5,5 @@ output "website_cdn_root_id" {
 
 output "edge_function_name" {
   description = "Lambda@Edge name for routing"
-  value       = aws_lambda_function.edge.function_name 
+  value       = aws_lambda_function.edge.function_name
 }

--- a/workspaces/apps/packages/goldstack-home/infra/aws/redirect.tf
+++ b/workspaces/apps/packages/goldstack-home/infra/aws/redirect.tf
@@ -155,18 +155,14 @@ resource "aws_route53_record" "website_cdn_redirect_record" {
   }
 }
 resource "aws_s3_bucket_versioning" "website_redirect" {
-  count = var.website_domain_redirect != null ? 1 : 0
-
-  bucket = aws_s3_bucket.website_redirect[0].id
+  bucket = aws_s3_bucket.website_redirect.id
   versioning_configuration {
     status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "website_redirect" {
-  count = var.website_domain_redirect != null ? 1 : 0
-
-  bucket = aws_s3_bucket.website_redirect[0].id
+  bucket = aws_s3_bucket.website_redirect.id
 
   rule {
     id     = "delete-noncurrent-versions"

--- a/workspaces/apps/packages/goldstack-home/infra/aws/redirect.tf
+++ b/workspaces/apps/packages/goldstack-home/infra/aws/redirect.tf
@@ -154,3 +154,27 @@ resource "aws_route53_record" "website_cdn_redirect_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/apps/packages/goldstack-home/infra/aws/root.tf
+++ b/workspaces/apps/packages/goldstack-home/infra/aws/root.tf
@@ -246,3 +246,23 @@ resource "aws_route53_record" "website_cdn_root_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/apps/packages/goldstack-home/infra/aws/root.tf
+++ b/workspaces/apps/packages/goldstack-home/infra/aws/root.tf
@@ -116,7 +116,7 @@ resource "aws_cloudfront_distribution" "website_cdn_root" {
     target_origin_id = "origin-bucket-${aws_s3_bucket.website_root.id}"
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy.id
-    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
     compress                   = true
     viewer_protocol_policy     = "redirect-to-https"
   }
@@ -129,7 +129,7 @@ resource "aws_cloudfront_distribution" "website_cdn_root" {
     target_origin_id = "origin-bucket-${aws_s3_bucket.website_root.id}"
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy.id
-    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
     compress                   = true
     viewer_protocol_policy     = "redirect-to-https"
   }
@@ -141,7 +141,7 @@ resource "aws_cloudfront_distribution" "website_cdn_root" {
     target_origin_id = "origin-bucket-${aws_s3_bucket.website_root.id}"
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy.id
-    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
     compress                   = true
     viewer_protocol_policy     = "redirect-to-https"
   }
@@ -153,7 +153,7 @@ resource "aws_cloudfront_distribution" "website_cdn_root" {
     target_origin_id = "origin-bucket-${aws_s3_bucket.website_root.id}"
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy.id
-    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
     compress                   = true
     viewer_protocol_policy     = "redirect-to-https"
   }

--- a/workspaces/apps/packages/goldstack-home/infra/aws/security.tf
+++ b/workspaces/apps/packages/goldstack-home/infra/aws/security.tf
@@ -1,4 +1,4 @@
- resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
+resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
   name = "security-headers-policy-${random_id.id.hex}"
   security_headers_config {
     content_type_options {
@@ -6,27 +6,27 @@
     }
     frame_options {
       frame_option = "DENY"
-      override = true
+      override     = true
     }
     referrer_policy {
       referrer_policy = "same-origin"
-      override = true
+      override        = true
     }
     xss_protection {
       mode_block = true
       protection = true
-      override = true
+      override   = true
     }
     strict_transport_security {
       access_control_max_age_sec = "63072000"
-      include_subdomains = true
-      preload = true
-      override = true
+      include_subdomains         = true
+      preload                    = true
+      override                   = true
     }
 
     content_security_policy {
       content_security_policy = "frame-ancestors 'none'; default-src https: data: 'unsafe-eval' 'unsafe-inline' 'self'; object-src 'none'"
-      override = true
+      override                = true
     }
   }
 }

--- a/workspaces/apps/packages/goldstack-home/infra/aws/variables.tf
+++ b/workspaces/apps/packages/goldstack-home/infra/aws/variables.tf
@@ -1,24 +1,24 @@
 variable "aws_region" {
   description = "Region where S3 buckets are deployed."
-  type = string
+  type        = string
 }
 
 variable "hosted_zone_domain" {
   description = "Domain of the Route 53 hosted zone this website domain should be added to"
-  type = string
+  type        = string
 }
 
 variable "website_domain" {
   description = "Main website domain, e.g. cloudmaniac.net"
-  type = string
+  type        = string
 }
 
 variable "website_domain_redirect" {
   description = "Secondary domain that will redirect to the main domain"
-  type = string
+  type        = string
 }
 
 variable "default_cache_duration" {
   description = "Default duration for which resources will be cached"
-  type = number
+  type        = number
 }

--- a/workspaces/docs/packages/cdn/infra/aws/providers.tf
+++ b/workspaces/docs/packages/cdn/infra/aws/providers.tf
@@ -1,12 +1,12 @@
 provider "aws" {
-  region                  = var.aws_region
-        shared_credentials_files = ["aws_credentials"]  
+  region                   = var.aws_region
+  shared_credentials_files = ["aws_credentials"]
 }
 
 # The provider below is required to handle ACM
 provider "aws" {
-  alias                   = "us-east-1"
-  region                  = "us-east-1"
-          shared_credentials_files = ["aws_credentials"]  
+  alias                    = "us-east-1"
+  region                   = "us-east-1"
+  shared_credentials_files = ["aws_credentials"]
 }
 

--- a/workspaces/docs/packages/cdn/infra/aws/redirect.tf
+++ b/workspaces/docs/packages/cdn/infra/aws/redirect.tf
@@ -155,18 +155,14 @@ resource "aws_route53_record" "website_cdn_redirect_record" {
   }
 }
 resource "aws_s3_bucket_versioning" "website_redirect" {
-  count = var.website_domain_redirect != null ? 1 : 0
-
-  bucket = aws_s3_bucket.website_redirect[0].id
+  bucket = aws_s3_bucket.website_redirect.id
   versioning_configuration {
     status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "website_redirect" {
-  count = var.website_domain_redirect != null ? 1 : 0
-
-  bucket = aws_s3_bucket.website_redirect[0].id
+  bucket = aws_s3_bucket.website_redirect.id
 
   rule {
     id     = "delete-noncurrent-versions"

--- a/workspaces/docs/packages/cdn/infra/aws/redirect.tf
+++ b/workspaces/docs/packages/cdn/infra/aws/redirect.tf
@@ -154,3 +154,27 @@ resource "aws_route53_record" "website_cdn_redirect_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/docs/packages/cdn/infra/aws/root.tf
+++ b/workspaces/docs/packages/cdn/infra/aws/root.tf
@@ -155,3 +155,23 @@ resource "aws_route53_record" "website_cdn_root_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/docs/packages/cdn/infra/aws/variables.tf
+++ b/workspaces/docs/packages/cdn/infra/aws/variables.tf
@@ -1,24 +1,24 @@
 variable "aws_region" {
   description = "Region where S3 buckets are deployed."
-  type = string
+  type        = string
 }
 
 variable "hosted_zone_domain" {
   description = "Domain of the Route 53 hosted zone this website domain should be added to"
-  type = string
+  type        = string
 }
 
 variable "website_domain" {
   description = "Main website domain, e.g. cloudmaniac.net"
-  type = string
+  type        = string
 }
 
 variable "website_domain_redirect" {
   description = "Secondary domain that will redirect to the main domain"
-  type = string
+  type        = string
 }
 
 variable "default_cache_duration" {
   description = "Default duration for which resources will be cached"
-  type = number
+  type        = number
 }

--- a/workspaces/docs/packages/docs-main/infra/aws/main.tf
+++ b/workspaces/docs/packages/docs-main/infra/aws/main.tf
@@ -41,7 +41,7 @@ resource "aws_route53_record" "wildcard_validation" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-   # Skips the domain if it doesn't contain a wildcard
+    # Skips the domain if it doesn't contain a wildcard
     if length(regexall("\\*\\..+", dvo.domain_name)) > 0
   }
 
@@ -57,7 +57,7 @@ resource "aws_route53_record" "wildcard_validation" {
 # Required to force ACM wildcard certificate validation
 # see https://kopi.cloud/blog/2021/terraform-aws_acm_certificate-wildcards/
 resource "aws_acm_certificate_validation" "wildcard_cert" {
-  provider = aws.us-east-1
+  provider        = aws.us-east-1
   certificate_arn = aws_acm_certificate.wildcard_website.arn
 
   validation_record_fqdns = concat(

--- a/workspaces/docs/packages/docs-main/infra/aws/output.tf
+++ b/workspaces/docs/packages/docs-main/infra/aws/output.tf
@@ -5,5 +5,5 @@ output "website_cdn_root_id" {
 
 output "edge_function_name" {
   description = "Lambda@Edge name for routing"
-  value       = aws_lambda_function.edge.function_name 
+  value       = aws_lambda_function.edge.function_name
 }

--- a/workspaces/docs/packages/docs-main/infra/aws/redirect.tf
+++ b/workspaces/docs/packages/docs-main/infra/aws/redirect.tf
@@ -155,18 +155,14 @@ resource "aws_route53_record" "website_cdn_redirect_record" {
   }
 }
 resource "aws_s3_bucket_versioning" "website_redirect" {
-  count = var.website_domain_redirect != null ? 1 : 0
-
-  bucket = aws_s3_bucket.website_redirect[0].id
+  bucket = aws_s3_bucket.website_redirect.id
   versioning_configuration {
     status = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "website_redirect" {
-  count = var.website_domain_redirect != null ? 1 : 0
-
-  bucket = aws_s3_bucket.website_redirect[0].id
+  bucket = aws_s3_bucket.website_redirect.id
 
   rule {
     id     = "delete-noncurrent-versions"

--- a/workspaces/docs/packages/docs-main/infra/aws/redirect.tf
+++ b/workspaces/docs/packages/docs-main/infra/aws/redirect.tf
@@ -154,3 +154,27 @@ resource "aws_route53_record" "website_cdn_redirect_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/docs/packages/docs-main/infra/aws/root.tf
+++ b/workspaces/docs/packages/docs-main/infra/aws/root.tf
@@ -194,3 +194,23 @@ resource "aws_route53_record" "website_cdn_root_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/docs/packages/docs-main/infra/aws/variables.tf
+++ b/workspaces/docs/packages/docs-main/infra/aws/variables.tf
@@ -1,24 +1,24 @@
 variable "aws_region" {
   description = "Region where S3 buckets are deployed."
-  type = string
+  type        = string
 }
 
 variable "hosted_zone_domain" {
   description = "Domain of the Route 53 hosted zone this website domain should be added to"
-  type = string
+  type        = string
 }
 
 variable "website_domain" {
   description = "Main website domain, e.g. cloudmaniac.net"
-  type = string
+  type        = string
 }
 
 variable "website_domain_redirect" {
   description = "Secondary domain that will redirect to the main domain"
-  type = string
+  type        = string
 }
 
 variable "default_cache_duration" {
   description = "Default duration for which resources will be cached"
-  type = number
+  type        = number
 }

--- a/workspaces/templates-lib/packages/template-static-website-aws/package.json
+++ b/workspaces/templates-lib/packages/template-static-website-aws/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@goldstack/infra": "0.4.41",
     "@goldstack/infra-aws": "0.4.65",
+    "@goldstack/utils-aws-cli": "0.4.66",
     "@goldstack/utils-cli": "0.3.32",
     "@goldstack/utils-config": "0.4.41",
     "@goldstack/utils-log": "0.3.34",

--- a/workspaces/templates-lib/packages/template-static-website-aws/src/infraAwsStaticWebsite.ts
+++ b/workspaces/templates-lib/packages/template-static-website-aws/src/infraAwsStaticWebsite.ts
@@ -1,4 +1,7 @@
-import { fatal } from '@goldstack/utils-log';
+import { readDeploymentState, readTerraformStateVariable } from '@goldstack/infra';
+import { getAWSUser } from '@goldstack/infra-aws';
+import { awsCli } from '@goldstack/utils-aws-cli';
+import { fatal, info, warn } from '@goldstack/utils-log';
 import { upload } from '@goldstack/utils-s3-deployment';
 import { assertDirectoryExists } from '@goldstack/utils-sh';
 import { terraformAwsCli } from '@goldstack/utils-terraform-aws';
@@ -68,6 +71,25 @@ export const deploy = async (config: AWSStaticWebsitePackage, args: string[]): P
     bucketPath: '/',
     localPath: webDistDir,
   });
+
+  const deploymentState = readDeploymentState('./', deployment.name);
+  const distributionId = readTerraformStateVariable(deploymentState, 'website_cdn_root_id');
+
+  if (distributionId) {
+    const user = await getAWSUser(deployment.awsUser);
+    info(`Invalidating CloudFront cache for distribution ${distributionId}`);
+
+    await awsCli({
+      command: `cloudfront create-invalidation --distribution-id ${distributionId} --paths "/*"`,
+      credentials: user,
+      region: deployment.awsRegion,
+      options: { silent: false },
+    });
+  } else {
+    warn(
+      'Could not find website_cdn_root_id in Terraform state. Skipping CloudFront invalidation.',
+    );
+  }
 };
 
 /**

--- a/workspaces/templates/packages/app-nextjs-bootstrap/infra/aws/main.tf
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/infra/aws/main.tf
@@ -37,7 +37,7 @@ resource "aws_route53_record" "wildcard_validation" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-   # Skips the domain if it doesn't contain a wildcard
+    # Skips the domain if it doesn't contain a wildcard
     if length(regexall("\\*\\..+", dvo.domain_name)) > 0
   }
 
@@ -53,7 +53,7 @@ resource "aws_route53_record" "wildcard_validation" {
 # Required to force ACM wildcard certificate validation
 # see https://kopi.cloud/blog/2021/terraform-aws_acm_certificate-wildcards/
 resource "aws_acm_certificate_validation" "wildcard_validation" {
-  provider = aws.us-east-1
+  provider        = aws.us-east-1
   certificate_arn = data.aws_acm_certificate.wildcard_website.arn
 
   validation_record_fqdns = concat(
@@ -82,5 +82,5 @@ data "aws_acm_certificate" "wildcard_website" {
 
 # Id used for unique resource names
 resource "random_id" "id" {
-	  byte_length = 8
+  byte_length = 8
 }

--- a/workspaces/templates/packages/app-nextjs-bootstrap/infra/aws/redirect.tf
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/infra/aws/redirect.tf
@@ -172,3 +172,27 @@ resource "aws_route53_record" "website_cdn_redirect_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/templates/packages/app-nextjs-bootstrap/infra/aws/root.tf
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/infra/aws/root.tf
@@ -207,3 +207,23 @@ resource "aws_route53_record" "website_cdn_root_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/templates/packages/app-nextjs-tailwind/infra/aws/redirect.tf
+++ b/workspaces/templates/packages/app-nextjs-tailwind/infra/aws/redirect.tf
@@ -172,3 +172,27 @@ resource "aws_route53_record" "website_cdn_redirect_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/templates/packages/app-nextjs-tailwind/infra/aws/root.tf
+++ b/workspaces/templates/packages/app-nextjs-tailwind/infra/aws/root.tf
@@ -207,3 +207,23 @@ resource "aws_route53_record" "website_cdn_root_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/templates/packages/app-nextjs-tailwind/src/state/deployments.json
+++ b/workspaces/templates/packages/app-nextjs-tailwind/src/state/deployments.json
@@ -1,5 +1,17 @@
 [
   {
-    "name": "prod"
+    "name": "prod",
+    "terraform": {
+      "routing_function_name": {
+        "sensitive": false,
+        "type": "string",
+        "value": "app-nextjs-tailwind-templates-dev-goldstack-party-routing"
+      },
+      "website_cdn_root_id": {
+        "sensitive": false,
+        "type": "string",
+        "value": "E11H1YKBVXHUH2"
+      }
+    }
   }
 ]

--- a/workspaces/templates/packages/app-nextjs/infra/aws/redirect.tf
+++ b/workspaces/templates/packages/app-nextjs/infra/aws/redirect.tf
@@ -17,6 +17,30 @@ resource "aws_s3_bucket" "website_redirect" {
   }
 }
 
+resource "aws_s3_bucket_versioning" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "website_redirect" {
   count = var.website_domain_redirect != null ? 1 : 0
 

--- a/workspaces/templates/packages/app-nextjs/infra/aws/root.tf
+++ b/workspaces/templates/packages/app-nextjs/infra/aws/root.tf
@@ -19,6 +19,26 @@ resource "aws_s3_bucket" "website_root" {
   }
 }
 
+resource "aws_s3_bucket_versioning" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "website_root" {
   bucket = aws_s3_bucket.website_root.id
 

--- a/workspaces/templates/packages/server-side-rendering/infra/aws/api_gateway.tf
+++ b/workspaces/templates/packages/server-side-rendering/infra/aws/api_gateway.tf
@@ -2,17 +2,17 @@
 # HTTP API
 
 resource "aws_apigatewayv2_api" "api" {
-  name        = "lambda-api-gateway-${random_id.id.hex}"
-  description = "API for Goldstack lambda deployment"
-	protocol_type = "HTTP"
+  name          = "lambda-api-gateway-${random_id.id.hex}"
+  description   = "API for Goldstack lambda deployment"
+  protocol_type = "HTTP"
 
   dynamic "cors_configuration" {
     for_each = var.cors != null ? [1] : []
     content {
       allow_credentials = true
-      allow_headers = ["Content-Type","Accept","x-csrf-token"]
-      allow_methods = ["GET","OPTIONS","POST","PUT","DELETE","PATCH"]
-      allow_origins = [var.cors]
+      allow_headers     = ["Content-Type", "Accept", "x-csrf-token"]
+      allow_methods     = ["GET", "OPTIONS", "POST", "PUT", "DELETE", "PATCH"]
+      allow_origins     = [var.cors]
     }
   }
 }
@@ -25,7 +25,7 @@ resource "aws_apigatewayv2_stage" "default" {
 
   # Conservative default limits for requests, adjust for your usecase as required
   default_route_settings {
-    throttling_rate_limit  = 30 
+    throttling_rate_limit  = 30
     throttling_burst_limit = 60
   }
 }

--- a/workspaces/templates/packages/server-side-rendering/infra/aws/domain.tf
+++ b/workspaces/templates/packages/server-side-rendering/infra/aws/domain.tf
@@ -20,7 +20,7 @@ resource "aws_acm_certificate" "wildcard" {
   }
 
   lifecycle {
-    ignore_changes = [tags]
+    ignore_changes        = [tags]
     create_before_destroy = true
   }
 }
@@ -34,7 +34,7 @@ resource "aws_route53_record" "wildcard_validation" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-   # Skips the domain if it doesn't contain a wildcard
+    # Skips the domain if it doesn't contain a wildcard
     if length(regexall("\\*\\..+", dvo.domain_name)) > 0
   }
 

--- a/workspaces/templates/packages/server-side-rendering/infra/aws/lambda_shared.tf
+++ b/workspaces/templates/packages/server-side-rendering/infra/aws/lambda_shared.tf
@@ -22,7 +22,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_admin_role_attach" {
-  role       = aws_iam_role.lambda_exec.name
+  role = aws_iam_role.lambda_exec.name
   # Gives this lambda full access to everything. Consider restricting rules to only the resources this lambda will require.
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }

--- a/workspaces/templates/packages/server-side-rendering/infra/aws/main.tf
+++ b/workspaces/templates/packages/server-side-rendering/infra/aws/main.tf
@@ -1,5 +1,5 @@
 
 # Id used for unique resource names
 resource "random_id" "id" {
-	  byte_length = 8
+  byte_length = 8
 }

--- a/workspaces/templates/packages/server-side-rendering/infra/aws/s3.tf
+++ b/workspaces/templates/packages/server-side-rendering/infra/aws/s3.tf
@@ -139,3 +139,43 @@ data "aws_iam_policy_document" "public_files" {
     }
   }
 }
+resource "aws_s3_bucket_versioning" "static_files" {
+  bucket = aws_s3_bucket.static_files.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "static_files" {
+  bucket = aws_s3_bucket.static_files.id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "public_files" {
+  bucket = aws_s3_bucket.public_files.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "public_files" {
+  bucket = aws_s3_bucket.public_files.id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/templates/packages/server-side-rendering/infra/aws/variables.tf
+++ b/workspaces/templates/packages/server-side-rendering/infra/aws/variables.tf
@@ -1,33 +1,33 @@
 variable "aws_region" {
   description = "Region where the Lambda is deployed."
-  type = string
+  type        = string
 }
 
 
 variable "domain" {
   description = "Domain under which the application should be deployed."
-  type = string
+  type        = string
 }
 
 variable "hosted_zone_domain" {
   description = "Domain for a hosted zone in AWS Route 53 that domain will be configured in."
-  type = string
+  type        = string
 }
 
 variable "name" {
   description = "Goldstack deployment name."
-  type = string
+  type        = string
 }
 
 variable "cors" {
   description = "Domain for an UI that should be allowed to access this server."
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 # Add routes https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/blob/master/variables.tf#L191
 # see here for different variable types https://www.terraform.io/language/values/variables
 variable "lambdas" {
   description = "Map of endpoint and lambdas for API"
-  type        = map
+  type        = map(any)
 }

--- a/workspaces/templates/packages/static-website-aws/infra/aws/main.tf
+++ b/workspaces/templates/packages/static-website-aws/infra/aws/main.tf
@@ -38,7 +38,7 @@ resource "aws_route53_record" "wildcard_validation" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-   # Skips the domain if it doesn't contain a wildcard
+    # Skips the domain if it doesn't contain a wildcard
     if length(regexall("\\*\\..+", dvo.domain_name)) > 0
   }
 
@@ -54,7 +54,7 @@ resource "aws_route53_record" "wildcard_validation" {
 # Required to force ACM wildcard certificate validation
 # see https://kopi.cloud/blog/2021/terraform-aws_acm_certificate-wildcards/
 resource "aws_acm_certificate_validation" "wildcard_validation" {
-  provider = aws.us-east-1
+  provider        = aws.us-east-1
   certificate_arn = data.aws_acm_certificate.wildcard_website.arn
 
   validation_record_fqdns = concat(
@@ -72,7 +72,7 @@ resource "time_sleep" "wait_for_cert" {
     aws_route53_record.wildcard_validation
   ]
 
-  create_duration = "60s"  # Waits for 60 seconds
+  create_duration = "60s" # Waits for 60 seconds
 }
 
 # Get the ARN of the issued certificate

--- a/workspaces/templates/packages/static-website-aws/infra/aws/redirect.tf
+++ b/workspaces/templates/packages/static-website-aws/infra/aws/redirect.tf
@@ -174,3 +174,27 @@ resource "aws_route53_record" "website_cdn_redirect_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_redirect" {
+  count = var.website_domain_redirect != null ? 1 : 0
+
+  bucket = aws_s3_bucket.website_redirect[0].id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/workspaces/templates/packages/static-website-aws/infra/aws/root.tf
+++ b/workspaces/templates/packages/static-website-aws/infra/aws/root.tf
@@ -157,3 +157,23 @@ resource "aws_route53_record" "website_cdn_root_record" {
     evaluate_target_health = false
   }
 }
+resource "aws_s3_bucket_versioning" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "website_root" {
+  bucket = aws_s3_bucket.website_root.id
+
+  rule {
+    id     = "delete-noncurrent-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -5191,6 +5191,7 @@ __metadata:
   dependencies:
     "@goldstack/infra": "npm:0.4.41"
     "@goldstack/infra-aws": "npm:0.4.65"
+    "@goldstack/utils-aws-cli": "npm:0.4.66"
     "@goldstack/utils-cli": "npm:0.3.32"
     "@goldstack/utils-config": "npm:0.4.41"
     "@goldstack/utils-log": "npm:0.3.34"


### PR DESCRIPTION
## Summary
- Enabled versioning (`aws_s3_bucket_versioning`) for all static website S3 buckets across templates and apps.
- Added a 30-day noncurrent version expiration lifecycle rule (`aws_s3_bucket_lifecycle_configuration`) to ensure old versions are automatically deleted to manage storage costs.
- Updated buckets in: `app-nextjs`, `app-nextjs-bootstrap`, `app-nextjs-tailwind`, `static-website-aws`, `server-side-rendering`, `docs-main`, `cdn`, and `goldstack-home`.