### PR TITLE
feat(utils-terraform): pass through Terraform environment variables

### DIFF
--- a/workspaces/docs/docs/goldstack/configuration/terraform.md
+++ b/workspaces/docs/docs/goldstack/configuration/terraform.md
@@ -239,3 +239,48 @@ When resolving Terraform variable values, Goldstack uses the following priority 
 3. Values from `.env` files
 
 If a variable defined in `variables.tf` is not found in any of these sources, a warning will be logged and the variable will not be passed to Terraform.
+
+#### Terraform Environment Variables
+
+Goldstack supports passing through Terraform environment variables to enable advanced configuration and CI/CD integration. The following environment variables are automatically passed through when defined:
+
+**Logging & Debugging:**
+- `TF_LOG` - Enable detailed logs (trace, debug, info, warn, error)
+- `TF_LOG_PATH` - Specify log output location
+- `TF_INPUT` - Disable prompts for unset variables
+
+**Variable Input:**
+- `TF_VAR_name` - Set Terraform variable values (e.g., `TF_VAR_region=us-west-1`)
+
+**CLI Configuration:**
+- `TF_CLI_ARGS` - Additional arguments for all commands
+- `TF_CLI_ARGS_name` - Additional arguments for specific commands (e.g., `TF_CLI_ARGS_plan="-refresh=false"`)
+- `TF_CLI_CONFIG_FILE` - Custom CLI configuration file location
+- `TF_DATA_DIR` - Override Terraform data directory
+- `TERRAFORM_CONFIG` - Deprecated alias for `TF_CLI_CONFIG_FILE`
+
+**Provider Plugin Cache:**
+- `TF_PLUGIN_CACHE_DIR` - Enable provider plugin cache directory
+- `TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE` - Allow cache to break dependency lock file
+
+**Registry:**
+- `TF_REGISTRY_DISCOVERY_RETRY` - Max retries for registry requests
+- `TF_REGISTRY_CLIENT_TIMEOUT` - Registry client timeout
+
+**Automation & State:**
+- `TF_IN_AUTOMATION` - Adjust output for automation workflows
+- `TF_STATE_PERSIST_INTERVAL` - State persist interval for remote backends
+- `TF_WORKSPACE` - Select workspace (warning shown if also using workspace option)
+
+**HCP Terraform:**
+- `TF_CLOUD_ORGANIZATION`, `TF_CLOUD_HOSTNAME`, `TF_TOKEN`, `TF_TOKEN_FILE`
+- `TF_CLOUD_WORKSPACE`, `TF_CLOUD_BACKUP`, `TF_CLOUD_DESCRIPTION`
+
+Example in GitHub workflow:
+```yaml
+env:
+  TF_PLUGIN_CACHE_DIR: /root/.tfcache
+  TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE: true
+```
+
+**Priority**: When the same key exists in both provider config and Terraform environment variables, a warning is logged and the environment variable value takes precedence over the provider configuration.

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.spec.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.spec.ts
@@ -1,7 +1,7 @@
 import { mkdir } from '@goldstack/utils-sh';
 import path from 'path';
 import MockCloudProvider from './MockCloudProvider';
