### PR TITLE
chore: remediate high-severity dependency vulnerabilities

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -4903,7 +4903,7 @@ const RAW_RUNTIME_STATE =
           ["@types/minimatch", "npm:5.1.2"],\
           ["@types/node", "npm:25.0.3"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
-          ["minimatch", "npm:10.0.1"],\
+          ["minimatch", "npm:10.2.5"],\
           ["node-watch", "npm:0.6.4"],\
           ["rimraf", "npm:6.1.2"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
@@ -7300,25 +7300,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/unplugged/@img-sharp-win32-x64-npm-0.34.3-4d5dda4460/node_modules/@img/sharp-win32-x64/",\
         "packageDependencies": [\
           ["@img/sharp-win32-x64", "npm:0.34.3"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@isaacs/balanced-match", [\
-      ["npm:4.0.1", {\
-        "packageLocation": "./.yarn/cache/@isaacs-balanced-match-npm-4.0.1-8965afafe6-102fbc6d2c.zip/node_modules/@isaacs/balanced-match/",\
-        "packageDependencies": [\
-          ["@isaacs/balanced-match", "npm:4.0.1"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@isaacs/brace-expansion", [\
-      ["npm:5.0.1", {\
-        "packageLocation": "./.yarn/cache/@isaacs-brace-expansion-npm-5.0.1-79f48d6db7-aec226065b.zip/node_modules/@isaacs/brace-expansion/",\
-        "packageDependencies": [\
-          ["@isaacs/balanced-match", "npm:4.0.1"],\
-          ["@isaacs/brace-expansion", "npm:5.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -12699,6 +12680,13 @@ const RAW_RUNTIME_STATE =
           ["balanced-match", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:4.0.4", {\
+        "packageLocation": "./.yarn/cache/balanced-match-npm-4.0.4-fd666b3c7f-fb07bb66a0.zip/node_modules/balanced-match/",\
+        "packageDependencies": [\
+          ["balanced-match", "npm:4.0.4"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["bare-events", [\
@@ -12879,6 +12867,22 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["balanced-match", "npm:1.0.0"],\
           ["brace-expansion", "npm:2.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.1.2", {\
+        "packageLocation": "./.yarn/cache/brace-expansion-npm-2.1.2-1d27efb657-0e0f9b0df1.zip/node_modules/brace-expansion/",\
+        "packageDependencies": [\
+          ["balanced-match", "npm:1.0.0"],\
+          ["brace-expansion", "npm:2.1.2"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:5.0.7", {\
+        "packageLocation": "./.yarn/cache/brace-expansion-npm-5.0.7-48dc108338-98c12de33f.zip/node_modules/brace-expansion/",\
+        "packageDependencies": [\
+          ["balanced-match", "npm:4.0.4"],\
+          ["brace-expansion", "npm:5.0.7"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -14584,7 +14588,7 @@ const RAW_RUNTIME_STATE =
           ["js-yaml", "npm:3.15.0"],\
           ["json5", "npm:2.2.3"],\
           ["lodash", "npm:4.17.23"],\
-          ["minimatch", "npm:7.4.6"],\
+          ["minimatch", "npm:7.4.9"],\
           ["multimatch", "npm:5.0.0"],\
           ["please-upgrade-node", "npm:3.2.0"],\
           ["readdirp", "npm:3.6.0"],\
@@ -16181,7 +16185,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/filelist-npm-1.0.4-3a835ae0a7-4b436fa944.zip/node_modules/filelist/",\
         "packageDependencies": [\
           ["filelist", "npm:1.0.4"],\
-          ["minimatch", "npm:5.1.6"]\
+          ["minimatch", "npm:5.1.9"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -16725,7 +16729,7 @@ const RAW_RUNTIME_STATE =
           ["foreground-child", "npm:3.3.1"],\
           ["glob", "npm:10.5.0"],\
           ["jackspeak", "npm:3.4.3"],\
-          ["minimatch", "npm:9.0.5"],\
+          ["minimatch", "npm:9.0.9"],\
           ["minipass", "npm:7.1.2"],\
           ["package-json-from-dist", "npm:1.0.1"],\
           ["path-scurry", "npm:1.11.1"]\
@@ -16738,7 +16742,7 @@ const RAW_RUNTIME_STATE =
           ["foreground-child", "npm:3.3.1"],\
           ["glob", "npm:11.1.0"],\
           ["jackspeak", "npm:4.1.1"],\
-          ["minimatch", "npm:10.1.1"],\
+          ["minimatch", "npm:10.2.5"],\
           ["minipass", "npm:7.1.2"],\
           ["package-json-from-dist", "npm:1.0.1"],\
           ["path-scurry", "npm:2.0.0"]\
@@ -16749,7 +16753,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/glob-npm-13.0.0-8e50143ca8-de390721d2.zip/node_modules/glob/",\
         "packageDependencies": [\
           ["glob", "npm:13.0.0"],\
-          ["minimatch", "npm:10.1.1"],\
+          ["minimatch", "npm:10.2.5"],\
           ["minipass", "npm:7.1.2"],\
           ["path-scurry", "npm:2.0.0"]\
         ],\
@@ -16762,7 +16766,7 @@ const RAW_RUNTIME_STATE =
           ["glob", "npm:7.1.7"],\
           ["inflight", "npm:1.0.6"],\
           ["inherits", "npm:2.0.4"],\
-          ["minimatch", "npm:3.1.2"],\
+          ["minimatch", "npm:3.1.5"],\
           ["once", "npm:1.4.0"],\
           ["path-is-absolute", "npm:1.0.1"]\
         ],\
@@ -16775,7 +16779,7 @@ const RAW_RUNTIME_STATE =
           ["glob", "npm:7.2.3"],\
           ["inflight", "npm:1.0.6"],\
           ["inherits", "npm:2.0.4"],\
-          ["minimatch", "npm:3.1.2"],\
+          ["minimatch", "npm:3.1.5"],\
           ["once", "npm:1.4.0"],\
           ["path-is-absolute", "npm:1.0.1"]\
         ],\
@@ -18623,7 +18627,7 @@ const RAW_RUNTIME_STATE =
           ["chalk", "npm:4.1.2"],\
           ["filelist", "npm:1.0.4"],\
           ["jake", "npm:10.8.5"],\
-          ["minimatch", "npm:3.1.2"]\
+          ["minimatch", "npm:3.1.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20345,19 +20349,11 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["minimatch", [\
-      ["npm:10.0.1", {\
-        "packageLocation": "./.yarn/cache/minimatch-npm-10.0.1-eabcc0d3a0-082e7ccbc0.zip/node_modules/minimatch/",\
+      ["npm:10.2.5", {\
+        "packageLocation": "./.yarn/cache/minimatch-npm-10.2.5-f1c8297822-19e87a931a.zip/node_modules/minimatch/",\
         "packageDependencies": [\
-          ["brace-expansion", "npm:2.0.1"],\
-          ["minimatch", "npm:10.0.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:10.1.1", {\
-        "packageLocation": "./.yarn/cache/minimatch-npm-10.1.1-453db4ee1a-110f38921e.zip/node_modules/minimatch/",\
-        "packageDependencies": [\
-          ["@isaacs/brace-expansion", "npm:5.0.1"],\
-          ["minimatch", "npm:10.1.1"]\
+          ["brace-expansion", "npm:5.0.7"],\
+          ["minimatch", "npm:10.2.5"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -20369,27 +20365,27 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:3.1.2", {\
-        "packageLocation": "./.yarn/cache/minimatch-npm-3.1.2-9405269906-e0b25b04cd.zip/node_modules/minimatch/",\
+      ["npm:3.1.5", {\
+        "packageLocation": "./.yarn/cache/minimatch-npm-3.1.5-86958baf50-b11a7ee577.zip/node_modules/minimatch/",\
         "packageDependencies": [\
           ["brace-expansion", "npm:1.1.11"],\
-          ["minimatch", "npm:3.1.2"]\
+          ["minimatch", "npm:3.1.5"]\
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:5.1.6", {\
-        "packageLocation": "./.yarn/cache/minimatch-npm-5.1.6-1e71429f4c-126b36485b.zip/node_modules/minimatch/",\
+      ["npm:5.1.9", {\
+        "packageLocation": "./.yarn/cache/minimatch-npm-5.1.9-fc73125478-23b4feb64d.zip/node_modules/minimatch/",\
         "packageDependencies": [\
           ["brace-expansion", "npm:2.0.1"],\
-          ["minimatch", "npm:5.1.6"]\
+          ["minimatch", "npm:5.1.9"]\
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:7.4.6", {\
-        "packageLocation": "./.yarn/cache/minimatch-npm-7.4.6-f3feee458c-0046ba1161.zip/node_modules/minimatch/",\
+      ["npm:7.4.9", {\
+        "packageLocation": "./.yarn/cache/minimatch-npm-7.4.9-ff5de02f7e-9bc60b593d.zip/node_modules/minimatch/",\
         "packageDependencies": [\
-          ["brace-expansion", "npm:2.0.1"],\
-          ["minimatch", "npm:7.4.6"]\
+          ["brace-expansion", "npm:2.1.2"],\
+          ["minimatch", "npm:7.4.9"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -20398,6 +20394,14 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["brace-expansion", "npm:2.0.1"],\
           ["minimatch", "npm:9.0.5"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:9.0.9", {\
+        "packageLocation": "./.yarn/cache/minimatch-npm-9.0.9-3ee8f15008-b91fad937d.zip/node_modules/minimatch/",\
+        "packageDependencies": [\
+          ["brace-expansion", "npm:2.1.2"],\
+          ["minimatch", "npm:9.0.9"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20605,7 +20609,7 @@ const RAW_RUNTIME_STATE =
           ["array-differ", "npm:3.0.0"],\
           ["array-union", "npm:2.1.0"],\
           ["arrify", "npm:2.0.1"],\
-          ["minimatch", "npm:3.1.2"],\
+          ["minimatch", "npm:3.1.5"],\
           ["multimatch", "npm:5.0.0"]\
         ],\
         "linkType": "HARD"\
@@ -21006,7 +21010,7 @@ const RAW_RUNTIME_STATE =
           ["chokidar", "npm:3.5.3"],\
           ["debug", "virtual:2fea8f7bf934d589dd2afccb55bdd68145a88b9aa55a29410057bbb8228035ad3d548659b5b68d9a9ac84d437a7692cb2fa244c9ab467fa2df8198a52edaac16#npm:3.2.7"],\
           ["ignore-by-default", "npm:1.0.1"],\
-          ["minimatch", "npm:3.1.2"],\
+          ["minimatch", "npm:3.1.5"],\
           ["nodemon", "npm:2.0.20"],\
           ["pstree.remy", "npm:1.1.8"],\
           ["semver", "npm:5.7.2"],\
@@ -23041,7 +23045,7 @@ const RAW_RUNTIME_STATE =
       ["npm:1.0.0", {\
         "packageLocation": "./.yarn/cache/readdir-glob-npm-1.0.0-ff4217e184-47b5fd16ac.zip/node_modules/readdir-glob/",\
         "packageDependencies": [\
-          ["minimatch", "npm:3.1.2"],\
+          ["minimatch", "npm:3.1.5"],\
           ["readdir-glob", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
@@ -25360,7 +25364,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@istanbuljs/schema", "npm:0.1.2"],\
           ["glob", "npm:7.2.3"],\
-          ["minimatch", "npm:3.1.2"],\
+          ["minimatch", "npm:3.1.5"],\
           ["test-exclude", "npm:6.0.0"]\
         ],\
         "linkType": "HARD"\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -20897,7 +20897,7 @@ const RAW_RUNTIME_STATE =
           ["@sinonjs/text-encoding", "npm:0.7.3"],\
           ["just-extend", "npm:6.2.0"],\
           ["nise", "npm:6.1.1"],\
-          ["path-to-regexp", "npm:8.3.0"]\
+          ["path-to-regexp", "npm:8.4.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -21671,10 +21671,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:8.3.0", {\
-        "packageLocation": "./.yarn/cache/path-to-regexp-npm-8.3.0-ef82f1008e-568f148fc6.zip/node_modules/path-to-regexp/",\
+      ["npm:8.4.2", {\
+        "packageLocation": "./.yarn/cache/path-to-regexp-npm-8.4.2-5602ed344b-70fd2cbce0.zip/node_modules/path-to-regexp/",\
         "packageDependencies": [\
-          ["path-to-regexp", "npm:8.3.0"]\
+          ["path-to-regexp", "npm:8.4.2"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -644,7 +644,7 @@ const RAW_RUNTIME_STATE =
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
           ["concurrently", "npm:7.3.0"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["root", "workspace:."],\
           ["syncpack", "npm:13.0.0"],\
           ["ts-node", "virtual:36a01d8083315b8a6e8362097258ea8bc0f9dfb672cb210742e054760850c673a1038f542a6b7156397b5275ace8ee0482231cac5e8898044fa1a1c29f78ee5b#npm:10.9.2"],\
@@ -4302,7 +4302,7 @@ const RAW_RUNTIME_STATE =
           ["fs-extra", "npm:11.2.0"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["rimraf", "npm:6.1.2"],\
-          ["semver", "npm:7.7.3"],\
+          ["semver", "npm:7.8.5"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
           ["uuid", "npm:11.0.5"]\
         ],\
@@ -4362,7 +4362,7 @@ const RAW_RUNTIME_STATE =
           ["@types/node", "npm:25.0.3"],\
           ["concurrently", "npm:7.3.0"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["reload", "npm:3.2.0"],\
           ["rimraf", "npm:6.1.2"],\
           ["ts-node", "virtual:a34d84b0830629706aa9f76341297032dfb316ac3c299bd43f58151c418314121b45f20e804b8bb0cc0046b94a8edd894244aa7537ab33ff98a1f1df12148e98#npm:10.9.2"],\
@@ -4385,7 +4385,7 @@ const RAW_RUNTIME_STATE =
           ["@types/node", "npm:25.0.3"],\
           ["concurrently", "npm:7.3.0"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["rimraf", "npm:6.1.2"],\
           ["ts-node", "virtual:a34d84b0830629706aa9f76341297032dfb316ac3c299bd43f58151c418314121b45f20e804b8bb0cc0046b94a8edd894244aa7537ab33ff98a1f1df12148e98#npm:10.9.2"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
@@ -5086,7 +5086,7 @@ const RAW_RUNTIME_STATE =
           ["fs-extra", "npm:11.2.0"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["rimraf", "npm:6.1.2"],\
-          ["semver", "npm:7.7.3"],\
+          ["semver", "npm:7.8.5"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
           ["uuid", "npm:11.0.5"]\
         ],\
@@ -5148,7 +5148,7 @@ const RAW_RUNTIME_STATE =
           ["@swc/core", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:1.15.8"],\
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["rimraf", "npm:6.1.2"],\
           ["ts-node", "virtual:f9142006202e84442d97960bffe1f194e2429cf8062d0c28268d7fd2f85865329bb070ab3bec3c6b72a4d8b89dd542ffd3284cb82516c4681ee8c29cae609f04#npm:10.9.2"]\
         ],\
@@ -6002,7 +6002,7 @@ const RAW_RUNTIME_STATE =
           ["fs-extra", "npm:11.2.0"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["rimraf", "npm:6.1.2"],\
-          ["semver", "npm:7.7.3"],\
+          ["semver", "npm:7.8.5"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
         ],\
         "linkType": "SOFT"\
@@ -8115,7 +8115,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@gar/promisify", "npm:1.1.3"],\
           ["@npmcli/fs", "npm:2.1.0"],\
-          ["semver", "npm:7.7.3"]\
+          ["semver", "npm:7.8.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -11977,7 +11977,7 @@ const RAW_RUNTIME_STATE =
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
           ["apps", "workspace:workspaces/apps"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["react", "npm:19.2.3"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
         ],\
@@ -14343,19 +14343,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:2fea8f7bf934d589dd2afccb55bdd68145a88b9aa55a29410057bbb8228035ad3d548659b5b68d9a9ac84d437a7692cb2fa244c9ab467fa2df8198a52edaac16#npm:3.2.7", {\
-        "packageLocation": "./.yarn/__virtual__/debug-virtual-59668cc157/0/cache/debug-npm-3.2.7-754e818c7a-d86fd7be2b.zip/node_modules/debug/",\
+      ["npm:4.4.3", {\
+        "packageLocation": "./.yarn/cache/debug-npm-4.4.3-0105c6123a-9ada3434ea.zip/node_modules/debug/",\
         "packageDependencies": [\
-          ["@types/supports-color", null],\
-          ["debug", "virtual:2fea8f7bf934d589dd2afccb55bdd68145a88b9aa55a29410057bbb8228035ad3d548659b5b68d9a9ac84d437a7692cb2fa244c9ab467fa2df8198a52edaac16#npm:3.2.7"],\
-          ["ms", "npm:2.1.2"],\
-          ["supports-color", "npm:5.5.0"]\
+          ["debug", "npm:4.4.3"]\
         ],\
-        "packagePeers": [\
-          "@types/supports-color",\
-          "supports-color"\
-        ],\
-        "linkType": "HARD"\
+        "linkType": "SOFT"\
       }],\
       ["virtual:3d605855b6d3d7eafd6eb5da331a216b7cc7ce7f73ae41f045460c895430bc3047336a53df4f4b3df05785b1b909917bd50bab97736ed695443f6fb65c923513#npm:4.3.4", {\
         "packageLocation": "./.yarn/__virtual__/debug-virtual-85380acbcd/0/cache/debug-npm-4.3.4-4513954577-0073c3bcbd.zip/node_modules/debug/",\
@@ -14380,6 +14373,20 @@ const RAW_RUNTIME_STATE =
         ],\
         "packagePeers": [\
           "@types/supports-color"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:58ccc9ac245a39eeec160ecda6f112d7ef0ddf9c7f8cfea2e2aceaea55ec9940ab3f8b3bf1e3152f49bc6f7b9ed1ecde5638b22c54edf74c709936ced24c14f4#npm:4.4.3", {\
+        "packageLocation": "./.yarn/__virtual__/debug-virtual-d78100f867/0/cache/debug-npm-4.4.3-0105c6123a-9ada3434ea.zip/node_modules/debug/",\
+        "packageDependencies": [\
+          ["@types/supports-color", null],\
+          ["debug", "virtual:58ccc9ac245a39eeec160ecda6f112d7ef0ddf9c7f8cfea2e2aceaea55ec9940ab3f8b3bf1e3152f49bc6f7b9ed1ecde5638b22c54edf74c709936ced24c14f4#npm:4.4.3"],\
+          ["ms", "npm:2.1.3"],\
+          ["supports-color", "npm:5.5.0"]\
+        ],\
+        "packagePeers": [\
+          "@types/supports-color",\
+          "supports-color"\
         ],\
         "linkType": "HARD"\
       }],\
@@ -14595,7 +14602,7 @@ const RAW_RUNTIME_STATE =
           ["require-package-name", "npm:2.0.1"],\
           ["resolve", "patch:resolve@npm%3A1.22.9#optional!builtin<compat/resolve>::version=1.22.9&hash=c3c19d"],\
           ["resolve-from", "npm:5.0.0"],\
-          ["semver", "npm:7.7.3"],\
+          ["semver", "npm:7.8.5"],\
           ["yargs", "npm:16.2.0"]\
         ],\
         "linkType": "HARD"\
@@ -14782,7 +14789,7 @@ const RAW_RUNTIME_STATE =
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
           ["docs", "workspace:workspaces/docs"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["react", "npm:19.2.3"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
         ],\
@@ -15769,7 +15776,7 @@ const RAW_RUNTIME_STATE =
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
           ["examples", "workspace:workspaces/examples"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["react", "npm:19.2.3"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
         ],\
@@ -18549,7 +18556,7 @@ const RAW_RUNTIME_STATE =
           ["@istanbuljs/schema", "npm:0.1.3"],\
           ["istanbul-lib-coverage", "npm:3.2.0"],\
           ["istanbul-lib-instrument", "npm:6.0.3"],\
-          ["semver", "npm:7.7.3"]\
+          ["semver", "npm:7.8.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -19164,7 +19171,7 @@ const RAW_RUNTIME_STATE =
           ["jest-snapshot", "npm:30.2.0"],\
           ["jest-util", "npm:30.2.0"],\
           ["pretty-format", "npm:30.2.0"],\
-          ["semver", "npm:7.7.3"],\
+          ["semver", "npm:7.8.5"],\
           ["synckit", "npm:0.11.11"]\
         ],\
         "linkType": "HARD"\
@@ -20969,7 +20976,7 @@ const RAW_RUNTIME_STATE =
           ["nopt", "npm:5.0.0"],\
           ["npmlog", "npm:6.0.1"],\
           ["rimraf", "npm:3.0.2"],\
-          ["semver", "npm:7.7.3"],\
+          ["semver", "npm:7.8.5"],\
           ["tar", "npm:6.2.1"],\
           ["which", "npm:2.0.2"]\
         ],\
@@ -21004,17 +21011,17 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["nodemon", [\
-      ["npm:2.0.20", {\
-        "packageLocation": "./.yarn/unplugged/nodemon-npm-2.0.20-2fea8f7bf9/node_modules/nodemon/",\
+      ["npm:3.1.14", {\
+        "packageLocation": "./.yarn/unplugged/nodemon-npm-3.1.14-58ccc9ac24/node_modules/nodemon/",\
         "packageDependencies": [\
           ["chokidar", "npm:3.5.3"],\
-          ["debug", "virtual:2fea8f7bf934d589dd2afccb55bdd68145a88b9aa55a29410057bbb8228035ad3d548659b5b68d9a9ac84d437a7692cb2fa244c9ab467fa2df8198a52edaac16#npm:3.2.7"],\
+          ["debug", "virtual:58ccc9ac245a39eeec160ecda6f112d7ef0ddf9c7f8cfea2e2aceaea55ec9940ab3f8b3bf1e3152f49bc6f7b9ed1ecde5638b22c54edf74c709936ced24c14f4#npm:4.4.3"],\
           ["ignore-by-default", "npm:1.0.1"],\
-          ["minimatch", "npm:3.1.5"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["minimatch", "npm:10.2.5"],\
+          ["nodemon", "npm:3.1.14"],\
           ["pstree.remy", "npm:1.1.8"],\
-          ["semver", "npm:5.7.2"],\
-          ["simple-update-notifier", "npm:1.0.7"],\
+          ["semver", "npm:7.8.5"],\
+          ["simple-update-notifier", "npm:2.0.0"],\
           ["supports-color", "npm:5.5.0"],\
           ["touch", "npm:3.1.0"],\
           ["undefsafe", "npm:2.0.5"]\
@@ -21075,7 +21082,7 @@ const RAW_RUNTIME_STATE =
           ["hosted-git-info", "npm:7.0.2"],\
           ["npm-package-arg", "npm:11.0.3"],\
           ["proc-log", "npm:4.2.0"],\
-          ["semver", "npm:7.7.3"],\
+          ["semver", "npm:7.8.5"],\
           ["validate-npm-package-name", "npm:5.0.1"]\
         ],\
         "linkType": "HARD"\
@@ -23535,7 +23542,7 @@ const RAW_RUNTIME_STATE =
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
           ["concurrently", "npm:7.3.0"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["root", "workspace:."],\
           ["syncpack", "npm:13.0.0"],\
           ["ts-node", "virtual:36a01d8083315b8a6e8362097258ea8bc0f9dfb672cb210742e054760850c673a1038f542a6b7156397b5275ace8ee0482231cac5e8898044fa1a1c29f78ee5b#npm:10.9.2"],\
@@ -23788,13 +23795,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:7.0.0", {\
-        "packageLocation": "./.yarn/cache/semver-npm-7.0.0-218e8c00ca-be264384c7.zip/node_modules/semver/",\
-        "packageDependencies": [\
-          ["semver", "npm:7.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:7.5.4", {\
         "packageLocation": "./.yarn/cache/semver-npm-7.5.4-c4ad957fcd-985dec0d37.zip/node_modules/semver/",\
         "packageDependencies": [\
@@ -23810,10 +23810,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:7.7.3", {\
-        "packageLocation": "./.yarn/cache/semver-npm-7.7.3-9cf7b3b46c-8dbc3168e0.zip/node_modules/semver/",\
+      ["npm:7.8.5", {\
+        "packageLocation": "./.yarn/cache/semver-npm-7.8.5-785968bbf9-9b01d2ff11.zip/node_modules/semver/",\
         "packageDependencies": [\
-          ["semver", "npm:7.7.3"]\
+          ["semver", "npm:7.8.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -24012,7 +24012,7 @@ const RAW_RUNTIME_STATE =
           ["@img/sharp-win32-x64", "npm:0.34.3"],\
           ["color", "npm:4.2.3"],\
           ["detect-libc", "npm:2.0.4"],\
-          ["semver", "npm:7.7.3"],\
+          ["semver", "npm:7.8.5"],\
           ["sharp", "npm:0.34.3"]\
         ],\
         "linkType": "HARD"\
@@ -24145,11 +24145,11 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["simple-update-notifier", [\
-      ["npm:1.0.7", {\
-        "packageLocation": "./.yarn/cache/simple-update-notifier-npm-1.0.7-c27b0a20ac-a0cee9f934.zip/node_modules/simple-update-notifier/",\
+      ["npm:2.0.0", {\
+        "packageLocation": "./.yarn/cache/simple-update-notifier-npm-2.0.0-4d6e5dba61-40bd4f96aa.zip/node_modules/simple-update-notifier/",\
         "packageDependencies": [\
-          ["semver", "npm:7.0.0"],\
-          ["simple-update-notifier", "npm:1.0.7"]\
+          ["semver", "npm:7.8.5"],\
+          ["simple-update-notifier", "npm:2.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -24253,7 +24253,7 @@ const RAW_RUNTIME_STATE =
           ["detect-newline", "npm:4.0.1"],\
           ["git-hooks-list", "npm:4.1.1"],\
           ["is-plain-obj", "npm:4.1.0"],\
-          ["semver", "npm:7.7.3"],\
+          ["semver", "npm:7.8.5"],\
           ["sort-object-keys", "npm:1.1.3"],\
           ["sort-package-json", "npm:3.4.0"],\
           ["tinyglobby", "npm:0.2.14"]\
@@ -25316,7 +25316,7 @@ const RAW_RUNTIME_STATE =
           ["@goldstack/utils-typescript-references", "workspace:workspaces/utils/packages/utils-typescript-references"],\
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["react", "npm:19.2.3"],\
           ["react-dom", "virtual:ed760a7c34979744c62e060773792c390ba8edd578a7ed312bba63b32e173f52532466f44fc6a74d8bdc7491e8b60ebb2aca10f5c122f0482340b1612cd02e70#npm:19.2.3"],\
           ["templates", "workspace:workspaces/templates"],\
@@ -25333,7 +25333,7 @@ const RAW_RUNTIME_STATE =
           ["@goldstack/utils-typescript-references", "workspace:workspaces/utils/packages/utils-typescript-references"],\
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["react", "npm:19.2.3"],\
           ["templates-lib", "workspace:workspaces/templates-lib"],\
           ["ts-node", "virtual:36a01d8083315b8a6e8362097258ea8bc0f9dfb672cb210742e054760850c673a1038f542a6b7156397b5275ace8ee0482231cac5e8898044fa1a1c29f78ee5b#npm:10.9.2"],\
@@ -25350,7 +25350,7 @@ const RAW_RUNTIME_STATE =
           ["@goldstack/utils-typescript-references", "workspace:workspaces/utils/packages/utils-typescript-references"],\
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["react", "npm:19.2.3"],\
           ["templates-management", "workspace:workspaces/templates-management"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
@@ -26549,7 +26549,7 @@ const RAW_RUNTIME_STATE =
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
           ["@types/rimraf", "npm:4.0.5"],\
-          ["nodemon", "npm:2.0.20"],\
+          ["nodemon", "npm:3.1.14"],\
           ["react", "npm:19.2.3"],\
           ["ts-node", "virtual:36a01d8083315b8a6e8362097258ea8bc0f9dfb672cb210742e054760850c673a1038f542a6b7156397b5275ace8ee0482231cac5e8898044fa1a1c29f78ee5b#npm:10.9.2"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -16121,7 +16121,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@types/picomatch", null],\
           ["fdir", "virtual:d4e4bcf80e67f9de0540c123c7c4882e34dce6a8ba807a0a834f267f9132ee6bd264e69a49c6203aa89877ed3a5a5d633bfa002384881be452cc3a2d2fbcce0b#npm:6.4.6"],\
-          ["picomatch", "npm:4.0.2"]\
+          ["picomatch", "npm:4.0.5"]\
         ],\
         "packagePeers": [\
           "@types/picomatch",\
@@ -19198,7 +19198,7 @@ const RAW_RUNTIME_STATE =
           ["ci-info", "npm:4.3.0"],\
           ["graceful-fs", "npm:4.2.11"],\
           ["jest-util", "npm:30.2.0"],\
-          ["picomatch", "npm:4.0.2"]\
+          ["picomatch", "npm:4.0.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -21737,10 +21737,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:4.0.2", {\
-        "packageLocation": "./.yarn/cache/picomatch-npm-4.0.2-e93516ddf2-ce617b8da3.zip/node_modules/picomatch/",\
+      ["npm:4.0.5", {\
+        "packageLocation": "./.yarn/cache/picomatch-npm-4.0.5-bb8e0de0f7-8bad770af9.zip/node_modules/picomatch/",\
         "packageDependencies": [\
-          ["picomatch", "npm:4.0.2"]\
+          ["picomatch", "npm:4.0.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -25471,7 +25471,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/tinyglobby-npm-0.2.14-d4e4bcf80e-3d306d3197.zip/node_modules/tinyglobby/",\
         "packageDependencies": [\
           ["fdir", "virtual:d4e4bcf80e67f9de0540c123c7c4882e34dce6a8ba807a0a834f267f9132ee6bd264e69a49c6203aa89877ed3a5a5d633bfa002384881be452cc3a2d2fbcce0b#npm:6.4.6"],\
-          ["picomatch", "npm:4.0.2"],\
+          ["picomatch", "npm:4.0.5"],\
           ["tinyglobby", "npm:0.2.14"]\
         ],\
         "linkType": "HARD"\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -4193,7 +4193,7 @@ const RAW_RUNTIME_STATE =
           ["react", "npm:19.2.3"],\
           ["react-dom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:19.2.3"],\
           ["react-is", "npm:19.2.1"],\
-          ["reload", "npm:3.2.0"],\
+          ["reload", "npm:3.4.3"],\
           ["rimraf", "npm:6.1.2"],\
           ["svg-url-loader", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:8.0.0"],\
           ["swr", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:0.4.0"],\
@@ -4231,7 +4231,7 @@ const RAW_RUNTIME_STATE =
           ["react-bootstrap", "virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:2.10.10"],\
           ["react-dom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:19.2.3"],\
           ["react-is", "npm:19.2.1"],\
-          ["reload", "npm:3.2.0"],\
+          ["reload", "npm:3.4.3"],\
           ["rimraf", "npm:6.1.2"],\
           ["sass", "npm:1.89.2"],\
           ["svg-url-loader", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:8.0.0"],\
@@ -4271,7 +4271,7 @@ const RAW_RUNTIME_STATE =
           ["react", "npm:19.2.3"],\
           ["react-dom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:19.2.3"],\
           ["react-is", "npm:19.2.1"],\
-          ["reload", "npm:3.2.0"],\
+          ["reload", "npm:3.4.3"],\
           ["rimraf", "npm:6.1.2"],\
           ["svg-url-loader", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:8.0.0"],\
           ["swr", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:0.4.0"],\
@@ -4363,7 +4363,7 @@ const RAW_RUNTIME_STATE =
           ["concurrently", "npm:7.3.0"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["nodemon", "npm:3.1.14"],\
-          ["reload", "npm:3.2.0"],\
+          ["reload", "npm:3.4.3"],\
           ["rimraf", "npm:6.1.2"],\
           ["ts-node", "virtual:a34d84b0830629706aa9f76341297032dfb316ac3c299bd43f58151c418314121b45f20e804b8bb0cc0046b94a8edd894244aa7537ab33ff98a1f1df12148e98#npm:10.9.2"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
@@ -4430,7 +4430,7 @@ const RAW_RUNTIME_STATE =
           ["react-bootstrap", "virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:2.10.10"],\
           ["react-dom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:19.2.3"],\
           ["react-is", "npm:19.2.1"],\
-          ["reload", "npm:3.2.0"],\
+          ["reload", "npm:3.4.3"],\
           ["rimraf", "npm:6.1.2"],\
           ["sass", "npm:1.89.2"],\
           ["styled-components", "virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:5.3.5"],\
@@ -5310,7 +5310,7 @@ const RAW_RUNTIME_STATE =
           ["gulp-replace", "npm:1.1.4"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["light-server", "npm:2.9.1"],\
-          ["reload", "npm:3.2.0"],\
+          ["reload", "npm:3.4.3"],\
           ["rimraf", "npm:6.1.2"],\
           ["ts-node", "virtual:a34d84b0830629706aa9f76341297032dfb316ac3c299bd43f58151c418314121b45f20e804b8bb0cc0046b94a8edd894244aa7537ab33ff98a1f1df12148e98#npm:10.9.2"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
@@ -12968,6 +12968,16 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["bundle-name", [\
+      ["npm:4.1.0", {\
+        "packageLocation": "./.yarn/cache/bundle-name-npm-4.1.0-4688335533-1d966c8d2d.zip/node_modules/bundle-name/",\
+        "packageDependencies": [\
+          ["bundle-name", "npm:4.1.0"],\
+          ["run-applescript", "npm:7.1.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["bytes", [\
       ["npm:3.1.2", {\
         "packageLocation": "./.yarn/cache/bytes-npm-3.1.2-28b8643004-a10abf2ba7.zip/node_modules/bytes/",\
@@ -13663,6 +13673,13 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
+      ["npm:14.0.3", {\
+        "packageLocation": "./.yarn/cache/commander-npm-14.0.3-93ab31471d-dfa9ebe2a4.zip/node_modules/commander/",\
+        "packageDependencies": [\
+          ["commander", "npm:14.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:4.1.1", {\
         "packageLocation": "./.yarn/cache/commander-npm-4.1.1-22a0fe921b-3b2dc4125f.zip/node_modules/commander/",\
         "packageDependencies": [\
@@ -13674,13 +13691,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/commander-npm-6.2.1-d5b635f237-25b88c2efd.zip/node_modules/commander/",\
         "packageDependencies": [\
           ["commander", "npm:6.2.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:7.2.0", {\
-        "packageLocation": "./.yarn/cache/commander-npm-7.2.0-19178180f8-9973af1072.zip/node_modules/commander/",\
-        "packageDependencies": [\
-          ["commander", "npm:7.2.0"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -14429,6 +14439,19 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
+      ["virtual:aff8faac6cfa670b253262cd878fc805b3a905c3e1119ac607fad95bea4ebce86be60530c6c5e01f6d002ab2e8e49c4eeabb5374cfd272f5bcfd6f734f703809#npm:4.4.3", {\
+        "packageLocation": "./.yarn/__virtual__/debug-virtual-46e645003a/0/cache/debug-npm-4.4.3-0105c6123a-9ada3434ea.zip/node_modules/debug/",\
+        "packageDependencies": [\
+          ["@types/supports-color", null],\
+          ["debug", "virtual:aff8faac6cfa670b253262cd878fc805b3a905c3e1119ac607fad95bea4ebce86be60530c6c5e01f6d002ab2e8e49c4eeabb5374cfd272f5bcfd6f734f703809#npm:4.4.3"],\
+          ["ms", "npm:2.1.3"],\
+          ["supports-color", "npm:9.0.1"]\
+        ],\
+        "packagePeers": [\
+          "@types/supports-color"\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["virtual:c7b184cd14c02e3ce555ab1875e60cf5033c617e17d82c4c02ea822101d3c817f48bf25a766b4d4335742dc5c9c14c2e88a57ed955a56c4ad0613899f82f5618#npm:2.6.9", {\
         "packageLocation": "./.yarn/__virtual__/debug-virtual-ce39f1817a/0/cache/debug-npm-2.6.9-7d4cb597dc-e07005f2b4.zip/node_modules/debug/",\
         "packageDependencies": [\
@@ -14521,11 +14544,38 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["default-browser", [\
+      ["npm:5.5.0", {\
+        "packageLocation": "./.yarn/cache/default-browser-npm-5.5.0-318b15cbba-c5c5d84a4a.zip/node_modules/default-browser/",\
+        "packageDependencies": [\
+          ["bundle-name", "npm:4.1.0"],\
+          ["default-browser", "npm:5.5.0"],\
+          ["default-browser-id", "npm:5.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["default-browser-id", [\
+      ["npm:5.0.1", {\
+        "packageLocation": "./.yarn/cache/default-browser-id-npm-5.0.1-f5b6cb1fde-52c637637b.zip/node_modules/default-browser-id/",\
+        "packageDependencies": [\
+          ["default-browser-id", "npm:5.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["define-lazy-prop", [\
       ["npm:2.0.0", {\
         "packageLocation": "./.yarn/cache/define-lazy-prop-npm-2.0.0-bba0cd91a7-0115fdb065.zip/node_modules/define-lazy-prop/",\
         "packageDependencies": [\
           ["define-lazy-prop", "npm:2.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/define-lazy-prop-npm-3.0.0-6bb0fc1510-f28421cf9e.zip/node_modules/define-lazy-prop/",\
+        "packageDependencies": [\
+          ["define-lazy-prop", "npm:3.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -16235,6 +16285,19 @@ const RAW_RUNTIME_STATE =
           ["unpipe", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.1.1", {\
+        "packageLocation": "./.yarn/cache/finalhandler-npm-2.1.1-aff8faac6c-f4ba75c234.zip/node_modules/finalhandler/",\
+        "packageDependencies": [\
+          ["debug", "virtual:aff8faac6cfa670b253262cd878fc805b3a905c3e1119ac607fad95bea4ebce86be60530c6c5e01f6d002ab2e8e49c4eeabb5374cfd272f5bcfd6f734f703809#npm:4.4.3"],\
+          ["encodeurl", "npm:2.0.0"],\
+          ["escape-html", "npm:1.0.3"],\
+          ["finalhandler", "npm:2.1.1"],\
+          ["on-finished", "npm:2.4.1"],\
+          ["parseurl", "npm:1.3.3"],\
+          ["statuses", "npm:2.0.2"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["find-replace", [\
@@ -16415,6 +16478,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/fresh-npm-0.5.2-ad2bb4c0a2-64c88e489b.zip/node_modules/fresh/",\
         "packageDependencies": [\
           ["fresh", "npm:0.5.2"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.0.0", {\
+        "packageLocation": "./.yarn/cache/fresh-npm-2.0.0-b0c1795dff-44e1468488.zip/node_modules/fresh/",\
+        "packageDependencies": [\
+          ["fresh", "npm:2.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -17547,6 +17617,18 @@ const RAW_RUNTIME_STATE =
           ["toidentifier", "npm:1.0.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.0.1", {\
+        "packageLocation": "./.yarn/cache/http-errors-npm-2.0.1-6d19ab492e-9fe31bc0ed.zip/node_modules/http-errors/",\
+        "packageDependencies": [\
+          ["depd", "npm:2.0.0"],\
+          ["http-errors", "npm:2.0.1"],\
+          ["inherits", "npm:2.0.4"],\
+          ["setprototypeof", "npm:1.2.0"],\
+          ["statuses", "npm:2.0.2"],\
+          ["toidentifier", "npm:1.0.1"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["http-proxy", [\
@@ -18102,6 +18184,13 @@ const RAW_RUNTIME_STATE =
           ["is-docker", "npm:2.2.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:3.0.0", {\
+        "packageLocation": "./.yarn/cache/is-docker-npm-3.0.0-1570e32177-b698118f04.zip/node_modules/is-docker/",\
+        "packageDependencies": [\
+          ["is-docker", "npm:3.0.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["is-extendable", [\
@@ -18181,6 +18270,25 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/is-hexadecimal-npm-1.0.4-b4091da09e-a452e04758.zip/node_modules/is-hexadecimal/",\
         "packageDependencies": [\
           ["is-hexadecimal", "npm:1.0.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["is-in-ssh", [\
+      ["npm:1.0.0", {\
+        "packageLocation": "./.yarn/cache/is-in-ssh-npm-1.0.0-d72be5b7c8-d55cb39afd.zip/node_modules/is-in-ssh/",\
+        "packageDependencies": [\
+          ["is-in-ssh", "npm:1.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["is-inside-container", [\
+      ["npm:1.0.0", {\
+        "packageLocation": "./.yarn/cache/is-inside-container-npm-1.0.0-f2c9e9bb96-c50b75a2ab.zip/node_modules/is-inside-container/",\
+        "packageDependencies": [\
+          ["is-docker", "npm:3.0.0"],\
+          ["is-inside-container", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -18476,6 +18584,14 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["is-docker", "npm:2.1.1"],\
           ["is-wsl", "npm:2.2.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:3.1.1", {\
+        "packageLocation": "./.yarn/cache/is-wsl-npm-3.1.1-6334502662-513d95b89a.zip/node_modules/is-wsl/",\
+        "packageDependencies": [\
+          ["is-inside-container", "npm:1.0.0"],\
+          ["is-wsl", "npm:3.1.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20308,6 +20424,13 @@ const RAW_RUNTIME_STATE =
           ["mime-db", "npm:1.52.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:1.54.0", {\
+        "packageLocation": "./.yarn/cache/mime-db-npm-1.54.0-82cccb9d70-9e7834be3d.zip/node_modules/mime-db/",\
+        "packageDependencies": [\
+          ["mime-db", "npm:1.54.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["mime-types", [\
@@ -20324,6 +20447,14 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["mime-db", "npm:1.52.0"],\
           ["mime-types", "npm:2.1.35"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:3.0.2", {\
+        "packageLocation": "./.yarn/cache/mime-types-npm-3.0.2-d6d24e27e8-9db0ad31f5.zip/node_modules/mime-types/",\
+        "packageDependencies": [\
+          ["mime-db", "npm:1.54.0"],\
+          ["mime-types", "npm:3.0.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -21298,13 +21429,16 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["open", [\
-      ["npm:8.2.1", {\
-        "packageLocation": "./.yarn/unplugged/open-npm-8.2.1-f135ffeb36/node_modules/open/",\
+      ["npm:11.0.0", {\
+        "packageLocation": "./.yarn/unplugged/open-npm-11.0.0-f702975017/node_modules/open/",\
         "packageDependencies": [\
-          ["define-lazy-prop", "npm:2.0.0"],\
-          ["is-docker", "npm:2.2.1"],\
-          ["is-wsl", "npm:2.2.0"],\
-          ["open", "npm:8.2.1"]\
+          ["default-browser", "npm:5.5.0"],\
+          ["define-lazy-prop", "npm:3.0.0"],\
+          ["is-in-ssh", "npm:1.0.0"],\
+          ["is-inside-container", "npm:1.0.0"],\
+          ["open", "npm:11.0.0"],\
+          ["powershell-utils", "npm:0.1.0"],\
+          ["wsl-utils", "npm:0.3.1"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -22346,6 +22480,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["powershell-utils", [\
+      ["npm:0.1.0", {\
+        "packageLocation": "./.yarn/cache/powershell-utils-npm-0.1.0-bce5e820f1-4cc0846bc9.zip/node_modules/powershell-utils/",\
+        "packageDependencies": [\
+          ["powershell-utils", "npm:0.1.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["prettier", [\
       ["npm:2.0.5", {\
         "packageLocation": "./.yarn/cache/prettier-npm-2.0.5-f0ee4e15ce-62e58e8b7a.zip/node_modules/prettier/",\
@@ -22719,6 +22862,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/range-parser-npm-1.2.1-1a470fa390-ce21ef2a2d.zip/node_modules/range-parser/",\
         "packageDependencies": [\
           ["range-parser", "npm:1.2.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:1.3.0", {\
+        "packageLocation": "./.yarn/cache/range-parser-npm-1.3.0-b4bc01b3e0-f0b7a34de6.zip/node_modules/range-parser/",\
+        "packageDependencies": [\
+          ["range-parser", "npm:1.3.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -23187,19 +23337,18 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["reload", [\
-      ["npm:3.2.0", {\
-        "packageLocation": "./.yarn/cache/reload-npm-3.2.0-260f1e95cd-3d56a4e252.zip/node_modules/reload/",\
+      ["npm:3.4.3", {\
+        "packageLocation": "./.yarn/cache/reload-npm-3.4.3-32debc8791-e199dabc2c.zip/node_modules/reload/",\
         "packageDependencies": [\
           ["cli-color", "npm:2.0.0"],\
-          ["commander", "npm:7.2.0"],\
-          ["finalhandler", "npm:1.1.2"],\
+          ["commander", "npm:14.0.3"],\
+          ["finalhandler", "npm:2.1.1"],\
           ["minimist", "npm:1.2.6"],\
-          ["open", "npm:8.2.1"],\
-          ["reload", "npm:3.2.0"],\
-          ["serve-static", "npm:1.14.2"],\
-          ["supervisor", "npm:0.12.0"],\
-          ["url-parse", "npm:1.5.10"],\
-          ["ws", "virtual:260f1e95cdc11dd5eb865368cfef0da76e26bafb4c72505a7c060b3d20e535c421be2aa4ca07e120887f1f68049834741fa151b2ae5c309c32beaf634a7f48a3#npm:7.4.6"]\
+          ["nodemon", "npm:3.1.14"],\
+          ["open", "npm:11.0.0"],\
+          ["reload", "npm:3.4.3"],\
+          ["serve-static", "npm:2.2.1"],\
+          ["ws", "virtual:32debc8791018e4db38b12247de9cdec4eb85c647f0a812416c2deee6e029653469be7818a592a92973a0dfbcffc1c641508f5fc882b8b10ae647690f918ba6a#npm:8.19.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -23567,6 +23716,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["run-applescript", [\
+      ["npm:7.1.0", {\
+        "packageLocation": "./.yarn/cache/run-applescript-npm-7.1.0-2799ad8fdb-8659fb5f27.zip/node_modules/run-applescript/",\
+        "packageDependencies": [\
+          ["run-applescript", "npm:7.1.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["run-parallel", [\
       ["npm:1.1.9", {\
         "packageLocation": "./.yarn/cache/run-parallel-npm-1.1.9-83c6b2d620-8bbeda89c2.zip/node_modules/run-parallel/",\
@@ -23897,6 +24055,24 @@ const RAW_RUNTIME_STATE =
           ["statuses", "npm:2.0.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:1.2.1", {\
+        "packageLocation": "./.yarn/cache/send-npm-1.2.1-6d273646b4-274f842d69.zip/node_modules/send/",\
+        "packageDependencies": [\
+          ["debug", "virtual:aff8faac6cfa670b253262cd878fc805b3a905c3e1119ac607fad95bea4ebce86be60530c6c5e01f6d002ab2e8e49c4eeabb5374cfd272f5bcfd6f734f703809#npm:4.4.3"],\
+          ["encodeurl", "npm:2.0.0"],\
+          ["escape-html", "npm:1.0.3"],\
+          ["etag", "npm:1.8.1"],\
+          ["fresh", "npm:2.0.0"],\
+          ["http-errors", "npm:2.0.1"],\
+          ["mime-types", "npm:3.0.2"],\
+          ["ms", "npm:2.1.3"],\
+          ["on-finished", "npm:2.4.1"],\
+          ["range-parser", "npm:1.3.0"],\
+          ["send", "npm:1.2.1"],\
+          ["statuses", "npm:2.0.2"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["serve-index", [\
@@ -23935,6 +24111,17 @@ const RAW_RUNTIME_STATE =
           ["parseurl", "npm:1.3.3"],\
           ["send", "npm:0.18.0"],\
           ["serve-static", "npm:1.16.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.2.1", {\
+        "packageLocation": "./.yarn/cache/serve-static-npm-2.2.1-14d79c9d45-71500fe80c.zip/node_modules/serve-static/",\
+        "packageDependencies": [\
+          ["encodeurl", "npm:2.0.0"],\
+          ["escape-html", "npm:1.0.3"],\
+          ["parseurl", "npm:1.3.3"],\
+          ["send", "npm:1.2.1"],\
+          ["serve-static", "npm:2.2.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -24520,6 +24707,13 @@ const RAW_RUNTIME_STATE =
           ["statuses", "npm:2.0.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.0.2", {\
+        "packageLocation": "./.yarn/cache/statuses-npm-2.0.2-2d84c63b8c-6927feb50c.zip/node_modules/statuses/",\
+        "packageDependencies": [\
+          ["statuses", "npm:2.0.2"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["stdin", [\
@@ -25021,15 +25215,6 @@ const RAW_RUNTIME_STATE =
         "packagePeers": [\
           "@types/supertest",\
           "supertest"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["supervisor", [\
-      ["npm:0.12.0", {\
-        "packageLocation": "./.yarn/cache/supervisor-npm-0.12.0-86eb2f0732-5cfd3256a9.zip/node_modules/supervisor/",\
-        "packageDependencies": [\
-          ["supervisor", "npm:0.12.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -27070,17 +27255,17 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["ws", [\
-      ["npm:7.4.6", {\
-        "packageLocation": "./.yarn/cache/ws-npm-7.4.6-9c9a725604-150e3f917b.zip/node_modules/ws/",\
-        "packageDependencies": [\
-          ["ws", "npm:7.4.6"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
       ["npm:7.5.11", {\
         "packageLocation": "./.yarn/cache/ws-npm-7.5.11-420a347b21-486141e4a0.zip/node_modules/ws/",\
         "packageDependencies": [\
           ["ws", "npm:7.5.11"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["npm:8.19.0", {\
+        "packageLocation": "./.yarn/cache/ws-npm-8.19.0-c967c046a5-26e4901e93.zip/node_modules/ws/",\
+        "packageDependencies": [\
+          ["ws", "npm:8.19.0"]\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -27091,14 +27276,14 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:260f1e95cdc11dd5eb865368cfef0da76e26bafb4c72505a7c060b3d20e535c421be2aa4ca07e120887f1f68049834741fa151b2ae5c309c32beaf634a7f48a3#npm:7.4.6", {\
-        "packageLocation": "./.yarn/__virtual__/ws-virtual-6c9edca8af/0/cache/ws-npm-7.4.6-9c9a725604-150e3f917b.zip/node_modules/ws/",\
+      ["virtual:32debc8791018e4db38b12247de9cdec4eb85c647f0a812416c2deee6e029653469be7818a592a92973a0dfbcffc1c641508f5fc882b8b10ae647690f918ba6a#npm:8.19.0", {\
+        "packageLocation": "./.yarn/__virtual__/ws-virtual-799d18acfb/0/cache/ws-npm-8.19.0-c967c046a5-26e4901e93.zip/node_modules/ws/",\
         "packageDependencies": [\
           ["@types/bufferutil", null],\
           ["@types/utf-8-validate", null],\
           ["bufferutil", null],\
           ["utf-8-validate", null],\
-          ["ws", "virtual:260f1e95cdc11dd5eb865368cfef0da76e26bafb4c72505a7c060b3d20e535c421be2aa4ca07e120887f1f68049834741fa151b2ae5c309c32beaf634a7f48a3#npm:7.4.6"]\
+          ["ws", "virtual:32debc8791018e4db38b12247de9cdec4eb85c647f0a812416c2deee6e029653469be7818a592a92973a0dfbcffc1c641508f5fc882b8b10ae647690f918ba6a#npm:8.19.0"]\
         ],\
         "packagePeers": [\
           "@types/bufferutil",\
@@ -27139,6 +27324,17 @@ const RAW_RUNTIME_STATE =
           "@types/utf-8-validate",\
           "bufferutil",\
           "utf-8-validate"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["wsl-utils", [\
+      ["npm:0.3.1", {\
+        "packageLocation": "./.yarn/cache/wsl-utils-npm-0.3.1-a4942ec282-46800b92fa.zip/node_modules/wsl-utils/",\
+        "packageDependencies": [\
+          ["is-wsl", "npm:3.1.1"],\
+          ["powershell-utils", "npm:0.1.0"],\
+          ["wsl-utils", "npm:0.3.1"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -19372,7 +19372,7 @@ const RAW_RUNTIME_STATE =
           ["whatwg-encoding", "npm:3.1.1"],\
           ["whatwg-mimetype", "npm:4.0.0"],\
           ["whatwg-url", "npm:14.2.0"],\
-          ["ws", "virtual:735549f69b21bf4741af789727997d0b27b7da3a44b744bf0c6b18abd356696f34e7a0c5d8c928bb0e47b8561d2bd31a64ce367444d30f5af710507379030607#npm:8.19.0"],\
+          ["ws", "virtual:735549f69b21bf4741af789727997d0b27b7da3a44b744bf0c6b18abd356696f34e7a0c5d8c928bb0e47b8561d2bd31a64ce367444d30f5af710507379030607#npm:8.21.0"],\
           ["xml-name-validator", "npm:5.0.0"]\
         ],\
         "packagePeers": [\
@@ -19411,7 +19411,7 @@ const RAW_RUNTIME_STATE =
           ["whatwg-encoding", "npm:2.0.0"],\
           ["whatwg-mimetype", "npm:3.0.0"],\
           ["whatwg-url", "npm:12.0.1"],\
-          ["ws", "virtual:735549f69b21bf4741af789727997d0b27b7da3a44b744bf0c6b18abd356696f34e7a0c5d8c928bb0e47b8561d2bd31a64ce367444d30f5af710507379030607#npm:8.19.0"],\
+          ["ws", "virtual:735549f69b21bf4741af789727997d0b27b7da3a44b744bf0c6b18abd356696f34e7a0c5d8c928bb0e47b8561d2bd31a64ce367444d30f5af710507379030607#npm:8.21.0"],\
           ["xml-name-validator", "npm:4.0.0"]\
         ],\
         "packagePeers": [\
@@ -19742,7 +19742,7 @@ const RAW_RUNTIME_STATE =
           ["serve-static", "npm:1.14.2"],\
           ["spdy", "npm:4.0.2"],\
           ["strip-json-comments", "npm:3.1.1"],\
-          ["ws", "virtual:dd36ba31a7b48a1ca2b6a3f8b887ffc553c9d2524d79995148d6d982d547957b8911d91c1075cafd174e2028319a1bc4cf5391f2362c3a849c1975dadf50fc21#npm:7.5.10"]\
+          ["ws", "virtual:dd36ba31a7b48a1ca2b6a3f8b887ffc553c9d2524d79995148d6d982d547957b8911d91c1075cafd174e2028319a1bc4cf5391f2362c3a849c1975dadf50fc21#npm:7.5.11"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -27073,17 +27073,17 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["npm:7.5.10", {\
-        "packageLocation": "./.yarn/cache/ws-npm-7.5.10-878ccb886b-9c796b84ba.zip/node_modules/ws/",\
+      ["npm:7.5.11", {\
+        "packageLocation": "./.yarn/cache/ws-npm-7.5.11-420a347b21-486141e4a0.zip/node_modules/ws/",\
         "packageDependencies": [\
-          ["ws", "npm:7.5.10"]\
+          ["ws", "npm:7.5.11"]\
         ],\
         "linkType": "SOFT"\
       }],\
-      ["npm:8.19.0", {\
-        "packageLocation": "./.yarn/cache/ws-npm-8.19.0-c967c046a5-26e4901e93.zip/node_modules/ws/",\
+      ["npm:8.21.0", {\
+        "packageLocation": "./.yarn/cache/ws-npm-8.21.0-7629fe02dd-0884119564.zip/node_modules/ws/",\
         "packageDependencies": [\
-          ["ws", "npm:8.19.0"]\
+          ["ws", "npm:8.21.0"]\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -27104,14 +27104,14 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:735549f69b21bf4741af789727997d0b27b7da3a44b744bf0c6b18abd356696f34e7a0c5d8c928bb0e47b8561d2bd31a64ce367444d30f5af710507379030607#npm:8.19.0", {\
-        "packageLocation": "./.yarn/__virtual__/ws-virtual-5fb6471b37/0/cache/ws-npm-8.19.0-c967c046a5-26e4901e93.zip/node_modules/ws/",\
+      ["virtual:735549f69b21bf4741af789727997d0b27b7da3a44b744bf0c6b18abd356696f34e7a0c5d8c928bb0e47b8561d2bd31a64ce367444d30f5af710507379030607#npm:8.21.0", {\
+        "packageLocation": "./.yarn/__virtual__/ws-virtual-86f48b7b4c/0/cache/ws-npm-8.21.0-7629fe02dd-0884119564.zip/node_modules/ws/",\
         "packageDependencies": [\
           ["@types/bufferutil", null],\
           ["@types/utf-8-validate", null],\
           ["bufferutil", null],\
           ["utf-8-validate", null],\
-          ["ws", "virtual:735549f69b21bf4741af789727997d0b27b7da3a44b744bf0c6b18abd356696f34e7a0c5d8c928bb0e47b8561d2bd31a64ce367444d30f5af710507379030607#npm:8.19.0"]\
+          ["ws", "virtual:735549f69b21bf4741af789727997d0b27b7da3a44b744bf0c6b18abd356696f34e7a0c5d8c928bb0e47b8561d2bd31a64ce367444d30f5af710507379030607#npm:8.21.0"]\
         ],\
         "packagePeers": [\
           "@types/bufferutil",\
@@ -27121,14 +27121,14 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:dd36ba31a7b48a1ca2b6a3f8b887ffc553c9d2524d79995148d6d982d547957b8911d91c1075cafd174e2028319a1bc4cf5391f2362c3a849c1975dadf50fc21#npm:7.5.10", {\
-        "packageLocation": "./.yarn/__virtual__/ws-virtual-2be355ea55/0/cache/ws-npm-7.5.10-878ccb886b-9c796b84ba.zip/node_modules/ws/",\
+      ["virtual:dd36ba31a7b48a1ca2b6a3f8b887ffc553c9d2524d79995148d6d982d547957b8911d91c1075cafd174e2028319a1bc4cf5391f2362c3a849c1975dadf50fc21#npm:7.5.11", {\
+        "packageLocation": "./.yarn/__virtual__/ws-virtual-04b101f2d5/0/cache/ws-npm-7.5.11-420a347b21-486141e4a0.zip/node_modules/ws/",\
         "packageDependencies": [\
           ["@types/bufferutil", null],\
           ["@types/utf-8-validate", null],\
           ["bufferutil", null],\
           ["utf-8-validate", null],\
-          ["ws", "virtual:dd36ba31a7b48a1ca2b6a3f8b887ffc553c9d2524d79995148d6d982d547957b8911d91c1075cafd174e2028319a1bc4cf5391f2362c3a849c1975dadf50fc21#npm:7.5.10"]\
+          ["ws", "virtual:dd36ba31a7b48a1ca2b6a3f8b887ffc553c9d2524d79995148d6d982d547957b8911d91c1075cafd174e2028319a1bc4cf5391f2362c3a849c1975dadf50fc21#npm:7.5.11"]\
         ],\
         "packagePeers": [\
           "@types/bufferutil",\

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
     "concurrently": "^7.3.0",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.0.0",
     "syncpack": "^13.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
     "concurrently": "^7.3.0",
-    "nodemon": "^3.0.0",
+    "nodemon": "^3.1.14",
     "syncpack": "^13.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/workspaces/apps/package.json
+++ b/workspaces/apps/package.json
@@ -26,7 +26,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.0.0",
     "react": "^19",
     "typescript": "^5.9.3"
   }

--- a/workspaces/apps/package.json
+++ b/workspaces/apps/package.json
@@ -26,7 +26,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^3.0.0",
+    "nodemon": "^3.1.14",
     "react": "^19",
     "typescript": "^5.9.3"
   }

--- a/workspaces/docs/package.json
+++ b/workspaces/docs/package.json
@@ -29,7 +29,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^3.0.0",
+    "nodemon": "^3.1.14",
     "react": "^19",
     "typescript": "^5.9.3"
   }

--- a/workspaces/docs/package.json
+++ b/workspaces/docs/package.json
@@ -29,7 +29,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.0.0",
     "react": "^19",
     "typescript": "^5.9.3"
   }

--- a/workspaces/docs/packages/cdn/package.json
+++ b/workspaces/docs/packages/cdn/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^25.0.3",
     "concurrently": "^7.3.0",
     "jest": "^30.2.0",
-    "nodemon": "^3.0.0",
+    "nodemon": "^3.1.14",
     "reload": "^3.4.3",
     "rimraf": "^6.1.2",
     "ts-node": "^10.9.2",

--- a/workspaces/docs/packages/cdn/package.json
+++ b/workspaces/docs/packages/cdn/package.json
@@ -38,7 +38,7 @@
     "concurrently": "^7.3.0",
     "jest": "^30.2.0",
     "nodemon": "^3.0.0",
-    "reload": "^3.2.0",
+    "reload": "^3.4.3",
     "rimraf": "^6.1.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/workspaces/docs/packages/cdn/package.json
+++ b/workspaces/docs/packages/cdn/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^25.0.3",
     "concurrently": "^7.3.0",
     "jest": "^30.2.0",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.0.0",
     "reload": "^3.2.0",
     "rimraf": "^6.1.2",
     "ts-node": "^10.9.2",

--- a/workspaces/docs/packages/docs-main/package.json
+++ b/workspaces/docs/packages/docs-main/package.json
@@ -66,7 +66,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-transform-stub": "^2.0.0",
     "next-compose-plugins": "^2.2.1",
-    "reload": "^3.2.0",
+    "reload": "^3.4.3",
     "rimraf": "^6.1.2",
     "sass": "^1.89.2",
     "svg-url-loader": "^8.0.0",

--- a/workspaces/examples/package.json
+++ b/workspaces/examples/package.json
@@ -28,7 +28,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.0.0",
     "react": "^19",
     "typescript": "^5.9.3"
   }

--- a/workspaces/examples/package.json
+++ b/workspaces/examples/package.json
@@ -28,7 +28,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^3.0.0",
+    "nodemon": "^3.1.14",
     "react": "^19",
     "typescript": "^5.9.3"
   }

--- a/workspaces/templates-lib/package.json
+++ b/workspaces/templates-lib/package.json
@@ -27,7 +27,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^3.0.0",
+    "nodemon": "^3.1.14",
     "react": "^19",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/workspaces/templates-lib/package.json
+++ b/workspaces/templates-lib/package.json
@@ -27,7 +27,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.0.0",
     "react": "^19",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/workspaces/templates-management/package.json
+++ b/workspaces/templates-management/package.json
@@ -24,7 +24,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.0.0",
     "react": "^19",
     "typescript": "^5.9.3"
   }

--- a/workspaces/templates-management/package.json
+++ b/workspaces/templates-management/package.json
@@ -24,7 +24,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^3.0.0",
+    "nodemon": "^3.1.14",
     "react": "^19",
     "typescript": "^5.9.3"
   }

--- a/workspaces/templates/package.json
+++ b/workspaces/templates/package.json
@@ -31,7 +31,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.0.0",
     "react": "^19",
     "react-dom": "^19",
     "typescript": "^5.9.3"

--- a/workspaces/templates/package.json
+++ b/workspaces/templates/package.json
@@ -31,7 +31,7 @@
     "@goldstack/utils-typescript-references": "0.3.31",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^3.0.0",
+    "nodemon": "^3.1.14",
     "react": "^19",
     "react-dom": "^19",
     "typescript": "^5.9.3"

--- a/workspaces/templates/packages/app-nextjs-bootstrap/package.json
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/package.json
@@ -55,7 +55,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-transform-stub": "^2.0.0",
     "next-compose-plugins": "^2.2.1",
-    "reload": "^3.2.0",
+    "reload": "^3.4.3",
     "rimraf": "^6.1.2",
     "sass": "^1.89.2",
     "svg-url-loader": "^8.0.0",

--- a/workspaces/templates/packages/app-nextjs-tailwind/package.json
+++ b/workspaces/templates/packages/app-nextjs-tailwind/package.json
@@ -57,7 +57,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-transform-stub": "^2.0.0",
     "postcss": "^8.5.6",
-    "reload": "^3.2.0",
+    "reload": "^3.4.3",
     "rimraf": "^6.1.2",
     "svg-url-loader": "^8.0.0",
     "tailwindcss": "^3",

--- a/workspaces/templates/packages/app-nextjs/package.json
+++ b/workspaces/templates/packages/app-nextjs/package.json
@@ -52,7 +52,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-transform-stub": "^2.0.0",
     "jsdom": "^21.0.0",
-    "reload": "^3.2.0",
+    "reload": "^3.4.3",
     "rimraf": "^6.1.2",
     "svg-url-loader": "^8.0.0",
     "ts-node": "^10.9.2",

--- a/workspaces/templates/packages/docker-image-aws/package.json
+++ b/workspaces/templates/packages/docker-image-aws/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^25.0.3",
     "concurrently": "^7.3.0",
     "jest": "^30.2.0",
-    "nodemon": "^3.0.0",
+    "nodemon": "^3.1.14",
     "rimraf": "^6.1.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/workspaces/templates/packages/docker-image-aws/package.json
+++ b/workspaces/templates/packages/docker-image-aws/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^25.0.3",
     "concurrently": "^7.3.0",
     "jest": "^30.2.0",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.0.0",
     "rimraf": "^6.1.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/workspaces/templates/packages/lambda-go-gin/package.json
+++ b/workspaces/templates/packages/lambda-go-gin/package.json
@@ -18,7 +18,7 @@
     "@swc/core": "^1.15.8",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^3.0.0",
+    "nodemon": "^3.1.14",
     "rimraf": "^6.1.2",
     "ts-node": "^10.9.2"
   }

--- a/workspaces/templates/packages/lambda-go-gin/package.json
+++ b/workspaces/templates/packages/lambda-go-gin/package.json
@@ -18,7 +18,7 @@
     "@swc/core": "^1.15.8",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.0.0",
     "rimraf": "^6.1.2",
     "ts-node": "^10.9.2"
   }

--- a/workspaces/templates/packages/static-website-aws/package.json
+++ b/workspaces/templates/packages/static-website-aws/package.json
@@ -41,7 +41,7 @@
     "concurrently": "^7.3.0",
     "jest": "^30.2.0",
     "light-server": "^2.9.1",
-    "reload": "^3.2.0",
+    "reload": "^3.4.3",
     "rimraf": "^6.1.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/workspaces/utils/package.json
+++ b/workspaces/utils/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
     "@types/rimraf": "^4.0.5",
-    "nodemon": "^3.0.0",
+    "nodemon": "^3.1.14",
     "react": "^19",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/workspaces/utils/package.json
+++ b/workspaces/utils/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
     "@types/rimraf": "^4.0.5",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.0.0",
     "react": "^19",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5846,22 +5846,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/balanced-match@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@isaacs/balanced-match@npm:4.0.1"
-  checksum: 10/102fbc6d2c0d5edf8f6dbf2b3feb21695a21bc850f11bc47c4f06aa83bd8884fde3fe9d6d797d619901d96865fdcb4569ac2a54c937992c48885c5e3d9967fe8
-  languageName: node
-  linkType: hard
-
-"@isaacs/brace-expansion@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@isaacs/brace-expansion@npm:5.0.1"
-  dependencies:
-    "@isaacs/balanced-match": "npm:^4.0.1"
-  checksum: 10/aec226065bc4285436a27379e08cc35bf94ef59f5098ac1c026495c9ba4ab33d851964082d3648d56d63eb90f2642867bd15a3e1b810b98beb1a8c14efce6a94
-  languageName: node
-  linkType: hard
-
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -10405,6 +10389,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10/fb07bb66a0959c2843fc055838047e2a95ccebb837c519614afb067ebfdf2fa967ca8d712c35ced07f2cd26fc6f07964230b094891315ad74f11eba3d53178a0
+  languageName: node
+  linkType: hard
+
 "bare-events@npm:^2.7.0":
   version: 2.8.2
   resolution: "bare-events@npm:2.8.2"
@@ -10554,6 +10545,24 @@ __metadata:
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10/a61e7cd2e8a8505e9f0036b3b6108ba5e926b4b55089eeb5550cd04a471fe216c96d4fe7e4c7f995c728c554ae20ddfc4244cad10aef255e72b62930afd233d1
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^2.0.2":
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+  checksum: 10/0e0f9b0df1f0809e9c326470e022eeb24334ddb54c43b1ac39f1d38f3cbaeb940794de1db826f5491843ac00d7932c43f10350a65ccd51fe7d05da627152f204
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10/98c12de33fa53ab07b2b5179f6740045508c61c4319638faf47a0d72615db80058f66c0d1cb74dc8ed591bbf507c068027e80cfb86a2f467bfd330574e13ed7b
   languageName: node
   linkType: hard
 
@@ -17221,7 +17230,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:9.0.5, minimatch@npm:^9.0.4":
+"minimatch@npm:9.0.5":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -17230,48 +17239,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "minimatch@npm:10.0.1"
+"minimatch@npm:^10.0.1, minimatch@npm:^10.1.1":
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/082e7ccbc090d5f8c4e4e029255d5a1d1e3af37bda837da2b8b0085b1503a1210c91ac90d9ebfe741d8a5f286ece820a1abb4f61dc1f82ce602a055d461d93f3
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "minimatch@npm:10.1.1"
-  dependencies:
-    "@isaacs/brace-expansion": "npm:^5.0.1"
-  checksum: 10/110f38921ea527022e90f7a5f43721838ac740d0a0c26881c03b57c261354fb9a0430e40b2c56dfcea2ef3c773768f27210d1106f1f2be19cde3eea93f26f45e
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10/19e87a931aff60ee7b9d80f39f817b8bfc54f61f8356ee3549fbf636dbccacacfec8d803eac73293955c4527cd085247dfc064bce4a5e349f8f3b85e2bf5da0f
   languageName: node
   linkType: hard
 
 "minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
-  checksum: 10/e0b25b04cd4ec6732830344e5739b13f8690f8a012d73445a4a19fbc623f5dd481ef7a5827fde25954cd6026fede7574cc54dc4643c99d6c6b653d6203f94634
+  checksum: 10/b11a7ee5773cd34c1a0c8436cdbe910901018fb4b6cb47aa508a18d567f6efd2148507959e35fba798389b161b8604a2d704ccef751ea36bd4582f9852b7d63f
   languageName: node
   linkType: hard
 
 "minimatch@npm:^5.0.1":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
+  version: 5.1.9
+  resolution: "minimatch@npm:5.1.9"
   dependencies:
     brace-expansion: "npm:^2.0.1"
-  checksum: 10/126b36485b821daf96d33b5c821dac600cc1ab36c87e7a532594f9b1652b1fa89a1eebcaad4dff17c764dce1a7ac1531327f190fed5f97d8f6e5f889c116c429
+  checksum: 10/23b4feb64dcb77ba93b70a72be551eb2e2677ac02178cf1ed3d38836cc4cd84802d90b77f60ef87f2bac64d270d2d8eba242e428f0554ea4e36bfdb7e9d25d0c
   languageName: node
   linkType: hard
 
 "minimatch@npm:^7.4.6":
-  version: 7.4.6
-  resolution: "minimatch@npm:7.4.6"
+  version: 7.4.9
+  resolution: "minimatch@npm:7.4.9"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/0046ba1161ac6414bde1b07c440792ebcdb2ed93e6714c85c73974332b709b7e692801550bc9da22028a8613407b3f13861e17dd0dd44f4babdeacd44950430b
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10/9bc60b593dafb71d68b1a671a0c1a4bb9a71ef2f8daa8ed4b8b6199bb2d522163fb2e94d82ca40518eaa3b00218f587ad7ab2ed40e56e4c57a8bddb6c2bd1d27
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.4":
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
+  dependencies:
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10/b91fad937deaffb68a45a2cb731ff3cff1c3baf9b6469c879477ed16f15c8f4ce39d63a3f75c2455107c2fdff0f3ab597d97dc09e2e93b883aafcf926ef0c8f9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18388,9 +18388,9 @@ __metadata:
   linkType: hard
 
 "path-to-regexp@npm:^8.1.0":
-  version: 8.3.0
-  resolution: "path-to-regexp@npm:8.3.0"
-  checksum: 10/568f148fc64f5fd1ecebf44d531383b28df924214eabf5f2570dce9587a228e36c37882805ff02d71c6209b080ea3ee6a4d2b712b5df09741b67f1f3cf91e55a
+  version: 8.4.2
+  resolution: "path-to-regexp@npm:8.4.2"
+  checksum: 10/70fd2cbce0b962cbcf4d312af07818bfce2bae11c09cf3bd86be99c0e30168238a1a7b02b18b452e73f075897df04597d30d63e56da7be41eecfc37998693389
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3059,7 +3059,7 @@ __metadata:
     "@types/node": "npm:^25.0.3"
     concurrently: "npm:^7.3.0"
     jest: "npm:^30.2.0"
-    nodemon: "npm:^3.0.0"
+    nodemon: "npm:^3.1.14"
     reload: "npm:^3.4.3"
     rimraf: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
@@ -3080,7 +3080,7 @@ __metadata:
     "@types/node": "npm:^25.0.3"
     concurrently: "npm:^7.3.0"
     jest: "npm:^30.2.0"
-    nodemon: "npm:^3.0.0"
+    nodemon: "npm:^3.1.14"
     rimraf: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
@@ -3791,7 +3791,7 @@ __metadata:
     "@swc/core": "npm:^1.15.8"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^3.0.0"
+    nodemon: "npm:^3.1.14"
     rimraf: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
   languageName: unknown
@@ -9895,7 +9895,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^3.0.0"
+    nodemon: "npm:^3.1.14"
     react: "npm:^19"
     typescript: "npm:^5.9.3"
   languageName: unknown
@@ -12254,7 +12254,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^3.0.0"
+    nodemon: "npm:^3.1.14"
     react: "npm:^19"
     typescript: "npm:^5.9.3"
   languageName: unknown
@@ -13170,7 +13170,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^3.0.0"
+    nodemon: "npm:^3.1.14"
     react: "npm:^19"
     typescript: "npm:^5.9.3"
   languageName: unknown
@@ -17894,7 +17894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemon@npm:^3.0.0, nodemon@npm:~3.1.4":
+"nodemon@npm:^3.1.14, nodemon@npm:~3.1.4":
   version: 3.1.14
   resolution: "nodemon@npm:3.1.14"
   dependencies:
@@ -20106,7 +20106,7 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
     concurrently: "npm:^7.3.0"
-    nodemon: "npm:^3.0.0"
+    nodemon: "npm:^3.1.14"
     syncpack: "npm:^13.0.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
@@ -21758,7 +21758,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^3.0.0"
+    nodemon: "npm:^3.1.14"
     react: "npm:^19"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
@@ -21773,7 +21773,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^3.0.0"
+    nodemon: "npm:^3.1.14"
     react: "npm:^19"
     typescript: "npm:^5.9.3"
   languageName: unknown
@@ -21788,7 +21788,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^3.0.0"
+    nodemon: "npm:^3.1.14"
     react: "npm:^19"
     react-dom: "npm:^19"
     typescript: "npm:^5.9.3"
@@ -22817,7 +22817,7 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
     "@types/rimraf": "npm:^4.0.5"
-    nodemon: "npm:^3.0.0"
+    nodemon: "npm:^3.1.14"
     react: "npm:^19"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3059,7 +3059,7 @@ __metadata:
     "@types/node": "npm:^25.0.3"
     concurrently: "npm:^7.3.0"
     jest: "npm:^30.2.0"
-    nodemon: "npm:^2.0.20"
+    nodemon: "npm:^3.0.0"
     reload: "npm:^3.2.0"
     rimraf: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
@@ -3080,7 +3080,7 @@ __metadata:
     "@types/node": "npm:^25.0.3"
     concurrently: "npm:^7.3.0"
     jest: "npm:^30.2.0"
-    nodemon: "npm:^2.0.20"
+    nodemon: "npm:^3.0.0"
     rimraf: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
@@ -3791,7 +3791,7 @@ __metadata:
     "@swc/core": "npm:^1.15.8"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^2.0.20"
+    nodemon: "npm:^3.0.0"
     rimraf: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
   languageName: unknown
@@ -9895,7 +9895,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^2.0.20"
+    nodemon: "npm:^3.0.0"
     react: "npm:^19"
     typescript: "npm:^5.9.3"
   languageName: unknown
@@ -11881,12 +11881,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^3.2.6, debug@npm:^3.2.7":
+"debug@npm:^3.2.6":
   version: 3.2.7
   resolution: "debug@npm:3.2.7"
   dependencies:
     ms: "npm:^2.1.1"
   checksum: 10/d86fd7be2b85462297ea16f1934dc219335e802f629ca9a69b63ed8ed041dda492389bb2ee039217c02e5b54792b1c51aa96ae954cf28634d363a2360c7a1639
+  languageName: node
+  linkType: hard
+
+"debug@npm:^4":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10/9ada3434ea2993800bd9a1e320bd4aa7af69659fb51cca685d390949434bc0a8873c21ed7c9b852af6f2455a55c6d050aa3937d52b3c69f796dab666f762acad
   languageName: node
   linkType: hard
 
@@ -12209,7 +12221,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^2.0.20"
+    nodemon: "npm:^3.0.0"
     react: "npm:^19"
     typescript: "npm:^5.9.3"
   languageName: unknown
@@ -13125,7 +13137,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^2.0.20"
+    nodemon: "npm:^3.0.0"
     react: "npm:^19"
     typescript: "npm:^5.9.3"
   languageName: unknown
@@ -17239,7 +17251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.1, minimatch@npm:^10.1.1":
+"minimatch@npm:^10.0.1, minimatch@npm:^10.1.1, minimatch@npm:^10.2.1":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -17248,7 +17260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1":
   version: 3.1.5
   resolution: "minimatch@npm:3.1.5"
   dependencies:
@@ -17763,23 +17775,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemon@npm:^2.0.20":
-  version: 2.0.20
-  resolution: "nodemon@npm:2.0.20"
+"nodemon@npm:^3.0.0":
+  version: 3.1.14
+  resolution: "nodemon@npm:3.1.14"
   dependencies:
     chokidar: "npm:^3.5.2"
-    debug: "npm:^3.2.7"
+    debug: "npm:^4"
     ignore-by-default: "npm:^1.0.1"
-    minimatch: "npm:^3.1.2"
+    minimatch: "npm:^10.2.1"
     pstree.remy: "npm:^1.1.8"
-    semver: "npm:^5.7.1"
-    simple-update-notifier: "npm:^1.0.7"
+    semver: "npm:^7.5.3"
+    simple-update-notifier: "npm:^2.0.0"
     supports-color: "npm:^5.5.0"
     touch: "npm:^3.1.0"
     undefsafe: "npm:^2.0.5"
   bin:
     nodemon: bin/nodemon.js
-  checksum: 10/5ef4609fca5bcd07b0245c6047af6b59f6ac2d333cd0ce8823ca7057b956d1a06301dbf7a4c768042470de36a35dee305d7782ec9dde8a618bef5817a6bd38c4
+  checksum: 10/187aa93fc461bb001bac5de63df49a38a7b1cb3c60a5fd6a3b0f2b15da68fe5adfd0f91244be2fd1f57263cbd351e3113cb04c4edf4af23699dd95b2782fbf9b
   languageName: node
   linkType: hard
 
@@ -19959,7 +19971,7 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
     concurrently: "npm:^7.3.0"
-    nodemon: "npm:^2.0.20"
+    nodemon: "npm:^3.0.0"
     syncpack: "npm:^13.0.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
@@ -20205,7 +20217,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^5.6.0, semver@npm:^5.7.1":
+"semver@npm:^5.6.0":
   version: 5.7.2
   resolution: "semver@npm:5.7.2"
   bin:
@@ -20223,21 +20235,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.1, semver@npm:^7.7.2":
-  version: 7.7.3
-  resolution: "semver@npm:7.7.3"
+"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.1, semver@npm:^7.7.2":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
   bin:
     semver: bin/semver.js
-  checksum: 10/8dbc3168e057a38fc322af909c7f5617483c50caddba135439ff09a754b20bdd6482a5123ff543dad4affa488ecf46ec5fb56d61312ad20bb140199b88dfaea9
-  languageName: node
-  linkType: hard
-
-"semver@npm:~7.0.0":
-  version: 7.0.0
-  resolution: "semver@npm:7.0.0"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/be264384c7c2f283d52a28cff172a4a25b99cc10f1481ece9479987e7145d197d3c00d8a0b2662316224fb346e97f770545126b0af88f94fee0292004cf809a1
+  checksum: 10/9b01d2ff11e6e4a4539b7ca3c5f280c8704cb397a28504469f2ed4f00ad2194748d756647362a9712fff30984d15772ab7f083108c2fb508e2096ae9e708f22c
   languageName: node
   linkType: hard
 
@@ -20584,12 +20587,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-update-notifier@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "simple-update-notifier@npm:1.0.7"
+"simple-update-notifier@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "simple-update-notifier@npm:2.0.0"
   dependencies:
-    semver: "npm:~7.0.0"
-  checksum: 10/a0cee9f934ab45432e741a3c8c35d40673f292557e8cc1b1586f4e253892d5c52c3834ed9bc483ad1008fd194983815a5140f74a5e402f2a244f3f561d674e78
+    semver: "npm:^7.5.3"
+  checksum: 10/40bd4f96aa89aedbf717ae9f4ab8fca70e8f7511e8b766feb15471cca3f6fe4fe673743309b08b4ba8abfe0965c9cd927e1de46550a757b819b70fc7430cc85d
   languageName: node
   linkType: hard
 
@@ -21585,7 +21588,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^2.0.20"
+    nodemon: "npm:^3.0.0"
     react: "npm:^19"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
@@ -21600,7 +21603,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^2.0.20"
+    nodemon: "npm:^3.0.0"
     react: "npm:^19"
     typescript: "npm:^5.9.3"
   languageName: unknown
@@ -21615,7 +21618,7 @@ __metadata:
     "@goldstack/utils-typescript-references": "npm:0.3.31"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
-    nodemon: "npm:^2.0.20"
+    nodemon: "npm:^3.0.0"
     react: "npm:^19"
     react-dom: "npm:^19"
     typescript: "npm:^5.9.3"
@@ -22644,7 +22647,7 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^25.0.3"
     "@types/rimraf": "npm:^4.0.5"
-    nodemon: "npm:^2.0.20"
+    nodemon: "npm:^3.0.0"
     react: "npm:^19"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18444,9 +18444,9 @@ __metadata:
   linkType: hard
 
 "picomatch@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "picomatch@npm:4.0.2"
-  checksum: 10/ce617b8da36797d09c0baacb96ca8a44460452c89362d7cb8f70ca46b4158ba8bc3606912de7c818eb4a939f7f9015cef3c766ec8a0c6bfc725fdc078e39c717
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10/8bad770af9dcdb7f94ad1a893adcbe08a97d75a18872f8fed37161d3124217471c402b3929f051532f795f4ff2e53dcebb1644df4c1a5f3a9c476fef3b9f8c51
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23104,8 +23104,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^7.3.1":
-  version: 7.5.10
-  resolution: "ws@npm:7.5.10"
+  version: 7.5.11
+  resolution: "ws@npm:7.5.11"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -23114,13 +23114,13 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/9c796b84ba80ffc2c2adcdfc9c8e9a219ba99caa435c9a8d45f9ac593bba325563b3f83edc5eb067cc6d21b9a6bf2c930adf76dd40af5f58a5ca6859e81858f0
+  checksum: 10/486141e4a01bb75883f9ba39317309c2427e24db1cb75e340fad6e5886b65c03d994a34209f0e4ba06dd6cb9ec95dd1b6a09c52c05eed9a34d6376f4fbbf617c
   languageName: node
   linkType: hard
 
 "ws@npm:^8.13.0, ws@npm:^8.18.0":
-  version: 8.19.0
-  resolution: "ws@npm:8.19.0"
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -23129,7 +23129,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/26e4901e93abaf73af9f26a93707c95b4845e91a7a347ec8c569e6e9be7f9df066f6c2b817b2d685544e208207898a750b78461e6e8d810c11a370771450c31b
+  checksum: 10/088411956432c8f876158409d5a285cb9ad1382f593391f51d3a599bd0a5b277f876609ebd00fc3596321c4a4c9064d6fffe1ebad960e8ea7fd9ae25324f35c2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2904,7 +2904,7 @@ __metadata:
     react-bootstrap: "npm:^2.10.10"
     react-dom: "npm:^19"
     react-is: "npm:^19"
-    reload: "npm:^3.2.0"
+    reload: "npm:^3.4.3"
     rimraf: "npm:^6.1.2"
     sass: "npm:^1.89.2"
     svg-url-loader: "npm:^8.0.0"
@@ -2942,7 +2942,7 @@ __metadata:
     react: "npm:^19"
     react-dom: "npm:^19"
     react-is: "npm:^19"
-    reload: "npm:^3.2.0"
+    reload: "npm:^3.4.3"
     rimraf: "npm:^6.1.2"
     svg-url-loader: "npm:^8.0.0"
     swr: "npm:^0.4.0"
@@ -2977,7 +2977,7 @@ __metadata:
     react: "npm:^19"
     react-dom: "npm:^19"
     react-is: "npm:^19"
-    reload: "npm:^3.2.0"
+    reload: "npm:^3.4.3"
     rimraf: "npm:^6.1.2"
     svg-url-loader: "npm:^8.0.0"
     swr: "npm:^0.4.0"
@@ -3060,7 +3060,7 @@ __metadata:
     concurrently: "npm:^7.3.0"
     jest: "npm:^30.2.0"
     nodemon: "npm:^3.0.0"
-    reload: "npm:^3.2.0"
+    reload: "npm:^3.4.3"
     rimraf: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
@@ -3123,7 +3123,7 @@ __metadata:
     react-bootstrap: "npm:^2.10.10"
     react-dom: "npm:^19"
     react-is: "npm:^19"
-    reload: "npm:^3.2.0"
+    reload: "npm:^3.4.3"
     rimraf: "npm:^6.1.2"
     sass: "npm:^1.89.2"
     styled-components: "npm:^5.3.5"
@@ -3943,7 +3943,7 @@ __metadata:
     gulp-replace: "npm:^1.1.4"
     jest: "npm:^30.2.0"
     light-server: "npm:^2.9.1"
-    reload: "npm:^3.2.0"
+    reload: "npm:^3.4.3"
     rimraf: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
@@ -10643,6 +10643,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bundle-name@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "bundle-name@npm:4.1.0"
+  dependencies:
+    run-applescript: "npm:^7.0.0"
+  checksum: 10/1d966c8d2dbf4d9d394e53b724ac756c2414c45c01340b37743621f59cc565a435024b394ddcb62b9b335d1c9a31f4640eb648c3fec7f97ee74dc0694c9beb6c
+  languageName: node
+  linkType: hard
+
 "bytes@npm:3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
@@ -11304,10 +11313,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:~7.2.0":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: 10/9973af10727ad4b44f26703bf3e9fdc323528660a7590efe3aa9ad5042b4584c0deed84ba443f61c9d6f02dade54a5a5d3c95e306a1e1630f8374ae6db16c06d
+"commander@npm:~14.0.0":
+  version: 14.0.3
+  resolution: "commander@npm:14.0.3"
+  checksum: 10/dfa9ebe2a433d277de5cb0252d23b10a543d245d892db858d23b516336a835c50fd4f52bee4cd13c705cc8acb6f03dc632c73dd806f7d06d3353eb09953dd17a
   languageName: node
   linkType: hard
 
@@ -11890,7 +11899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4":
+"debug@npm:^4, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -11985,10 +11994,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"default-browser-id@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "default-browser-id@npm:5.0.1"
+  checksum: 10/52c637637bcd76bfe974462a2f1dd75cb04784c2852935575760f82e1fd338e5e80d3c45a9b01fdbb1e450553a830bb163b004d2eca223c5573989f82232a072
+  languageName: node
+  linkType: hard
+
+"default-browser@npm:^5.4.0":
+  version: 5.5.0
+  resolution: "default-browser@npm:5.5.0"
+  dependencies:
+    bundle-name: "npm:^4.1.0"
+    default-browser-id: "npm:^5.0.0"
+  checksum: 10/c5c5d84a4abd82850e98f06798a55dee87fc1064538bea00cc14c0fb2dccccbff5e9e07eeea80385fa653202d5d92509838b4239d610ddfa1c76a04a1f65e767
+  languageName: node
+  linkType: hard
+
 "define-lazy-prop@npm:^2.0.0":
   version: 2.0.0
   resolution: "define-lazy-prop@npm:2.0.0"
   checksum: 10/0115fdb065e0490918ba271d7339c42453d209d4cb619dfe635870d906731eff3e1ade8028bb461ea27ce8264ec5e22c6980612d332895977e89c1bbc80fcee2
+  languageName: node
+  linkType: hard
+
+"define-lazy-prop@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "define-lazy-prop@npm:3.0.0"
+  checksum: 10/f28421cf9ee86eecaf5f3b8fe875f13d7009c2625e97645bfff7a2a49aca678270b86c39f9c32939e5ca7ab96b551377ed4139558c795e076774287ad3af1aa4
   languageName: node
   linkType: hard
 
@@ -12561,17 +12594,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encodeurl@npm:^2.0.0, encodeurl@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "encodeurl@npm:2.0.0"
+  checksum: 10/abf5cd51b78082cf8af7be6785813c33b6df2068ce5191a40ca8b1afe6a86f9230af9a9ce694a5ce4665955e5c1120871826df9c128a642e09c58d592e2807fe
+  languageName: node
+  linkType: hard
+
 "encodeurl@npm:~1.0.2":
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
   checksum: 10/e50e3d508cdd9c4565ba72d2012e65038e5d71bdc9198cb125beb6237b5b1ade6c0d343998da9e170fb2eae52c1bed37d4d6d98a46ea423a0cddbed5ac3f780c
-  languageName: node
-  linkType: hard
-
-"encodeurl@npm:~2.0.0":
-  version: 2.0.0
-  resolution: "encodeurl@npm:2.0.0"
-  checksum: 10/abf5cd51b78082cf8af7be6785813c33b6df2068ce5191a40ca8b1afe6a86f9230af9a9ce694a5ce4665955e5c1120871826df9c128a642e09c58d592e2807fe
   languageName: node
   linkType: hard
 
@@ -12975,7 +13008,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-html@npm:~1.0.3":
+"escape-html@npm:^1.0.3, escape-html@npm:~1.0.3":
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 10/6213ca9ae00d0ab8bccb6d8d4e0a98e76237b2410302cf7df70aaa6591d509a2a37ce8998008cbecae8fc8ffaadf3fb0229535e6a145f3ce0b211d060decbb24
@@ -13074,7 +13107,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"etag@npm:~1.8.1":
+"etag@npm:^1.8.1, etag@npm:~1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 10/571aeb3dbe0f2bbd4e4fadbdb44f325fc75335cd5f6f6b6a091e6a06a9f25ed5392f0863c5442acb0646787446e816f13cbfc6edce5b07658541dff573cab1ff
@@ -13526,7 +13559,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"finalhandler@npm:1.1.2, finalhandler@npm:~1.1.1":
+"finalhandler@npm:1.1.2":
   version: 1.1.2
   resolution: "finalhandler@npm:1.1.2"
   dependencies:
@@ -13553,6 +13586,20 @@ __metadata:
     statuses: "npm:2.0.1"
     unpipe: "npm:~1.0.0"
   checksum: 10/635718cb203c6d18e6b48dfbb6c54ccb08ea470e4f474ddcef38c47edcf3227feec316f886dd701235997d8af35240cae49856721ce18f539ad038665ebbf163
+  languageName: node
+  linkType: hard
+
+"finalhandler@npm:~2.1.0":
+  version: 2.1.1
+  resolution: "finalhandler@npm:2.1.1"
+  dependencies:
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    on-finished: "npm:^2.4.1"
+    parseurl: "npm:^1.3.3"
+    statuses: "npm:^2.0.1"
+  checksum: 10/f4ba75c23408d8f9d393c3e875b9452e84d68c925411a6e67b7efa678b0bed5075ef33def4bb65ed8e0dd37c92a3ea354bcbde07303cd4dc2550e12b95885067
   languageName: node
   linkType: hard
 
@@ -13703,6 +13750,13 @@ __metadata:
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 10/64c88e489b5d08e2f29664eb3c79c705ff9a8eb15d3e597198ef76546d4ade295897a44abb0abd2700e7ef784b2e3cbf1161e4fbf16f59129193fd1030d16da1
+  languageName: node
+  linkType: hard
+
+"fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fresh@npm:2.0.0"
+  checksum: 10/44e1468488363074641991c1340d2a10c5a6f6d7c353d89fd161c49d120c58ebf9890720f7584f509058385836e3ce50ddb60e9f017315a4ba8c6c3461813bfc
   languageName: node
   linkType: hard
 
@@ -14771,6 +14825,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-errors@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "http-errors@npm:2.0.1"
+  dependencies:
+    depd: "npm:~2.0.0"
+    inherits: "npm:~2.0.4"
+    setprototypeof: "npm:~1.2.0"
+    statuses: "npm:~2.0.2"
+    toidentifier: "npm:~1.0.1"
+  checksum: 10/9fe31bc0edf36566c87048aed1d3d0cbe03552564adc3541626a0613f542d753fbcb13bdfcec0a3a530dbe1714bb566c89d46244616b66bddd26ac413b06a207
+  languageName: node
+  linkType: hard
+
 "http-errors@npm:~1.6.2":
   version: 1.6.3
   resolution: "http-errors@npm:1.6.3"
@@ -15008,7 +15075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.0, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.0, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10/cd45e923bee15186c07fa4c89db0aace24824c482fb887b528304694b2aa6ff8a898da8657046a5dcf3e46cd6db6c61629551f9215f208d7c3f157cf9b290521
@@ -15259,6 +15326,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-docker@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-docker@npm:3.0.0"
+  bin:
+    is-docker: cli.js
+  checksum: 10/b698118f04feb7eaf3338922bd79cba064ea54a1c3db6ec8c0c8d8ee7613e7e5854d802d3ef646812a8a3ace81182a085dfa0a71cc68b06f3fa794b9783b3c90
+  languageName: node
+  linkType: hard
+
 "is-extendable@npm:^0.1.0":
   version: 0.1.1
   resolution: "is-extendable@npm:0.1.1"
@@ -15327,6 +15403,24 @@ __metadata:
   version: 1.0.4
   resolution: "is-hexadecimal@npm:1.0.4"
   checksum: 10/a452e047587b6069332d83130f54d30da4faf2f2ebaa2ce6d073c27b5703d030d58ed9e0b729c8e4e5b52c6f1dab26781bb77b7bc6c7805f14f320e328ff8cd5
+  languageName: node
+  linkType: hard
+
+"is-in-ssh@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-in-ssh@npm:1.0.0"
+  checksum: 10/d55cb39afdbca0cdc94cd493da7819c00d35048ea04fc1624aabde6e0c86aa6b91ddb38b2baf73c4b5d53cc8fbf1a8dfbf2e315594a808474b751ffb6b0d3e58
+  languageName: node
+  linkType: hard
+
+"is-inside-container@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-inside-container@npm:1.0.0"
+  dependencies:
+    is-docker: "npm:^3.0.0"
+  bin:
+    is-inside-container: cli.js
+  checksum: 10/c50b75a2ab66ab3e8b92b3bc534e1ea72ca25766832c0623ac22d134116a98bcf012197d1caabe1d1c4bd5f84363d4aa5c36bb4b585fbcaf57be172cd10a1a03
   languageName: node
   linkType: hard
 
@@ -15580,6 +15674,15 @@ __metadata:
   dependencies:
     is-docker: "npm:^2.0.0"
   checksum: 10/20849846ae414997d290b75e16868e5261e86ff5047f104027026fd61d8b5a9b0b3ade16239f35e1a067b3c7cc02f70183cb661010ed16f4b6c7c93dad1b19d8
+  languageName: node
+  linkType: hard
+
+"is-wsl@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "is-wsl@npm:3.1.1"
+  dependencies:
+    is-inside-container: "npm:^1.0.0"
+  checksum: 10/513d95b89af0e60b43d7b17ecb7eb78edea0a439136a3da37b1b56e215379cc46a9221474ad5b2de044824ca72d7869dee6e015273dc3f71f2bb87c715f9f1dc
   languageName: node
   linkType: hard
 
@@ -17185,12 +17288,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 10/9e7834be3d66ae7f10eaa69215732c6d389692b194f876198dca79b2b90cbf96688d9d5d05ef7987b20f749b769b11c01766564264ea5f919c88b32a29011311
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:^2.1.35, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10/89aa9651b67644035de2784a6e665fc685d79aba61857e02b9c8758da874a754aed4a9aced9265f5ed1171fd934331e5516b84a7f0218031b6fa0270eca1e51a
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "mime-types@npm:3.0.2"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10/9db0ad31f5eff10ee8f848130779b7f2d056ddfdb6bda696cb69be68d486d33a3457b4f3f9bdeb60d0736edb471bd5a7c0a384375c011c51c889fd0d5c3b893e
   languageName: node
   linkType: hard
 
@@ -17775,7 +17894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemon@npm:^3.0.0":
+"nodemon@npm:^3.0.0, nodemon@npm:~3.1.4":
   version: 3.1.14
   resolution: "nodemon@npm:3.1.14"
   dependencies:
@@ -17992,7 +18111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:2.4.1":
+"on-finished@npm:2.4.1, on-finished@npm:^2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -18035,14 +18154,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:^8.0.0":
-  version: 8.2.1
-  resolution: "open@npm:8.2.1"
+"open@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "open@npm:11.0.0"
   dependencies:
-    define-lazy-prop: "npm:^2.0.0"
-    is-docker: "npm:^2.1.1"
-    is-wsl: "npm:^2.2.0"
-  checksum: 10/d452f8cc3978da904b0de3f1f17d2da9acbc588777499841c65491b34c08a0429830ab6385559d691ad16e7de2f477afde32626022d033c40a211671ace8c728
+    default-browser: "npm:^5.4.0"
+    define-lazy-prop: "npm:^3.0.0"
+    is-in-ssh: "npm:^1.0.0"
+    is-inside-container: "npm:^1.0.0"
+    powershell-utils: "npm:^0.1.0"
+    wsl-utils: "npm:^0.3.0"
+  checksum: 10/d4572cd0c1f40fe1713edce9e3812367acbfaac0e909a68be0ee0b5acf4ee0a567d01d432dc2d708a55aab684002ab47fe13c679213fb749fe096b77a5d8e51b
   languageName: node
   linkType: hard
 
@@ -18907,6 +19029,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"powershell-utils@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "powershell-utils@npm:0.1.0"
+  checksum: 10/4cc0846bc903ef9c8ac8cc9d178185d5972160a6c8776d44cf4c27ce31c0b614fc7cd20a53e8fcaf7f5296cdb34087a5d4396bdd863492972c84f76f3cadef67
+  languageName: node
+  linkType: hard
+
 "prettier@npm:^2.0.5":
   version: 2.0.5
   resolution: "prettier@npm:2.0.5"
@@ -19215,6 +19344,13 @@ __metadata:
   dependencies:
     performance-now: "npm:^2.1.0"
   checksum: 10/4c4b4c826b09d2aec6ca809f1a3c3c12136e7ec8d13fbb91f495dd2c99cd43345240e003da3bfd16036a432e635049fc6d9f69f9187f5f22ea88bb146ec75881
+  languageName: node
+  linkType: hard
+
+"range-parser@npm:^1.2.1":
+  version: 1.3.0
+  resolution: "range-parser@npm:1.3.0"
+  checksum: 10/f0b7a34de67333b80da0a1098cc02579bd5f74da717fdc0807caf87f043af6641d98d94c64a60477a8f88ba7c214aede965fd0e0c3036ea35c9fe89e1149923d
   languageName: node
   linkType: hard
 
@@ -19551,22 +19687,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reload@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "reload@npm:3.2.0"
+"reload@npm:^3.4.3":
+  version: 3.4.3
+  resolution: "reload@npm:3.4.3"
   dependencies:
     cli-color: "npm:~2.0.0"
-    commander: "npm:~7.2.0"
-    finalhandler: "npm:~1.1.1"
+    commander: "npm:~14.0.0"
+    finalhandler: "npm:~2.1.0"
     minimist: "npm:~1.2.0"
-    open: "npm:^8.0.0"
-    serve-static: "npm:~1.14.0"
-    supervisor: "npm:~0.12.0"
-    url-parse: "npm:~1.5.0"
-    ws: "npm:~7.4.0"
+    nodemon: "npm:~3.1.4"
+    open: "npm:^11.0.0"
+    serve-static: "npm:~2.2.0"
+    ws: "npm:~8.19.0"
   bin:
     reload: bin/reload
-  checksum: 10/3d56a4e2528ece37e3ce049f0e25dcb34f9211835ab20d58d917d7ed7f09bce457d621032650e1b9834bfc056dc293b11388f92fca557cfb3ab7040039ef3afb
+  checksum: 10/e199dabc2c7c830de8a7c254a9552b05f23a2fa48972982f79ebc93ebfbe6a67a132415c70ea9d0dd969bdd86a96c70aa2e57418ff21cb9f178361114f3257a5
   languageName: node
   linkType: hard
 
@@ -19992,6 +20127,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"run-applescript@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "run-applescript@npm:7.1.0"
+  checksum: 10/8659fb5f2717b2b37a68cbfe5f678254cf24b5a82a6df3372b180c80c7c137dcd757a4166c3887e459f59a090ca414e8ea7ca97cf3ee5123db54b3b4006d7b7a
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.1.9
   resolution: "run-parallel@npm:1.1.9"
@@ -20318,6 +20460,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "send@npm:1.2.1"
+  dependencies:
+    debug: "npm:^4.4.3"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.1"
+    mime-types: "npm:^3.0.2"
+    ms: "npm:^2.1.3"
+    on-finished: "npm:^2.4.1"
+    range-parser: "npm:^1.2.1"
+    statuses: "npm:^2.0.2"
+  checksum: 10/274f842d69ccfa49d4940a85598c6825da58dee6cb8ea33b08d5bd3988e6a82267c4d7c32b23d0e4706aad076ee95b1edfa13f859877db9b589829019397e355
+  languageName: node
+  linkType: hard
+
 "serve-index@npm:^1.9.1":
   version: 1.9.1
   resolution: "serve-index@npm:1.9.1"
@@ -20345,7 +20506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-static@npm:~1.14.0, serve-static@npm:~1.14.1":
+"serve-static@npm:~1.14.1":
   version: 1.14.2
   resolution: "serve-static@npm:1.14.2"
   dependencies:
@@ -20354,6 +20515,18 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:0.17.2"
   checksum: 10/b84f9d58b07db2e4d6b1f60e60a27839f5247331b9bbfa1a90eda3523d8bc58585c914e069e785bb2645668e0b9cdd1a305bc1aa81c4284f5ead103741bb705c
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:~2.2.0":
+  version: 2.2.1
+  resolution: "serve-static@npm:2.2.1"
+  dependencies:
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    parseurl: "npm:^1.3.3"
+    send: "npm:^1.2.0"
+  checksum: 10/71500fe80cc7163fec04e4297de7591ad1cb682d137fc030e7a53e57040fda5187e8082a9c1b2ef37f1d3f9c27c9a94d4ba61806ebc28938ba4a7c8947c9f71e
   languageName: node
   linkType: hard
 
@@ -20371,7 +20544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"setprototypeof@npm:1.2.0":
+"setprototypeof@npm:1.2.0, setprototypeof@npm:~1.2.0":
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
   checksum: 10/fde1630422502fbbc19e6844346778f99d449986b2f9cdcceb8326730d2f3d9964dbcb03c02aaadaefffecd0f2c063315ebea8b3ad895914bf1afc1747fc172e
@@ -20915,6 +21088,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"statuses@npm:^2.0.1, statuses@npm:^2.0.2, statuses@npm:~2.0.2":
+  version: 2.0.2
+  resolution: "statuses@npm:2.0.2"
+  checksum: 10/6927feb50c2a75b2a4caab2c565491f7a93ad3d8dbad7b1398d52359e9243a20e2ebe35e33726dee945125ef7a515e9097d8a1b910ba2bbd818265a2f6c39879
+  languageName: node
+  linkType: hard
+
 "stdin-discarder@npm:^0.2.1":
   version: 0.2.2
   resolution: "stdin-discarder@npm:0.2.2"
@@ -21313,16 +21493,6 @@ __metadata:
     methods: "npm:^1.1.2"
     superagent: "npm:^10.2.3"
   checksum: 10/ecb5d41f2b62b257dbdcabac245c32b8e8fb264fe2636dd85c2c883569d23dc14adc0a471abb84187cbdb49bc36ad870ad355b4a0b85973f510fd57fc229e6cc
-  languageName: node
-  linkType: hard
-
-"supervisor@npm:~0.12.0":
-  version: 0.12.0
-  resolution: "supervisor@npm:0.12.0"
-  bin:
-    node-supervisor: lib/cli-wrapper.js
-    supervisor: lib/cli-wrapper.js
-  checksum: 10/5cfd3256a9919999a7570202280bad8ac6f390031c8d97352ff17487fbbda8cbed2f62a1b2fd8044b4459f2945b751f1601c1a9511024422af53a487402f12dd
   languageName: node
   linkType: hard
 
@@ -21790,7 +21960,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toidentifier@npm:1.0.1":
+"toidentifier@npm:1.0.1, toidentifier@npm:~1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10/952c29e2a85d7123239b5cfdd889a0dde47ab0497f0913d70588f19c53f7e0b5327c95f4651e413c74b785147f9637b17410ac8c846d5d4a20a5a33eb6dc3a45
@@ -22590,7 +22760,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"url-parse@npm:^1.5.3, url-parse@npm:~1.5.0":
+"url-parse@npm:^1.5.3":
   version: 1.5.10
   resolution: "url-parse@npm:1.5.10"
   dependencies:
@@ -23145,18 +23315,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:~7.4.0":
-  version: 7.4.6
-  resolution: "ws@npm:7.4.6"
+"ws@npm:~8.19.0":
+  version: 8.19.0
+  resolution: "ws@npm:8.19.0"
   peerDependencies:
     bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
+    utf-8-validate: ">=5.0.2"
   peerDependenciesMeta:
     bufferutil:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/150e3f917b7cde568d833a5ea6ccc4132e59c38d04218afcf2b6c7b845752bd011a9e0dc1303c8694d3c402a0bdec5893661a390b71ff88f0fc81a4e4e66b09c
+  checksum: 10/26e4901e93abaf73af9f26a93707c95b4845e91a7a347ec8c569e6e9be7f9df066f6c2b817b2d685544e208207898a750b78461e6e8d810c11a370771450c31b
+  languageName: node
+  linkType: hard
+
+"wsl-utils@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "wsl-utils@npm:0.3.1"
+  dependencies:
+    is-wsl: "npm:^3.1.0"
+    powershell-utils: "npm:^0.1.0"
+  checksum: 10/46800b92fa4974f2a846a93f0b8c409a455c35897d001a7599b5524766b603c8fb0945d2b21ad6ad27d4b0ae7e72ca2e58d832ccfcaabf659399921c6448b1d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Remediates 28 of 37 high-severity advisory instances via lockfile-only upgrades and direct dependency bumps.

### Upgrades applied

| Package | From | To | Method |
|---------|------|----|--------|
| picomatch | 4.0.2 | 4.0.5 | `yarn up -R` |
| path-to-regexp | 8.3.0 | 8.4.2 | `yarn up -R` |
| ws | 7.5.10 / 8.19.0 | 7.5.11 / 8.21.0 | `yarn up -R` |
| minimatch | 3.1.2 / 5.1.6 / 7.4.6 / 10.0.1/10.1.1 | 3.1.5 / 5.1.9 / 7.4.9 / 10.2.5 | `yarn up -R` |
| nodemon | 2.0.20 | 3.1.14 | package.json bump (all workspaces) |
| semver | 7.0.0 | 7.8.5 | via nodemon upgrade |
| reload | 3.2.0 | 3.4.3 | package.json bump (fixes ws 7.4.6) |

### Remaining unfixable (no resolution entries)

| Package | Reason |
|---------|--------|
| effect 3.6.5 | syncpack dependency, needs resolution |
| fast-xml-parser 5.4.1 | @aws-sdk/xml-builder pins exact version |
| lodash 4.17.23 | No fix released |
| minimatch 3.0.8 | globule `~3.0.2` constraint |
| minimatch 9.0.5 | syncpack pins exact version |
| path-to-regexp 0.1.10 | express 4.20.0 pins exact version |
| prismjs 1.17.1 | refractor dependency |
| tar 6.2.1 | node-gyp v6→v7 major bump |
| trim 0.0.1 | remark-parse dependency |
| underscore 1.12.1/1.13.6 | transitive dependencies |
