### PR TITLE
Update deleteUser to explicitly take username and email

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6655,6 +6655,23 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@goldstack/template-user-management", [\
+      ["npm:0.1.95", {\
+        "packageLocation": "./.yarn/cache/@goldstack-template-user-management-npm-0.1.95-028a7342a7-8cc8bce5cd.zip/node_modules/@goldstack/template-user-management/",\
+        "packageDependencies": [\
+          ["@aws-sdk/client-cognito-identity-provider", "npm:3.1004.0"],\
+          ["@goldstack/infra", "workspace:workspaces/templates-lib/packages/infra"],\
+          ["@goldstack/infra-aws", "workspace:workspaces/templates-lib/packages/infra-aws"],\
+          ["@goldstack/template-user-management", "npm:0.1.95"],\
+          ["@goldstack/utils-esbuild", "workspace:workspaces/utils/packages/utils-esbuild"],\
+          ["@goldstack/utils-package", "workspace:workspaces/templates-lib/packages/utils-package"],\
+          ["@goldstack/utils-package-config-embedded", "workspace:workspaces/templates-lib/packages/utils-package-config-embedded"],\
+          ["@goldstack/utils-template", "workspace:workspaces/templates-lib/packages/utils-template"],\
+          ["@goldstack/utils-terraform", "workspace:workspaces/templates-lib/packages/utils-terraform"],\
+          ["aws-jwt-verify", "npm:3.2.0"],\
+          ["source-map-support", "npm:0.5.21"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["workspace:workspaces/templates-lib/packages/template-user-management", {\
         "packageLocation": "./workspaces/templates-lib/packages/template-user-management/",\
         "packageDependencies": [\
@@ -6689,7 +6706,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@goldstack/infra", "workspace:workspaces/templates-lib/packages/infra"],\
           ["@goldstack/infra-aws", "workspace:workspaces/templates-lib/packages/infra-aws"],\
-          ["@goldstack/template-user-management", "workspace:workspaces/templates-lib/packages/template-user-management"],\
+          ["@goldstack/template-user-management", "npm:0.1.95"],\
           ["@goldstack/template-user-management-cli", "workspace:workspaces/templates-lib/packages/template-user-management-cli"],\
           ["@goldstack/utils-aws-lambda", "workspace:workspaces/templates-lib/packages/utils-aws-lambda"],\
           ["@goldstack/utils-cli", "workspace:workspaces/utils/packages/utils-cli"],\
@@ -6740,7 +6757,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./workspaces/templates/packages/user-management/",\
         "packageDependencies": [\
           ["@aws-sdk/client-cognito-identity-provider", "npm:3.1004.0"],\
-          ["@goldstack/template-user-management", "workspace:workspaces/templates-lib/packages/template-user-management"],\
+          ["@goldstack/template-user-management", "npm:0.1.95"],\
           ["@goldstack/template-user-management-cli", "workspace:workspaces/templates-lib/packages/template-user-management-cli"],\
           ["@goldstack/user-management", "workspace:workspaces/templates/packages/user-management"],\
           ["@goldstack/utils-log", "workspace:workspaces/utils/packages/utils-log"],\

--- a/workspaces/templates-lib/packages/template-user-management-cli/package.json
+++ b/workspaces/templates-lib/packages/template-user-management-cli/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@goldstack/infra": "0.4.41",
     "@goldstack/infra-aws": "0.4.65",
-    "@goldstack/template-user-management": "0.1.95",
+    "@goldstack/template-user-management": "0.2.0",
     "@goldstack/utils-aws-lambda": "0.3.78",
     "@goldstack/utils-cli": "0.3.32",
     "@goldstack/utils-docker": "0.4.41",

--- a/workspaces/templates-lib/packages/template-user-management/package.json
+++ b/workspaces/templates-lib/packages/template-user-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goldstack/template-user-management",
-  "version": "0.1.95",
+  "version": "0.2.0",
   "description": "Template utilities for user management",
   "keywords": [
     "goldstack",

--- a/workspaces/templates-lib/packages/template-user-management/src/CognitoManager.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/CognitoManager.ts
@@ -90,11 +90,21 @@ export class CognitoManagerImpl implements CognitoManager {
         }),
       );
 