-import { tf } from './terraformCli';
+import { getTerraformEnvVars, tf } from './terraformCli';
 
 describe('Terraform CLI', () => {
   it('Should accept folder with spaces (v0.12)', async () => {
@@ -21,5 +21,89 @@ describe('Terraform CLI', () => {
       version: '0.13',
       provider: new MockCloudProvider(),
     });
+  });
+});
+
+describe('getTerraformEnvVars', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('Should extract TF_VAR_ prefixed variables', () => {
+    process.env.TF_VAR_region = 'us-west-1';
+    process.env.TF_VAR_ami = 'ami-12345';
+
+    const result = getTerraformEnvVars();
+
+    expect(result.TF_VAR_region).toEqual('us-west-1');
+    expect(result.TF_VAR_ami).toEqual('ami-12345');
+  });
+
+  it('Should extract TF_CLI_ARGS_ prefixed variables', () => {
+    process.env.TF_CLI_ARGS = '-input=false';
+    process.env.TF_CLI_ARGS_plan = '-refresh=false';
+
+    const result = getTerraformEnvVars();
+
+    expect(result.TF_CLI_ARGS).toEqual('-input=false');
+    expect(result.TF_CLI_ARGS_plan).toEqual('-refresh=false');
+  });
+
+  it('Should extract TF_ prefixed variables', () => {
+    process.env.TF_LOG = 'trace';
+    process.env.TF_LOG_PATH = './terraform.log';
+    process.env.TF_PLUGIN_CACHE_DIR = '/root/.tfcache';
+    process.env.TF_WORKSPACE = 'production';
+
+    const result = getTerraformEnvVars();
+
+    expect(result.TF_LOG).toEqual('trace');
+    expect(result.TF_LOG_PATH).toEqual('./terraform.log');
+    expect(result.TF_PLUGIN_CACHE_DIR).toEqual('/root/.tfcache');
+    expect(result.TF_WORKSPACE).toEqual('production');
+  });
+
+  it('Should extract HCP Terraform environment variables', () => {
+    process.env.TF_CLOUD_ORGANIZATION = 'my-org';
+    process.env.TF_TOKEN = 'my-token';
+
+    const result = getTerraformEnvVars();
+
+    expect(result.TF_CLOUD_ORGANIZATION).toEqual('my-org');
+    expect(result.TF_TOKEN).toEqual('my-token');
+  });
+
+  it('Should extract TERRAFORM_CONFIG', () => {
+    process.env.TERRAFORM_CONFIG = '/custom/terraformrc';
+
+    const result = getTerraformEnvVars();
+
+    expect(result.TERRAFORM_CONFIG).toEqual('/custom/terraformrc');
+  });
+
+  it('Should not extract non-TF environment variables', () => {
+    process.env.AWS_ACCESS_KEY_ID = 'AKIAIOSFODNN7EXAMPLE';
+    process.env.MY_VAR = 'should-be-ignored';
+    process.env.NODE_ENV = 'test';
+
+    const result = getTerraformEnvVars();
+
+    expect(result.AWS_ACCESS_KEY_ID).toBeUndefined();
+    expect(result.MY_VAR).toBeUndefined();
+    expect(result.NODE_ENV).toBeUndefined();
+  });
+
+  it('Should include empty string values', () => {
+    process.env.TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE = '';
+
+    const result = getTerraformEnvVars();
+
+    expect(result.TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE).toEqual('');
   });
 });

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -16,8 +16,7 @@ export const getTerraformEnvVars = (): Record<string, string> => {
     if (value === undefined) continue;
 
     if (
-      key.startsWith('TF_VAR_') ||
-      key.startsWith('TF_CLI_ARGS_') ||
+      key.startsWith('TF_') ||
       key.startsWith('TF_') ||
       key === 'TERRAFORM_CONFIG'
     ) {

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -10,6 +10,25 @@ import { writeVarsFile } from './writeVarsFile';
 
 export type Variables = [string, string][];
 
+export const getTerraformEnvVars = (): Record<string, string> => {
+  const terraformEnvVars: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+
+    if (
+      key.startsWith('TF_VAR_') ||
+      key.startsWith('TF_CLI_ARGS_') ||
+      key.startsWith('TF_') ||
+      key === 'TERRAFORM_CONFIG'
+    ) {
+      terraformEnvVars[key] = value;
+    }
+  }
+  return terraformEnvVars;
+};
+
+export type { TerraformOptions };
+
 interface TerraformOptions {
   dir?: string;
   provider: CloudProvider;
@@ -41,16 +60,27 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
   // Write AWS credentials file
   writeCredentials(options.provider.generateEnvVariableString(), options.dir);
 
+  const terraformEnvVars = getTerraformEnvVars();
+
   let workspaceEnvVariable = '';
   if (options.workspace) {
+    if (terraformEnvVars.TF_WORKSPACE) {
+      warn(
+        `TF_WORKSPACE environment variable is set to '${terraformEnvVars.TF_WORKSPACE}' but will be overridden by workspace option '${options.workspace}'. Please unset TF_WORKSPACE or remove the workspace option to avoid confusion.`,
+      );
+    }
     workspaceEnvVariable = `-e TF_WORKSPACE=${options.workspace}`;
   }
+
+  const terraformEnvFlags = Object.entries(terraformEnvVars)
+    .map(([key, value]) => `-e ${key}="${value}"`)
+    .join(' ');
 
   const [command, ...rest] = cmd.split(' ');
 
   const cmd3 =
     `docker run --rm -v "${options.dir}":/app ` +
-    // ` ${options.provider.generateEnvVariableString()} ` +
+    ` ${terraformEnvFlags} ` +
     ` ${workspaceEnvVariable} ` +
     '-w /app ' +
     `${imageTerraform(options.version)} ` +
@@ -102,6 +132,8 @@ const execWithCli = (cmd: string, options: TerraformOptions): string => {
   // Write AWS credentials file
   writeCredentials(options.provider.generateEnvVariableString(), options.dir);
 
+  const terraformEnvVars = getTerraformEnvVars();
+
   // Set environment variables from provider
   const envVars = options.provider
     .generateEnvVariableString()
@@ -112,11 +144,31 @@ const execWithCli = (cmd: string, options: TerraformOptions): string => {
   for (const envVar of envVars) {
     const [key, value] = envVar.split('=');
     if (key && value) {
+      if (key in process.env) {
+        warn(
+          `Terraform environment variable '${key}' is already set from provider config, overwriting with value from environment: '${process.env[key]}' -> '${value.replace(/["']/g, '')}'`,
+        );
+      }
       process.env[key] = value.replace(/["']/g, '');
     }
   }
 
+  // TF env vars take precedence over provider config, with warning
+  for (const [key, value] of Object.entries(terraformEnvVars)) {
+    if (key !== 'TF_WORKSPACE' && key in process.env) {
+      warn(
+        `Terraform environment variable '${key}' is already set from provider config, overwriting with value from environment: '${process.env[key]}' -> '${value}'`,
+      );
+    }
+    process.env[key] = value;
+  }
+
   if (options.workspace) {
+    if (terraformEnvVars.TF_WORKSPACE) {
+      warn(
+        `TF_WORKSPACE environment variable is set to '${terraformEnvVars.TF_WORKSPACE}' but will be overridden by workspace option '${options.workspace}'. Please unset TF_WORKSPACE or remove the workspace option to avoid confusion.`,
+      );
+    }
     process.env.TF_WORKSPACE = options.workspace;
   } else {
     delete process.env.TF_WORKSPACE;

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -15,11 +15,7 @@ export const getTerraformEnvVars = (): Record<string, string> => {
   for (const [key, value] of Object.entries(process.env)) {
     if (value === undefined) continue;
 
-    if (
-      key.startsWith('TF_') ||
-      key.startsWith('TF_') ||
-      key === 'TERRAFORM_CONFIG'
-    ) {
+    if (key.startsWith('TF_') || key.startsWith('TF_') || key === 'TERRAFORM_CONFIG') {
       terraformEnvVars[key] = value;
     }
   }
@@ -68,11 +64,14 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
         `TF_WORKSPACE environment variable is set to '${terraformEnvVars.TF_WORKSPACE}' but will be overridden by workspace option '${options.workspace}'. Please unset TF_WORKSPACE or remove the workspace option to avoid confusion.`,
       );
     }
-    workspaceEnvVariable = "-e TF_WORKSPACE=\"" + options.workspace + "\"";
+    workspaceEnvVariable = '-e TF_WORKSPACE="' + options.workspace + '"';
   }
 
   const terraformEnvFlags = Object.entries(terraformEnvVars)
-    .map(([key, value]) => "-e " + key + "=\"" + value.replace(/\"/g, '\\\"').replace(/\$/g, '\\$') + "\"")
+    .map(
+      ([key, value]) =>
+        '-e ' + key + '="' + value.replace(/\"/g, '\\\"').replace(/\$/g, '\\$') + '"',
+    )
     .join(' ');
 
   const [command, ...rest] = cmd.split(' ');
@@ -141,11 +140,18 @@ const execWithCli = (cmd: string, options: TerraformOptions): string => {
     .map((v) => v.trim());
 
   for (const envVar of envVars) {
-    const [key, value] = envVar.split('=');
+    const [key, ...valueParts] = envVar.split('=');
+    const value = valueParts.join('=');
     if (key && value) {
       if (key in process.env) {
         warn(
-          "Environment variable '" + key + "' is already set, overwriting with value from provider config: '" + process.env[key] + "' -> '" + value.replace(/["']/g, '') + "'",
+          "Environment variable '" +
+            key +
+            "' is already set, overwriting with value from provider config: '" +
+            process.env[key] +
+            "' -> '" +
+            value.replace(/["']/g, '') +
+            "'",
         );
       }
       process.env[key] = value.replace(/["']/g, '');

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -70,7 +70,7 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
   const terraformEnvFlags = Object.entries(terraformEnvVars)
     .map(
       ([key, value]) =>
-        '-e ' + key + '="' + value.replace(/\"/g, '\\\"').replace(/\$/g, '\\$') + '"',
+        '-e ' + key + '="' + value.replace(/\\/g, '\\\\').replace(/\"/g, '\\\"').replace(/\$/g, '\\\$') + '"',
     )
     .join(' ');
 

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -1,6 +1,7 @@
 import { assertDocker, hasDocker, imageTerraform } from '@goldstack/utils-docker';
 import { fatal, warn } from '@goldstack/utils-log';
 import { commandExists, exec, pwd } from '@goldstack/utils-sh';
+import child_process from 'child_process';
 import path from 'path';
 import type { CloudProvider } from './cloudProvider';
 import type { TerraformVersion } from './types/utilsTerraformConfig';
@@ -57,49 +58,47 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
 
   const terraformEnvVars = getTerraformEnvVars();
 
-  let workspaceEnvVariable = '';
+  const dockerEnvArgs: string[] = [];
   if (options.workspace) {
     if (terraformEnvVars.TF_WORKSPACE) {
       warn(
         `TF_WORKSPACE environment variable is set to '${terraformEnvVars.TF_WORKSPACE}' but will be overridden by workspace option '${options.workspace}'. Please unset TF_WORKSPACE or remove the workspace option to avoid confusion.`,
       );
     }
-    workspaceEnvVariable =
-      typeof options.workspace === 'string'
-        ? '-e TF_WORKSPACE="' +
-          options.workspace.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\\$') +
-          '"'
-        : '';
+    if (typeof options.workspace === 'string') {
+      dockerEnvArgs.push('-e', `TF_WORKSPACE=${options.workspace}`);
+    }
   }
 
-  const terraformEnvFlags = Object.entries(terraformEnvVars)
-    .map(
-      ([key, value]) =>
-        '-e ' +
-        key +
-        '="' +
-        value
-          .replace(/\\/g, '\\\\')
-          .replace(/"/g, '\\"')
-          .replace(/\$/g, '\\$')
-          .replace(/`/g, '\\`') +
-        '"',
-    )
-    .join(' ');
+  for (const [key, value] of Object.entries(terraformEnvVars)) {
+    dockerEnvArgs.push('-e', `${key}=${value}`);
+  }
 
   const [command, ...rest] = cmd.split(' ');
+  const dockerArgs: string[] = [
+    'run',
+    '--rm',
+    '-v',
+    `${options.dir}:/app`,
+    ...dockerEnvArgs,
+    '-w',
+    '/app',
+    imageTerraform(options.version),
+    command,
+    ...(options.options || []),
+    ...rest,
+  ];
 
-  const cmd3 =
-    `docker run --rm -v "${options.dir}":/app ` +
-    ` ${terraformEnvFlags} ` +
-    ` ${workspaceEnvVariable} ` +
-    '-w /app ' +
-    `${imageTerraform(options.version)} ` +
-    ` ${command} ` +
-    ` ${options.options?.join(' ') || ''} ` +
-    ` ${rest.join(' ')} `;
+  const result = child_process.spawnSync('docker', dockerArgs, {
+    shell: false,
+    encoding: 'utf-8',
+  });
 
-  return exec(cmd3, { silent: options.silent });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `Docker terraform command failed with exit code ${result.status}`);
+  }
+
+  return result.stdout || '';
 };
 
 export const assertTerraform = (): void => {

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -71,7 +71,8 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
   }
 
   for (const [key, value] of Object.entries(terraformEnvVars)) {
-    dockerEnvArgs.push('-e', `${key}=${value}`);
+    if (key === 'TF_WORKSPACE' && options.workspace) continue;
+    dockerEnvArgs.push('-e', key + '=' + String(value));
   }
 
   const [command, ...rest] = cmd.split(' ');

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -73,7 +73,7 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
   }
 
   const terraformEnvFlags = Object.entries(terraformEnvVars)
-    .map(([key, value]) => `-e ${key}="${value}"`)
+    .map(([key, value]) => "-e " + key + "=\"" + value.replace(/\"/g, '\\\"').replace(/\$/g, '\\$') + "\"")
     .join(' ');
 
   const [command, ...rest] = cmd.split(' ');

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -64,7 +64,7 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
         `TF_WORKSPACE environment variable is set to '${terraformEnvVars.TF_WORKSPACE}' but will be overridden by workspace option '${options.workspace}'. Please unset TF_WORKSPACE or remove the workspace option to avoid confusion.`,
       );
     }
-    workspaceEnvVariable = '-e TF_WORKSPACE="' + options.workspace + '"';
+    workspaceEnvVariable = typeof options.workspace === 'string' ? '-e TF_WORKSPACE="' + options.workspace.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\\$') + '"' : '';
   }
 
   const terraformEnvFlags = Object.entries(terraformEnvVars)

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -1,7 +1,6 @@
 import { assertDocker, hasDocker, imageTerraform } from '@goldstack/utils-docker';
 import { fatal, warn } from '@goldstack/utils-log';
 import { commandExists, exec, pwd } from '@goldstack/utils-sh';
-import child_process from 'child_process';
 import path from 'path';
 import type { CloudProvider } from './cloudProvider';
 import type { TerraformVersion } from './types/utilsTerraformConfig';
@@ -58,50 +57,48 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
 
   const terraformEnvVars = getTerraformEnvVars();
 
-  const dockerEnvArgs: string[] = [];
+  let workspaceEnvVariable = '';
   if (options.workspace) {
     if (terraformEnvVars.TF_WORKSPACE) {
       warn(
         `TF_WORKSPACE environment variable is set to '${terraformEnvVars.TF_WORKSPACE}' but will be overridden by workspace option '${options.workspace}'. Please unset TF_WORKSPACE or remove the workspace option to avoid confusion.`,
       );
     }
-    if (typeof options.workspace === 'string') {
-      dockerEnvArgs.push('-e', `TF_WORKSPACE=${options.workspace}`);
-    }
+    workspaceEnvVariable =
+      '-e ' +
+      'TF_WORKSPACE="' +
+      options.workspace
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"')
+        .replace(/\$/g, '\\$')
+        .replace(/`/g, '\\`') +
+      '"';
   }
 
-  for (const [key, value] of Object.entries(terraformEnvVars)) {
-    if (key === 'TF_WORKSPACE' && options.workspace) continue;
-    dockerEnvArgs.push('-e', key + '=' + String(value));
-  }
+  const terraformEnvFlags = Object.entries(terraformEnvVars)
+    .map(
+      ([key, value]) =>
+        '-e ' +
+        key +
+        '="' +
+        value
+          .replace(/\\/g, '\\\\')
+          .replace(/"/g, '\\"')
+          .replace(/\$/g, '\\$')
+          .replace(/`/g, '\\`') +
+        '"',
+    )
+    .join(' ');
 
   const [command, ...rest] = cmd.split(' ');
-  const dockerArgs: string[] = [
-    'run',
-    '--rm',
-    '-v',
-    `${options.dir}:/app`,
-    ...dockerEnvArgs,
-    '-w',
-    '/app',
-    imageTerraform(options.version),
-    command,
-    ...(options.options || []),
-    ...rest,
-  ];
 
-  const result = child_process.spawnSync('docker', dockerArgs, {
-    shell: false,
-    encoding: 'utf-8',
-  });
+  const cmd3 =
+    `docker run --rm -v "${options.dir}":/app ` +
+    ` ${terraformEnvFlags} ` +
+    ` ${workspaceEnvVariable} ` +
+    ` -w /app ${imageTerraform(options.version)} ${command} ${rest.join(' ')}`;
 
-  if (result.status !== 0) {
-    throw new Error(
-      result.stderr || `Docker terraform command failed with exit code ${result.status}`,
-    );
-  }
-
-  return result.stdout || '';
+  return exec(cmd3, { silent: options.silent });
 };
 
 export const assertTerraform = (): void => {

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -15,7 +15,7 @@ export const getTerraformEnvVars = (): Record<string, string> => {
   for (const [key, value] of Object.entries(process.env)) {
     if (value === undefined) continue;
 
-    if (key.startsWith('TF_') || key.startsWith('TF_') || key === 'TERRAFORM_CONFIG') {
+    if (key.startsWith('TF_') || key === 'TERRAFORM_CONFIG') {
       terraformEnvVars[key] = value;
     }
   }
@@ -70,7 +70,15 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
   const terraformEnvFlags = Object.entries(terraformEnvVars)
     .map(
       ([key, value]) =>
-        '-e ' + key + '="' + value.replace(/\\/g, '\\\\').replace(/\"/g, '\\\"').replace(/\$/g, '\\\$') + '"',
+        '-e ' +
+        key +
+        '="' +
+        value
+          .replace(/\\/g, '\\\\')
+          .replace(/"/g, '\\"')
+          .replace(/\$/g, '\\$')
+          .replace(/`/g, '\\`') +
+        '"',
     )
     .join(' ');
 

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -95,7 +95,9 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
   });
 
   if (result.status !== 0) {
-    throw new Error(result.stderr || `Docker terraform command failed with exit code ${result.status}`);
+    throw new Error(
+      result.stderr || `Docker terraform command failed with exit code ${result.status}`,
+    );
   }
 
   return result.stdout || '';
@@ -154,10 +156,10 @@ const execWithCli = (cmd: string, options: TerraformOptions): string => {
   for (const envVar of envVars) {
     const [key, ...valueParts] = envVar.split('=');
     const value = valueParts.join('=');
-    if (key && value) {
+    if (key) {
       if (key in terraformEnvVars) {
         warn(
-          `Environment variable '${key}' is a Terraform environment variable, taking precedence over provider config: '${process.env[key]}' -> '${value.replace(/["']/g, '')}'`,
+          `Environment variable '${key}' is a Terraform environment variable, taking precedence over provider config: '${process.env[key]}' -> '${value.replace(/^["']|["']$/g, '')}'`,
         );
         continue;
       }
@@ -168,11 +170,11 @@ const execWithCli = (cmd: string, options: TerraformOptions): string => {
             "' is already set, overwriting with value from provider config: '" +
             process.env[key] +
             "' -> '" +
-            value.replace(/["']/g, '') +
+            value.replace(/^["']|["']$/g, '') +
             "'",
         );
       }
-      process.env[key] = value.replace(/["']/g, '');
+      process.env[key] = value.replace(/^["']|["']$/g, '');
     }
   }
 

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -164,7 +164,7 @@ const execWithCli = (cmd: string, options: TerraformOptions): string => {
             "'",
         );
       }
-      process.env[key] = value.replace(/["']/g, '');
+      process.env[key] = typeof value === 'string' ? value.replace(/^[\"']|[\"']$/g, '') : value;
       providerSetKeys.add(key);
     }
   }

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -64,7 +64,12 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
         `TF_WORKSPACE environment variable is set to '${terraformEnvVars.TF_WORKSPACE}' but will be overridden by workspace option '${options.workspace}'. Please unset TF_WORKSPACE or remove the workspace option to avoid confusion.`,
       );
     }
-    workspaceEnvVariable = typeof options.workspace === 'string' ? '-e TF_WORKSPACE="' + options.workspace.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\\$') + '"' : '';
+    workspaceEnvVariable =
+      typeof options.workspace === 'string'
+        ? '-e TF_WORKSPACE="' +
+          options.workspace.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\\$') +
+          '"'
+        : '';
   }
 
   const terraformEnvFlags = Object.entries(terraformEnvVars)
@@ -147,12 +152,16 @@ const execWithCli = (cmd: string, options: TerraformOptions): string => {
     .filter((v) => v)
     .map((v) => v.trim());
 
-  const providerSetKeys = new Set<string>();
-
   for (const envVar of envVars) {
     const [key, ...valueParts] = envVar.split('=');
     const value = valueParts.join('=');
     if (key && value) {
+      if (key in terraformEnvVars) {
+        warn(
+          `Environment variable '${key}' is a Terraform environment variable, taking precedence over provider config: '${process.env[key]}' -> '${value.replace(/["']/g, '')}'`,
+        );
+        continue;
+      }
       if (key in process.env) {
         warn(
           "Environment variable '" +
@@ -164,19 +173,8 @@ const execWithCli = (cmd: string, options: TerraformOptions): string => {
             "'",
         );
       }
-      process.env[key] = typeof value === 'string' ? value.replace(/^[\"']|[\"']$/g, '') : value;
-      providerSetKeys.add(key);
+      process.env[key] = value.replace(/["']/g, '');
     }
-  }
-
-  // TF env vars take precedence over provider config, with warning
-  for (const [key, value] of Object.entries(terraformEnvVars)) {
-    if (key !== 'TF_WORKSPACE' && providerSetKeys.has(key)) {
-      warn(
-        `Terraform environment variable '${key}' is already set from provider config, overwriting with value from environment: '${process.env[key]}' -> '${value}'`,
-      );
-    }
-    process.env[key] = value;
   }
 
   if (options.workspace) {

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -69,7 +69,7 @@ const execWithDocker = (cmd: string, options: TerraformOptions): string => {
         `TF_WORKSPACE environment variable is set to '${terraformEnvVars.TF_WORKSPACE}' but will be overridden by workspace option '${options.workspace}'. Please unset TF_WORKSPACE or remove the workspace option to avoid confusion.`,
       );
     }
-    workspaceEnvVariable = `-e TF_WORKSPACE=${options.workspace}`;
+    workspaceEnvVariable = "-e TF_WORKSPACE=\"" + options.workspace + "\"";
   }
 
   const terraformEnvFlags = Object.entries(terraformEnvVars)

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -145,7 +145,7 @@ const execWithCli = (cmd: string, options: TerraformOptions): string => {
     if (key && value) {
       if (key in process.env) {
         warn(
-          `Terraform environment variable '${key}' is already set from provider config, overwriting with value from environment: '${process.env[key]}' -> '${value.replace(/["']/g, '')}'`,
+          "Environment variable '" + key + "' is already set, overwriting with value from provider config: '" + process.env[key] + "' -> '" + value.replace(/["']/g, '') + "'",
         );
       }
       process.env[key] = value.replace(/["']/g, '');

--- a/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
+++ b/workspaces/templates-lib/packages/utils-terraform/src/terraformCli.ts
@@ -139,6 +139,8 @@ const execWithCli = (cmd: string, options: TerraformOptions): string => {
     .filter((v) => v)
     .map((v) => v.trim());
 
+  const providerSetKeys = new Set<string>();
+
   for (const envVar of envVars) {
     const [key, ...valueParts] = envVar.split('=');
     const value = valueParts.join('=');
@@ -155,12 +157,13 @@ const execWithCli = (cmd: string, options: TerraformOptions): string => {
         );
       }
       process.env[key] = value.replace(/["']/g, '');
+      providerSetKeys.add(key);
     }
   }
 
   // TF env vars take precedence over provider config, with warning
   for (const [key, value] of Object.entries(terraformEnvVars)) {
-    if (key !== 'TF_WORKSPACE' && key in process.env) {
+    if (key !== 'TF_WORKSPACE' && providerSetKeys.has(key)) {
       warn(
         `Terraform environment variable '${key}' is already set from provider config, overwriting with value from environment: '${process.env[key]}' -> '${value}'`,
       );


### PR DESCRIPTION
## Summary
- Add `getTerraformEnvVars()` to extract TF_*, TF_VAR_*, TF_CLI_ARGS_*, and TERRAFORM_CONFIG from `process.env`
- Modify `execWithDocker()` to pass TF env vars to container via `-e` flags
- Modify `execWithCli()` to set TF env vars on `process.env` (takes precedence over provider config)
- Add warnings when `TF_WORKSPACE` conflicts with `options.workspace`
- Add warnings when TF env vars conflict with provider config env vars
- Add comprehensive tests for `getTerraformEnvVars()`
- Update terraform.md documentation

## Motivation
Terraform environment variables like `TF_PLUGIN_CACHE_DIR` and `TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE` were not being passed through when executing Terraform, which prevented users from enabling plugin caching in CI/CD environments like GitHub workflows.

## Testing
- All 29 tests pass
- Lint and compile clean