### PR TITLE
Fix AWS SDK v3 upgrade: add --experimental-vm-modules flag and SWR mock for Jest

### DIFF
--- a/workspaces/apps/package.json
+++ b/workspaces/apps/package.json
@@ -19,7 +19,7 @@
     "lint": "biome lint",
     "lint-fix": "biome lint --write",
     "package:doctor": "yarn dlx @yarnpkg/doctor .",
-    "test": "yarn workspaces foreach -Wv run test"
+    "test": "NODE_OPTIONS=--experimental-vm-modules yarn workspaces foreach -Wv run test"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.5",

--- a/workspaces/apps/packages/goldstack-api/package.json
+++ b/workspaces/apps/packages/goldstack-api/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@goldstack/goldstack-email-send": "0.1.0",
     "@goldstack/module-template-utils": "0.1.2",
-    "@goldstack/template-s3": "0.5.80",
+    "@goldstack/template-s3": "0.5.81",
     "@goldstack/utils-template-test": "0.1.0",
     "@jest-mock/express": "^1.4.5",
     "@swc/core": "^1.15.8",

--- a/workspaces/examples/package.json
+++ b/workspaces/examples/package.json
@@ -19,7 +19,7 @@
     "lint": "biome lint",
     "lint-fix": "biome lint --write",
     "package:doctor": "yarn dlx @yarnpkg/doctor .",
-    "test": "yarn workspaces foreach -Wv run test",
+    "test": "NODE_OPTIONS=--experimental-vm-modules yarn workspaces foreach -Wv run test",
     "test-watch": "nodemonx --watch . --exec 'yarn test'"
   },
   "devDependencies": {

--- a/workspaces/templates-lib/package.json
+++ b/workspaces/templates-lib/package.json
@@ -20,7 +20,7 @@
     "package:doctor": "yarn dlx @yarnpkg/doctor .",
     "publish": "yarn workspaces foreach --topological-dev --worktree run publish",
     "set-npm-ignore": "ts-node scripts/setNpmIgnore.ts",
-    "test": "yarn workspaces foreach -Wv run test"
+    "test": "NODE_OPTIONS=--experimental-vm-modules yarn workspaces foreach -Wv run test"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.5",

--- a/workspaces/templates-lib/packages/template-s3/src/connectLocal.ts
+++ b/workspaces/templates-lib/packages/template-s3/src/connectLocal.ts
@@ -3,7 +3,7 @@ import { type AWSDeploymentRegion, getAWSUser } from '@goldstack/infra-aws';
 import { excludeInBundle } from '@goldstack/utils-esbuild';
 import { debug, warn } from '@goldstack/utils-log';
 import { EmbeddedPackageConfig } from '@goldstack/utils-package-config-embedded';
-import type { S3Deployment, S3Package } from './templateS3';
+import type { S3Deployment, S3Package } from './types/S3Package';
 
 let s3MockUsed = false;
 

--- a/workspaces/templates/package.json
+++ b/workspaces/templates/package.json
@@ -22,7 +22,7 @@
     "check": "biome check",
     "check-fix": "biome check --write",
     "package:doctor": "yarn dlx @yarnpkg/doctor .",
-    "test": "yarn workspaces foreach -Wv run test",
+    "test": "NODE_OPTIONS=--experimental-vm-modules yarn workspaces foreach -Wv run test",
     "test-watch": "nodemonx --watch . --exec 'yarn test'"
   },
   "devDependencies": {

--- a/workspaces/templates/packages/app-nextjs-bootstrap/src/__tests__/index.uispec.tsx
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/src/__tests__/index.uispec.tsx
@@ -2,6 +2,16 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Homepage from '../../pages/index';
 
+jest.mock('swr', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    data: undefined,
+    error: undefined,
+    isValidating: false,
+    mutate: jest.fn(),
+  })),
+}));
+
 test('Check App component render', () => {
   const res = render(<Homepage />);
 

--- a/workspaces/templates/packages/app-nextjs-bootstrap/src/__tests__/index.uispec.tsx
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/src/__tests__/index.uispec.tsx
@@ -10,6 +10,7 @@ jest.mock('swr', () => ({
     isValidating: false,
     mutate: jest.fn(),
   })),
+  mutate: jest.fn(),
 }));
 
 test('Check App component render', () => {

--- a/workspaces/templates/packages/app-nextjs/src/__tests__/index.uispec.tsx
+++ b/workspaces/templates/packages/app-nextjs/src/__tests__/index.uispec.tsx
@@ -10,6 +10,7 @@ jest.mock('swr', () => ({
     isValidating: false,
     mutate: jest.fn(),
   })),
+  mutate: jest.fn(),
 }));
 
 test('Check App component render', async () => {

--- a/workspaces/templates/packages/app-nextjs/src/__tests__/index.uispec.tsx
+++ b/workspaces/templates/packages/app-nextjs/src/__tests__/index.uispec.tsx
@@ -2,6 +2,16 @@ import { render } from '@testing-library/react';
 import Homepage from '../../pages';
 import '@testing-library/jest-dom';
 
+jest.mock('swr', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    data: undefined,
+    error: undefined,
+    isValidating: false,
+    mutate: jest.fn(),
+  })),
+}));
+
 test('Check App component render', async () => {
   const res = render(<Homepage />);
 

--- a/workspaces/utils/package.json
+++ b/workspaces/utils/package.json
@@ -20,7 +20,7 @@
     "package:doctor": "yarn dlx @yarnpkg/doctor .",
     "publish": "yarn workspaces foreach --topological-dev --worktree run publish",
     "set-npm-ignore": "ts-node scripts/setNpmIgnore.ts",
-    "test": "yarn workspaces foreach -Wv run test"
+    "test": "NODE_OPTIONS=--experimental-vm-modules yarn workspaces foreach -Wv run test"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.5",


### PR DESCRIPTION
## Changes

### Fix AWS SDK v3 dynamic import error in Jest
Newer AWS SDK v3 packages (`@aws-sdk/core`, `@smithy/core`) use dynamic `import()` internally, which requires `--experimental-vm-modules` Node flag when running in Jest's VM-based test environment.

**Fix:** Added `NODE_OPTIONS=--experimental-vm-modules` to workspace-level test scripts in:
- `workspaces/templates-lib/package.json`
- `workspaces/templates/package.json`
- `workspaces/utils/package.json`
- `workspaces/examples/package.json`
- `workspaces/apps/package.json`

### Mock SWR in Next.js UI tests
Tests rendering components that import SWR trigger real network calls and leave timers open.

**Fix:** Added `jest.mock('swr', ...)` to:
- `workspaces/templates/packages/app-nextjs/src/__tests__/index.uispec.tsx`
- `workspaces/templates/packages/app-nextjs-bootstrap/src/__tests__/index.uispec.tsx`