### PR TITLE
[All Templates]: Fix: Set AWS_REGION and AWS_DEFAULT_REGION from goldstack config

### DIFF
--- a/workspaces/templates-lib/packages/infra-aws/src/awsUserUtils.ts
+++ b/workspaces/templates-lib/packages/infra-aws/src/awsUserUtils.ts
@@ -134,6 +134,11 @@ export async function getAWSUserFromGoldstackConfig(
       process.env.AWS_CONFIG_FILE = userConfig.awsConfigFileName;
     }
 
+    if (userConfig.awsDefaultRegion) {
+      process.env.AWS_REGION = userConfig.awsDefaultRegion;
+      process.env.AWS_DEFAULT_REGION = userConfig.awsDefaultRegion;
+    }
+
     let credentials: AwsCredentialIdentityProvider;
     let filename: string | undefined;
     if (!process.env.SHARE_CREDENTIALS_FILE) {
@@ -185,6 +190,8 @@ export async function getAWSUserFromGoldstackConfig(
 
     process.env.AWS_ACCESS_KEY_ID = config.awsAccessKeyId;
     process.env.AWS_SECRET_ACCESS_KEY = config.awsSecretAccessKey;
+    process.env.AWS_REGION = config.awsDefaultRegion;
+    process.env.AWS_DEFAULT_REGION = config.awsDefaultRegion;
 
     const credentials = fromEnv();
     injectCredentials(credentials, {
@@ -220,6 +227,8 @@ export async function getAWSUserFromGoldstackConfig(
 
     process.env.AWS_ACCESS_KEY_ID = awsAccessKeyId;
     process.env.AWS_SECRET_ACCESS_KEY = awsSecretAccessKey;
+    process.env.AWS_REGION = awsDefaultRegion;
+    process.env.AWS_DEFAULT_REGION = awsDefaultRegion;
     const credentials = fromEnv();
 
     injectCredentials(credentials, {


### PR DESCRIPTION
## Summary
This PR fixes an issue where the AWS region environment variables (`AWS_REGION` and `AWS_DEFAULT_REGION`) were not being set when loading AWS credentials from the Goldstack configuration (`config.json`).

## Changes
- Updated `getAWSUserFromGoldstackConfig` in `awsUserUtils.ts` to set `process.env.AWS_REGION` and `process.env.AWS_DEFAULT_REGION` for:
  - `apiKey` user types
  - `profile` user types
  - `environmentVariables` user types

This ensures that subsequent AWS SDK operations and environment assertions correctly identify the target region.