### PR TITLE
fix: lazy-load pino-pretty to prevent webpack bundling it in client builds

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -183,6 +183,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/goldstack-setup
+      - name: Compile dependencies
+        run: |
+          yarn workspace @goldstack/goldstack-api compile
       - name: Build Next.js app
         run: |
           yarn workspace @goldstack/goldstack-home web:build

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -176,6 +176,17 @@ jobs:
         run: |
           yarn generate-schema
 
+  web-build:
+    name: 'Web Build (goldstack-home)'
+    if: ${{ ! contains(github.event.head_commit.message, 'ci_skip') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/goldstack-setup
+      - name: Build Next.js app
+        run: |
+          yarn workspace @goldstack/goldstack-home web:build
+
   docs:
     name: 'Generate Docs'
     if: ${{ ! contains(github.event.head_commit.message, 'ci_skip') }}

--- a/workspaces/utils/packages/utils-cli/src/utilsCli.ts
+++ b/workspaces/utils/packages/utils-cli/src/utilsCli.ts
@@ -29,9 +29,15 @@ let defaultLogger: LoggerInstance | undefined;
 
 function getDefaultLogger(): LoggerInstance {
   if (!defaultLogger) {
-    // biome-ignore lint/security/noGlobalEval: Prevent webpack from bundling pino-pretty in client builds
-    const pinoPretty = eval('require')('pino-pretty');
-    const prettyModule = pinoPretty.default || pinoPretty;
+    // biome-ignore lint/suspicious/noExplicitAny: pino-pretty module is dynamically loaded
+    let prettyModule: any;
+    try {
+      // biome-ignore lint/security/noGlobalEval: Prevent webpack from bundling pino-pretty in client builds
+      const pinoPretty = eval('require')('pino-pretty');
+      prettyModule = pinoPretty.default || pinoPretty;
+    } catch (_e) {
+      // Fallback if pino-pretty is not available or require is not defined (e.g. browser)
+    }
 
     defaultLogger = pino(
       {
@@ -62,8 +68,8 @@ function getDefaultLogger(): LoggerInstance {
           },
         }),
       },
-      isLambda
-        ? undefined // Use default JSON transport for Lambda
+      isLambda || !prettyModule
+        ? undefined // Use default JSON transport for Lambda or if prettyModule is not available
         : prettyModule({
             colorize: true,
             hideObject: false,

--- a/workspaces/utils/packages/utils-cli/src/utilsCli.ts
+++ b/workspaces/utils/packages/utils-cli/src/utilsCli.ts
@@ -1,5 +1,4 @@
 import pino from 'pino';
-import pinoPretty from 'pino-pretty';
 
 type AsyncFunction<O> = () => Promise<O>;
 
@@ -26,47 +25,58 @@ export interface LoggerConfig {
 
 let loggerInstance: LoggerInstance | undefined;
 
-const defaultLogger = pino(
-  {
-    level: isDebug ? 'debug' : 'info',
-    ...(isLambda && {
-      timestamp: () => `,"time":"${new Date(Date.now()).toISOString()}"`,
-      formatters: {
-        level: (label: string) => ({ level: label }),
-        log: (obj: Record<string, unknown>) => {
-          if (obj.err) {
-            const err = obj.err as Error;
-            return {
-              ...obj,
-              error: {
-                type: err.name,
-                stack: err.stack,
-                message: err.message,
-              },
-            };
-          }
-          return obj;
-        },
+let defaultLogger: LoggerInstance | undefined;
+
+function getDefaultLogger(): LoggerInstance {
+  if (!defaultLogger) {
+    // biome-ignore lint/security/noGlobalEval: Prevent webpack from bundling pino-pretty in client builds
+    const pinoPretty = eval('require')('pino-pretty');
+    const prettyModule = pinoPretty.default || pinoPretty;
+
+    defaultLogger = pino(
+      {
+        level: isDebug ? 'debug' : 'info',
+        ...(isLambda && {
+          timestamp: () => `,"time":"${new Date(Date.now()).toISOString()}"`,
+          formatters: {
+            level: (label: string) => ({ level: label }),
+            log: (obj: Record<string, unknown>) => {
+              if (obj.err) {
+                const err = obj.err as Error;
+                return {
+                  ...obj,
+                  error: {
+                    type: err.name,
+                    stack: err.stack,
+                    message: err.message,
+                  },
+                };
+              }
+              return obj;
+            },
+          },
+          base: {
+            aws_request_id: process.env.AWS_LAMBDA_REQUEST_ID || undefined,
+            function_name: process.env.AWS_LAMBDA_FUNCTION_NAME,
+            function_version: process.env.AWS_LAMBDA_FUNCTION_VERSION,
+          },
+        }),
       },
-      base: {
-        aws_request_id: process.env.AWS_LAMBDA_REQUEST_ID || undefined,
-        function_name: process.env.AWS_LAMBDA_FUNCTION_NAME,
-        function_version: process.env.AWS_LAMBDA_FUNCTION_VERSION,
-      },
-    }),
-  },
-  isLambda
-    ? undefined // Use default JSON transport for Lambda
-    : pinoPretty({
-        colorize: true,
-        hideObject: false,
-        colorizeObjects: true,
-        translateTime: 'HH:MM:ss',
-        ignore: 'pid,hostname',
-        singleLine: false,
-        sync: true, // required for work in Jest see https://github.com/pinojs/pino-pretty?tab=readme-ov-file#usage-with-jest
-      }),
-);
+      isLambda
+        ? undefined // Use default JSON transport for Lambda
+        : prettyModule({
+            colorize: true,
+            hideObject: false,
+            colorizeObjects: true,
+            translateTime: 'HH:MM:ss',
+            ignore: 'pid,hostname',
+            singleLine: false,
+            sync: true, // required for work in Jest see https://github.com/pinojs/pino-pretty?tab=readme-ov-file#usage-with-jest
+          }),
+    );
+  }
+  return defaultLogger;
+}
 
 /**
  * Configure the logger instance
@@ -81,7 +91,7 @@ export function configureLogger(config: LoggerConfig): void {
  * @returns The configured logger instance or the default pino logger
  */
 export function logger(): LoggerInstance {
-  return loggerInstance || defaultLogger;
+  return loggerInstance || getDefaultLogger();
 }
 
 export const wrapCli = async (func: AsyncFunction<unknown>): Promise<void> => {


### PR DESCRIPTION
## Problem

Next.js build of `@goldstack/goldstack-home` fails because `pino-pretty` (and its transitive deps `worker_threads`, `fs`) is being pulled into the client bundle through this chain:

```
build.tsx → @goldstack/goldstack-api → @goldstack/utils-log → @goldstack/utils-cli → pino-pretty
```

Even though the page only uses `getEndpoint`, the barrel import in `@goldstack/goldstack-api` pulls in `debug` → the entire logging stack → `pino-pretty` is statically imported and evaluated at module init time.

## Fix

In `@goldstack/utils-cli/src/utilsCli.ts`:
- Removed static `import pinoPretty from 'pino-pretty'`
- Replaced top-level `defaultLogger` with a lazy `getDefaultLogger()` that loads pino-pretty via `eval('require')` — the same webpack-hiding pattern already used in `goldstack-api/src/module.ts:14`

## Verification

```
yarn workspace @goldstack/goldstack-home next build
```

Builds successfully with no `pino-pretty`/worker_threads/fs errors.