-      if (!listUsersResponse.Users || listUsersResponse.Users.length === 0) {
+      const usersWithUsername = (listUsersResponse.Users || []).filter(
+        (u) => typeof u.Username === 'string',
+      );
+
+      if (usersWithUsername.length === 0) {
         throw new Error(`No user found with email: ${params.email}`);
       }
 
-      resolvedUsername = listUsersResponse.Users[0].Username;
+      if (usersWithUsername.length > 1) {
+        throw new Error(
+          `Multiple users found with email: ${params.email}. Please provide a specific username.`,
+        );
+      }
+
+      resolvedUsername = usersWithUsername[0].Username;
     }
 
     if (!resolvedUsername) {

--- a/workspaces/templates-lib/packages/template-user-management/src/CognitoManager.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/CognitoManager.ts
@@ -2,9 +2,24 @@ import {
   AdminDeleteUserCommand,
   AdminDisableUserCommand,
   CognitoIdentityProviderClient,
+  ListUsersCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
 import type { CognitoAccessTokenPayload, CognitoIdTokenPayload } from 'aws-jwt-verify/jwt-model';
+
+/**
+ * Parameters for deleting a user from the Cognito user pool.
+ */
+export interface CognitoDeleteUserParams {
+  /**
+   * The username of the user to delete.
+   */
+  username?: string;
+  /**
+   * The email address of the user to delete. Will be used to look up the username if not provided directly.
+   */
+  email?: string;
+}
 
 export interface CognitoManager {
   validate(accessToken: string): Promise<CognitoAccessTokenPayload>;
@@ -18,9 +33,9 @@ export interface CognitoManager {
   /**
    * Deletes a user from the Cognito user pool. First disables the user, then deletes them.
    *
-   * @param username - The username (or email) of the user to delete
+   * @param params - Object containing the username or email of the user to delete
    */
-  deleteUser(username: string): Promise<void>;
+  deleteUser(params: CognitoDeleteUserParams): Promise<void>;
 }
 
 export class CognitoManagerImpl implements CognitoManager {
@@ -60,17 +75,42 @@ export class CognitoManagerImpl implements CognitoManager {
     }
   }
 
-  async deleteUser(username: string): Promise<void> {
+  async deleteUser(params: CognitoDeleteUserParams): Promise<void> {
+    let resolvedUsername = params.username;
+
+    if (!resolvedUsername) {
+      if (!params.email) {
+        throw new Error('Either username or email must be provided to delete a user.');
+      }
+
+      const listUsersResponse = await this.cognitoClient.send(
+        new ListUsersCommand({
+          UserPoolId: this.userPoolId,
+          Filter: `email = "${params.email}"`,
+        }),
+      );
+
+      if (!listUsersResponse.Users || listUsersResponse.Users.length === 0) {
+        throw new Error(`No user found with email: ${params.email}`);
+      }
+
+      resolvedUsername = listUsersResponse.Users[0].Username;
+    }
+
+    if (!resolvedUsername) {
+      throw new Error('Unable to resolve username for deletion.');
+    }
+
     await this.cognitoClient.send(
       new AdminDisableUserCommand({
         UserPoolId: this.userPoolId,
-        Username: username,
+        Username: resolvedUsername,
       }),
     );
     await this.cognitoClient.send(
       new AdminDeleteUserCommand({
         UserPoolId: this.userPoolId,
-        Username: username,
+        Username: resolvedUsername,
       }),
     );
   }

--- a/workspaces/templates-lib/packages/template-user-management/src/deleteCognitoUser.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/deleteCognitoUser.ts
@@ -8,16 +8,23 @@ export interface DeleteCognitoUserParams {
    */
   cognitoManager: CognitoManager;
   /**
-   * The username (or email) of the user to delete
+   * The username of the user to delete
    */
-  username: string;
+  username?: string;
+  /**
+   * The email address of the user to delete (used if username is not provided)
+   */
+  email?: string;
 }
 
 /**
  * Deletes a user from the Cognito user pool. First disables the user, then deletes them.
  *
- * @param params - Object containing the CognitoManager and username
+ * @param params - Object containing the CognitoManager and username or email
  */
 export async function deleteCognitoUser(params: DeleteCognitoUserParams): Promise<void> {
-  await params.cognitoManager.deleteUser(params.username);
+  await params.cognitoManager.deleteUser({
+    username: params.username,
+    email: params.email,
+  });
 }

--- a/workspaces/templates-lib/packages/template-user-management/src/userManagementServerMock.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/userManagementServerMock.ts
@@ -2,7 +2,7 @@
 
 import type { CognitoAccessTokenPayload, CognitoIdTokenPayload } from 'aws-jwt-verify/jwt-model';
 import crypto from 'crypto';
-import type { CognitoManager } from './CognitoManager';
+import type { CognitoManager, CognitoDeleteUserParams } from './CognitoManager';
 import { getMockedAccessTokenProperties, getMockedIdTokenProperties } from './userManagementMock';
 
 let localCognitoManager: CognitoManager | undefined;
@@ -12,7 +12,7 @@ export function getLocalUserManager(): CognitoManager {
     return localCognitoManager;
   }
   localCognitoManager = new LocalUserManagerImpl();
-  return localCognitoManager;
+  return localCognitoManager!;
 }
 
 export function setLocalUserManager(userManager: CognitoManager) {
@@ -84,7 +84,7 @@ export class LocalUserManagerImpl implements CognitoManager {
     return JSON.parse(Buffer.from(jwtToken.split('.')[1], 'base64').toString());
   }
 
-  async deleteUser(_username: string): Promise<void> {
+  async deleteUser(_params: CognitoDeleteUserParams): Promise<void> {
     assertNotInProd();
   }
 }

--- a/workspaces/templates/packages/user-management/package.json
+++ b/workspaces/templates/packages/user-management/package.json
@@ -24,7 +24,7 @@
     "test": "GOLDSTACK_DEPLOYMENT=local jest --passWithNoTests --config=./jest.config.js --runInBand"
   },
   "dependencies": {
-    "@goldstack/template-user-management": "0.1.95",
+    "@goldstack/template-user-management": "0.2.0",
     "source-map-support": "^0.5.21",
     "uuid": "^11.0.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5279,7 +5279,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@goldstack/template-user-management@npm:0.1.95, @goldstack/template-user-management@workspace:workspaces/templates-lib/packages/template-user-management":
+"@goldstack/template-user-management@npm:0.1.95":
+  version: 0.1.95
+  resolution: "@goldstack/template-user-management@npm:0.1.95"
+  dependencies:
+    "@aws-sdk/client-cognito-identity-provider": "npm:^3.1004.0"
+    "@goldstack/infra": "npm:0.4.41"
+    "@goldstack/infra-aws": "npm:0.4.65"
+    "@goldstack/utils-esbuild": "npm:0.5.26"
+    "@goldstack/utils-package": "npm:0.4.43"
+    "@goldstack/utils-package-config-embedded": "npm:0.5.44"
+    "@goldstack/utils-template": "npm:0.4.42"
+    "@goldstack/utils-terraform": "npm:0.4.82"
+    aws-jwt-verify: "npm:^3.2.0"
+    source-map-support: "npm:^0.5.21"
+  checksum: 10/8cc8bce5cd405a03237bd9c2b895924935ecdf4e80746a269bf4be353d45f975da0149e5e27506d2e5482e28b05137397678a2558e6316ee11a4771ba8cd7f33
+  languageName: node
+  linkType: hard
+
+"@goldstack/template-user-management@workspace:workspaces/templates-lib/packages/template-user-management":
   version: 0.0.0-use.local
   resolution: "@goldstack/template-user-management@workspace:workspaces/templates-lib/packages/template-user-management"
   dependencies:


### PR DESCRIPTION
## Summary
- Extended `deleteUser` in `CognitoManager` to accept an explicit params object (`CognitoDeleteUserParams`).
- Added email lookup logic using `ListUsersCommand` to find the username if only an email is provided.
- Updated `deleteCognitoUser` params to support optional username and email.