### PR TITLE
[User Management Template]: Prevent unhandled token exceptions for monitoring tools

### DIFF
--- a/workspaces/docs/docs/templates/user-management/faq.md
+++ b/workspaces/docs/docs/templates/user-management/faq.md
@@ -26,3 +26,11 @@ You can change the lifecycle configuration in `main.tf` to ignore schema changes
 
 Otherwise you will have to delete and recreate the user pool but DO SO WITH CAUTION since all
 your existing user data will be irrecoverably lost, including the passwords your users have set.
+
+### Error 'CannotObtainTokenError: Cannot obtain token ...'
+
+If you are using monitoring tools like Sentry, Datadog, or similar error tracking services, you might notice an exception named `CannotObtainTokenError` being frequently logged.
+
+This exception is expected during normal application behavior. It occurs when a user's session has expired and the application attempts to refresh their access token using an expired or invalid refresh token. The user management library will gracefully catch this error internally and redirect the user back to the login screen.
+
+Since this does not represent a bug or an application failure, it is recommended to configure your monitoring tool to filter out or ignore any errors where the name or type is `CannotObtainTokenError`.

--- a/workspaces/templates-lib/packages/template-user-management/src/client/CannotObtainTokenError.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/CannotObtainTokenError.ts
@@ -1,0 +1,9 @@
+export class CannotObtainTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CannotObtainTokenError';
+
+    // Set the prototype explicitly for standard Error inheritance in TS
+    Object.setPrototypeOf(this, CannotObtainTokenError.prototype);
+  }
+}

--- a/workspaces/templates-lib/packages/template-user-management/src/client/executeTokenRequest.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/executeTokenRequest.ts
@@ -33,7 +33,15 @@ export async function executeTokenRequest(args: {
     body: body.toString(),
   });
 
-  const data = await response.json();
+  let data;
+  try {
+    data = await response.json();
+  } catch (e) {
+    return {
+      error: `HTTP ${response.status}`,
+      errorDescription: 'Received non-JSON response from server',
+    };
+  }
 
   if (response.ok) {
     return {

--- a/workspaces/templates-lib/packages/template-user-management/src/client/executeTokenRequest.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/executeTokenRequest.ts
@@ -1,42 +1,50 @@
 import { getCodeVerifier } from './getCodeVerifier';
 import type { GetTokenResults } from './getToken';
 
+export interface ExecuteTokenError {
+  error: string;
+  errorDescription: string;
+}
+
 export async function executeTokenRequest(args: {
   tokenEndpoint: string;
   clientId: string;
   code?: string;
   refreshToken?: string;
   redirectUri: string;
-}): Promise<GetTokenResults> {
-  const xhr = new XMLHttpRequest();
+}): Promise<GetTokenResults | ExecuteTokenError> {
+  const codeVerifier = await getCodeVerifier();
 
-  return new Promise<GetTokenResults>(async (resolve, reject) => {
-    xhr.onload = () => {
-      const response = xhr.response;
-      if (xhr.status === 200) {
-        resolve({
-          accessToken: response.access_token,
-          refreshToken: args.refreshToken || response.refresh_token,
-          idToken: response.id_token,
-        });
-      } else {
-        reject(new Error(`Cannot obtain token ${response.error_description} (${response.error})`));
-      }
-    };
-    xhr.responseType = 'json';
-    xhr.open('POST', args.tokenEndpoint, true);
-    xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-    const codeVerifier = await getCodeVerifier();
-    xhr.send(
-      new URLSearchParams({
-        client_id: args.clientId,
-        code_verifier: args.code ? codeVerifier : '',
-        grant_type: args.code ? 'authorization_code' : 'refresh_token',
-        redirect_uri: args.redirectUri,
-        refresh_token: args.refreshToken || '',
-        code: args.code || '',
-        scope: 'openid email profile',
-      }),
-    );
+  const body = new URLSearchParams({
+    client_id: args.clientId,
+    code_verifier: args.code ? codeVerifier : '',
+    grant_type: args.code ? 'authorization_code' : 'refresh_token',
+    redirect_uri: args.redirectUri,
+    refresh_token: args.refreshToken || '',
+    code: args.code || '',
+    scope: 'openid email profile',
   });
+
+  const response = await fetch(args.tokenEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/x-www-form-urlencoded',
+    },
+    body: body.toString(),
+  });
+
+  const data = await response.json();
+
+  if (response.ok) {
+    return {
+      accessToken: data.access_token,
+      refreshToken: args.refreshToken || data.refresh_token,
+      idToken: data.id_token,
+    };
+  } else {
+    return {
+      error: data.error || `HTTP ${response.status}`,
+      errorDescription: data.error_description || 'Unknown error',
+    };
+  }
 }

--- a/workspaces/templates-lib/packages/template-user-management/src/client/getToken.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/client/getToken.ts
@@ -6,6 +6,7 @@ import { getMockedUserAccessToken, getMockedUserIdToken } from '../userManagemen
 import { getDeploymentName, getDeploymentsOutput } from '../userManagementConfig';
 import { executeTokenRequest } from './executeTokenRequest';
 import { getEndpoint } from './getEndpoints';
+import { CannotObtainTokenError } from './CannotObtainTokenError';
 
 export interface GetTokenResults {
   accessToken: string;
@@ -50,11 +51,19 @@ export async function getToken(args: {
 
   const deployment = packageConfig.getDeployment(deploymentName);
 
-  return await executeTokenRequest({
+  const result = await executeTokenRequest({
     tokenEndpoint: await getEndpoint({ ...args, endpoint: 'token' }),
     clientId: deploymentOutput.terraform.user_pool_client_id.value,
     code: args.code,
     refreshToken: args.refreshToken,
     redirectUri: deployment.configuration.callbackUrl,
   });
+
+  if ('error' in result) {
+    throw new CannotObtainTokenError(
+      `Cannot obtain token ${result.errorDescription} (${result.error})`,
+    );
+  }
+
+  return result;
 }

--- a/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
+++ b/workspaces/templates-lib/packages/template-user-management/src/templateUserManagement.ts
@@ -33,6 +33,7 @@ export {
   setMockedUserAccessToken,
   setMockedUserIdToken,
 } from './userManagementClientMock';
+export { CannotObtainTokenError } from './client/CannotObtainTokenError';
 export {
   generateTestAccessToken,
   generateTestIdToken,

--- a/workspaces/templates/packages/user-management/src/users.ts
+++ b/workspaces/templates/packages/user-management/src/users.ts
@@ -40,6 +40,7 @@ export type {
   LoginOptions,
 } from '@goldstack/template-user-management';
 export {
+  CannotObtainTokenError,
   generateTestAccessToken,
   generateTestIdToken,
   getLocalUserManager,


### PR DESCRIPTION
## Summary
- Replaced `XMLHttpRequest` with `fetch` in `executeTokenRequest` to prevent monitoring tools (like Sentry) from eagerly capturing expected token failures.
- Introduced `CannotObtainTokenError` for expected token auth refresh errors so it can be exported and tracked separately.
- Updated docs to explain how to filter `CannotObtainTokenError`.