### PR TITLE
fix: set AWS_REGION alongside AWS_DEFAULT_REGION in AWS CLI exec functions

### DIFF
--- a/workspaces/templates-lib/packages/utils-aws-cli/src/utilsAwsCli.ts
+++ b/workspaces/templates-lib/packages/utils-aws-cli/src/utilsAwsCli.ts
@@ -51,6 +51,7 @@ export const execWithDocker = async (params: AWSExecParams): Promise<string> => 
     `-e AWS_ACCESS_KEY_ID=${credentials.accessKeyId} ` +
     `-e AWS_SECRET_ACCESS_KEY=${credentials.secretAccessKey} ` +
     `-e AWS_SESSION_TOKEN=${credentials.sessionToken || ''} ` +
+    `-e AWS_REGION=${params.region} ` +
     `-e AWS_DEFAULT_REGION=${params.region} `;
   const mountDir = params.workDir || pwd();
 
@@ -74,6 +75,7 @@ export const execWithCli = async (params: AWSExecParams): Promise<string> => {
   process.env.AWS_ACCESS_KEY_ID = credentials.accessKeyId;
   process.env.AWS_SECRET_ACCESS_KEY = credentials.secretAccessKey;
   process.env.AWS_SESSION_TOKEN = credentials.sessionToken || '';
+  process.env.AWS_REGION = params.region;
   process.env.AWS_DEFAULT_REGION = params.region;
 
   assertDirectoryExists(


### PR DESCRIPTION
## Problem

AWS CLI v2 prioritises `AWS_REGION` over `AWS_DEFAULT_REGION`. If a user has `AWS_REGION` set in their shell environment (e.g. from their AWS profile `region` setting), it would silently override the intended region.

This caused Lambda@Edge deploys to fail with `ResourceNotFoundException` because the edge Lambda lives in `us-east-1` (as required by AWS), but `AWS_REGION` was set to the deployment's configured region (e.g. `us-west-2` from `goldstack.json`).

## Fix

- `execWithCli`: Set `process.env.AWS_REGION = params.region` alongside `AWS_DEFAULT_REGION`
- `execWithDocker`: Pass `-e AWS_REGION=${params.region}` alongside `-e AWS_DEFAULT_REGION`

## Files Changed

- `workspaces/templates-lib/packages/utils-aws-cli/src/utilsAwsCli.ts` (+2 lines)