### PR TITLE
[Maintenance] Resolve Easy Non-Critical Security Vulnerabilities

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -4180,7 +4180,7 @@ const RAW_RUNTIME_STATE =
           ["jest-environment-jsdom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:30.2.0"],\
           ["jest-transform-stub", "npm:2.0.0"],\
           ["jsdom", "virtual:b28f6f2dcaa3de9aaf6c7d093d23c4c2c32e9cbea00ed9a5cf21e895c3e09ac7db18108871bf828a77a26ad19ff27d6b02e951ed326d7565e29513f7342ba4d9#npm:21.1.2"],\
-          ["next", "virtual:b28f6f2dcaa3de9aaf6c7d093d23c4c2c32e9cbea00ed9a5cf21e895c3e09ac7db18108871bf828a77a26ad19ff27d6b02e951ed326d7565e29513f7342ba4d9#npm:15.5.18"],\
+          ["next", "virtual:b28f6f2dcaa3de9aaf6c7d093d23c4c2c32e9cbea00ed9a5cf21e895c3e09ac7db18108871bf828a77a26ad19ff27d6b02e951ed326d7565e29513f7342ba4d9#npm:15.5.22"],\
           ["react", "npm:19.2.3"],\
           ["react-dom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:19.2.3"],\
           ["react-is", "npm:19.2.1"],\
@@ -4216,7 +4216,7 @@ const RAW_RUNTIME_STATE =
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["jest-environment-jsdom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:30.2.0"],\
           ["jest-transform-stub", "npm:2.0.0"],\
-          ["next", "virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:15.5.18"],\
+          ["next", "virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:15.5.22"],\
           ["next-compose-plugins", "npm:2.2.1"],\
           ["react", "npm:19.2.3"],\
           ["react-bootstrap", "virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:2.10.10"],\
@@ -4257,7 +4257,7 @@ const RAW_RUNTIME_STATE =
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["jest-environment-jsdom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:30.2.0"],\
           ["jest-transform-stub", "npm:2.0.0"],\
-          ["next", "virtual:b28f6f2dcaa3de9aaf6c7d093d23c4c2c32e9cbea00ed9a5cf21e895c3e09ac7db18108871bf828a77a26ad19ff27d6b02e951ed326d7565e29513f7342ba4d9#npm:15.5.18"],\
+          ["next", "virtual:b28f6f2dcaa3de9aaf6c7d093d23c4c2c32e9cbea00ed9a5cf21e895c3e09ac7db18108871bf828a77a26ad19ff27d6b02e951ed326d7565e29513f7342ba4d9#npm:15.5.22"],\
           ["postcss", "npm:8.5.6"],\
           ["react", "npm:19.2.3"],\
           ["react-dom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:19.2.3"],\
@@ -4295,7 +4295,7 @@ const RAW_RUNTIME_STATE =
           ["rimraf", "npm:6.1.2"],\
           ["semver", "npm:7.8.5"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
-          ["uuid", "npm:11.0.5"]\
+          ["uuid", "npm:11.1.1"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -4415,7 +4415,7 @@ const RAW_RUNTIME_STATE =
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["jest-environment-jsdom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:30.2.0"],\
           ["jest-transform-stub", "npm:2.0.0"],\
-          ["next", "virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:15.5.18"],\
+          ["next", "virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:15.5.22"],\
           ["next-compose-plugins", "npm:2.2.1"],\
           ["react", "npm:19.2.3"],\
           ["react-bootstrap", "virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:2.10.10"],\
@@ -4528,7 +4528,7 @@ const RAW_RUNTIME_STATE =
           ["@types/uuid", "npm:10.0.0"],\
           ["@yarnpkg/esbuild-plugin-pnp", "virtual:513fa9bf8fd99628bce0825e4db4c92367fd2a211840a12f001653f8353bb24582a65fc5f1634991bde367f9642415112f75812ec60b1a68670bd8b298fe2442#npm:3.0.0-rc.15"],\
           ["aws-serverless-express", "npm:3.3.8"],\
-          ["cookie-parser", "npm:1.4.5"],\
+          ["cookie-parser", "npm:1.4.7"],\
           ["cors", "npm:2.8.5"],\
           ["crypto-random-string", "npm:3.3.0"],\
           ["esbuild", "npm:0.25.6"],\
@@ -4545,7 +4545,7 @@ const RAW_RUNTIME_STATE =
           ["ts-node", "virtual:a34d84b0830629706aa9f76341297032dfb316ac3c299bd43f58151c418314121b45f20e804b8bb0cc0046b94a8edd894244aa7537ab33ff98a1f1df12148e98#npm:10.9.2"],\
           ["ts-node-dev", "virtual:640d59121dc50aef8c4e2e9c0fc24c425951c20d64b04f5476f7080bfeeaf953e8d8f92366ff62026e8f3b035a2de8fa49aa2900c07271fe8ad998892fded072#npm:2.0.0"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
-          ["uuid", "npm:11.0.5"]\
+          ["uuid", "npm:11.1.1"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -4612,7 +4612,7 @@ const RAW_RUNTIME_STATE =
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["jest-environment-jsdom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:30.2.0"],\
           ["jest-transform-stub", "npm:2.0.0"],\
-          ["next", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:15.5.18"],\
+          ["next", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:15.5.22"],\
           ["next-compose-plugins", "npm:2.2.1"],\
           ["react", "npm:19.2.3"],\
           ["react-bootstrap", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:2.10.10"],\
@@ -4688,7 +4688,7 @@ const RAW_RUNTIME_STATE =
           ["@swc/jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:0.2.39"],\
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
-          ["axios", "npm:1.16.0"],\
+          ["axios", "npm:1.18.1"],\
           ["handlebars", "npm:4.7.9"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["renamer", "npm:0.7.3"],\
@@ -4713,7 +4713,7 @@ const RAW_RUNTIME_STATE =
           ["@swc/jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:0.2.39"],\
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
-          ["axios", "npm:1.16.0"],\
+          ["axios", "npm:1.18.1"],\
           ["handlebars", "npm:4.7.9"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["renamer", "npm:0.7.3"],\
@@ -5019,7 +5019,7 @@ const RAW_RUNTIME_STATE =
           ["@swc/jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:0.2.39"],\
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
-          ["axios", "npm:1.16.0"],\
+          ["axios", "npm:1.18.1"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["rimraf", "npm:6.1.2"],\
           ["temp-dir", "npm:2.0.0"],\
@@ -5079,7 +5079,7 @@ const RAW_RUNTIME_STATE =
           ["rimraf", "npm:6.1.2"],\
           ["semver", "npm:7.8.5"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
-          ["uuid", "npm:11.0.5"]\
+          ["uuid", "npm:11.1.1"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -5253,7 +5253,7 @@ const RAW_RUNTIME_STATE =
           ["rimraf", "npm:6.1.2"],\
           ["stripe", "npm:8.114.0"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
-          ["uuid", "npm:11.0.5"]\
+          ["uuid", "npm:11.1.1"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -5604,7 +5604,7 @@ const RAW_RUNTIME_STATE =
           ["rimraf", "npm:6.1.2"],\
           ["ts-node", "virtual:a34d84b0830629706aa9f76341297032dfb316ac3c299bd43f58151c418314121b45f20e804b8bb0cc0046b94a8edd894244aa7537ab33ff98a1f1df12148e98#npm:10.9.2"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
-          ["uuid", "npm:11.0.5"]\
+          ["uuid", "npm:11.1.1"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -5662,7 +5662,7 @@ const RAW_RUNTIME_STATE =
           ["rimraf", "npm:6.1.2"],\
           ["ts-node", "virtual:a34d84b0830629706aa9f76341297032dfb316ac3c299bd43f58151c418314121b45f20e804b8bb0cc0046b94a8edd894244aa7537ab33ff98a1f1df12148e98#npm:10.9.2"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
-          ["uuid", "npm:11.0.5"]\
+          ["uuid", "npm:11.1.1"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -6119,7 +6119,7 @@ const RAW_RUNTIME_STATE =
           ["rimraf", "npm:6.1.2"],\
           ["ts-node", "virtual:a34d84b0830629706aa9f76341297032dfb316ac3c299bd43f58151c418314121b45f20e804b8bb0cc0046b94a8edd894244aa7537ab33ff98a1f1df12148e98#npm:10.9.2"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
-          ["uuid", "npm:11.0.5"]\
+          ["uuid", "npm:11.1.1"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -6433,7 +6433,7 @@ const RAW_RUNTIME_STATE =
           ["source-map-support", "npm:0.5.21"],\
           ["ts-node", "virtual:a34d84b0830629706aa9f76341297032dfb316ac3c299bd43f58151c418314121b45f20e804b8bb0cc0046b94a8edd894244aa7537ab33ff98a1f1df12148e98#npm:10.9.2"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
-          ["uuid", "npm:11.0.5"]\
+          ["uuid", "npm:11.1.1"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -6921,7 +6921,7 @@ const RAW_RUNTIME_STATE =
           ["@swc/jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:0.2.39"],\
           ["@types/jest", "npm:30.0.0"],\
           ["@types/node", "npm:25.0.3"],\
-          ["axios", "npm:1.16.0"],\
+          ["axios", "npm:1.18.1"],\
           ["extract-zip", "npm:2.0.1"],\
           ["jest", "virtual:0a32958ded74dc6ab398a3279f865064052fe18d5a8638b6db416e0db715fd0de1f2a3db782b38897bb15560cc038848c1a70fd021c9627c4a6d64591e4c4808#npm:30.2.0"],\
           ["mock-aws-s3-v3", "workspace:workspaces/utils/packages/mock-aws-s3-v3"],\
@@ -7990,82 +7990,82 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@next/env", [\
-      ["npm:15.5.18", {\
-        "packageLocation": "./.yarn/cache/@next-env-npm-15.5.18-43762b7e71-476db14578.zip/node_modules/@next/env/",\
+      ["npm:15.5.22", {\
+        "packageLocation": "./.yarn/cache/@next-env-npm-15.5.22-850d240554-0289b68fe3.zip/node_modules/@next/env/",\
         "packageDependencies": [\
-          ["@next/env", "npm:15.5.18"]\
+          ["@next/env", "npm:15.5.22"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-darwin-arm64", [\
-      ["npm:15.5.18", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-darwin-arm64-npm-15.5.18-ac1ed6c8cc/node_modules/@next/swc-darwin-arm64/",\
+      ["npm:15.5.22", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-darwin-arm64-npm-15.5.22-1f2dd64490/node_modules/@next/swc-darwin-arm64/",\
         "packageDependencies": [\
-          ["@next/swc-darwin-arm64", "npm:15.5.18"]\
+          ["@next/swc-darwin-arm64", "npm:15.5.22"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-darwin-x64", [\
-      ["npm:15.5.18", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-darwin-x64-npm-15.5.18-ce4eeb5400/node_modules/@next/swc-darwin-x64/",\
+      ["npm:15.5.22", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-darwin-x64-npm-15.5.22-1758e5c31d/node_modules/@next/swc-darwin-x64/",\
         "packageDependencies": [\
-          ["@next/swc-darwin-x64", "npm:15.5.18"]\
+          ["@next/swc-darwin-x64", "npm:15.5.22"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-linux-arm64-gnu", [\
-      ["npm:15.5.18", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-linux-arm64-gnu-npm-15.5.18-39da491c17/node_modules/@next/swc-linux-arm64-gnu/",\
+      ["npm:15.5.22", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-linux-arm64-gnu-npm-15.5.22-0ab47fb284/node_modules/@next/swc-linux-arm64-gnu/",\
         "packageDependencies": [\
-          ["@next/swc-linux-arm64-gnu", "npm:15.5.18"]\
+          ["@next/swc-linux-arm64-gnu", "npm:15.5.22"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-linux-arm64-musl", [\
-      ["npm:15.5.18", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-linux-arm64-musl-npm-15.5.18-c9e6bf7d4f/node_modules/@next/swc-linux-arm64-musl/",\
+      ["npm:15.5.22", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-linux-arm64-musl-npm-15.5.22-1038ac0a19/node_modules/@next/swc-linux-arm64-musl/",\
         "packageDependencies": [\
-          ["@next/swc-linux-arm64-musl", "npm:15.5.18"]\
+          ["@next/swc-linux-arm64-musl", "npm:15.5.22"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-linux-x64-gnu", [\
-      ["npm:15.5.18", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-linux-x64-gnu-npm-15.5.18-388d9a3fbc/node_modules/@next/swc-linux-x64-gnu/",\
+      ["npm:15.5.22", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-linux-x64-gnu-npm-15.5.22-10e03aef21/node_modules/@next/swc-linux-x64-gnu/",\
         "packageDependencies": [\
-          ["@next/swc-linux-x64-gnu", "npm:15.5.18"]\
+          ["@next/swc-linux-x64-gnu", "npm:15.5.22"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-linux-x64-musl", [\
-      ["npm:15.5.18", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-linux-x64-musl-npm-15.5.18-cbba3ace7c/node_modules/@next/swc-linux-x64-musl/",\
+      ["npm:15.5.22", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-linux-x64-musl-npm-15.5.22-0d4b79b16a/node_modules/@next/swc-linux-x64-musl/",\
         "packageDependencies": [\
-          ["@next/swc-linux-x64-musl", "npm:15.5.18"]\
+          ["@next/swc-linux-x64-musl", "npm:15.5.22"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-win32-arm64-msvc", [\
-      ["npm:15.5.18", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-win32-arm64-msvc-npm-15.5.18-8151a07038/node_modules/@next/swc-win32-arm64-msvc/",\
+      ["npm:15.5.22", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-win32-arm64-msvc-npm-15.5.22-fd6b9137cb/node_modules/@next/swc-win32-arm64-msvc/",\
         "packageDependencies": [\
-          ["@next/swc-win32-arm64-msvc", "npm:15.5.18"]\
+          ["@next/swc-win32-arm64-msvc", "npm:15.5.22"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@next/swc-win32-x64-msvc", [\
-      ["npm:15.5.18", {\
-        "packageLocation": "./.yarn/unplugged/@next-swc-win32-x64-msvc-npm-15.5.18-44ada3adc9/node_modules/@next/swc-win32-x64-msvc/",\
+      ["npm:15.5.22", {\
+        "packageLocation": "./.yarn/unplugged/@next-swc-win32-x64-msvc-npm-15.5.22-b8df0dd8dd/node_modules/@next/swc-win32-x64-msvc/",\
         "packageDependencies": [\
-          ["@next/swc-win32-x64-msvc", "npm:15.5.18"]\
+          ["@next/swc-win32-x64-msvc", "npm:15.5.22"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -12236,25 +12236,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:2d530d6fbeaaa4c75fa2f21d60fe0cd21d4295fb5d26e8646781c08be8613d27f527d1138522a554ec5d9a7d4a79c2fb545737f95fe746c35f4581d44e33cc34#npm:10.4.20", {\
-        "packageLocation": "./.yarn/__virtual__/autoprefixer-virtual-a5d0e4edcf/0/cache/autoprefixer-npm-10.4.20-dd5fd05d27-d3c4b562fc.zip/node_modules/autoprefixer/",\
-        "packageDependencies": [\
-          ["@types/postcss", null],\
-          ["autoprefixer", "virtual:2d530d6fbeaaa4c75fa2f21d60fe0cd21d4295fb5d26e8646781c08be8613d27f527d1138522a554ec5d9a7d4a79c2fb545737f95fe746c35f4581d44e33cc34#npm:10.4.20"],\
-          ["browserslist", "npm:4.24.3"],\
-          ["caniuse-lite", "npm:1.0.30001689"],\
-          ["fraction.js", "npm:4.3.7"],\
-          ["normalize-range", "npm:0.1.2"],\
-          ["picocolors", "npm:1.1.1"],\
-          ["postcss", "npm:8.4.31"],\
-          ["postcss-value-parser", "npm:4.2.0"]\
-        ],\
-        "packagePeers": [\
-          "@types/postcss",\
-          "postcss"\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["virtual:6e6a19ccf8c83346d9f79f4676f574e62d32bf92e99e6749c22e13d87c7c6992254aa59106ce2f48cb8675403ba55b493da6bb46258c31710cda5fb0f1e8ecdc#npm:10.4.20", {\
         "packageLocation": "./.yarn/__virtual__/autoprefixer-virtual-c73a912ff5/0/cache/autoprefixer-npm-10.4.20-dd5fd05d27-d3c4b562fc.zip/node_modules/autoprefixer/",\
         "packageDependencies": [\
@@ -12266,6 +12247,25 @@ const RAW_RUNTIME_STATE =
           ["normalize-range", "npm:0.1.2"],\
           ["picocolors", "npm:1.1.1"],\
           ["postcss", "npm:8.5.6"],\
+          ["postcss-value-parser", "npm:4.2.0"]\
+        ],\
+        "packagePeers": [\
+          "@types/postcss",\
+          "postcss"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:dfef3eaa3df1954bba9572fb5d9725776c0be7da5b7556a01ad43a6daa12ec6722a6bf75691d08cf961d68b87cfa72347bce792807086a547aa687b057b8097b#npm:10.4.20", {\
+        "packageLocation": "./.yarn/__virtual__/autoprefixer-virtual-cbcfc166f5/0/cache/autoprefixer-npm-10.4.20-dd5fd05d27-d3c4b562fc.zip/node_modules/autoprefixer/",\
+        "packageDependencies": [\
+          ["@types/postcss", null],\
+          ["autoprefixer", "virtual:dfef3eaa3df1954bba9572fb5d9725776c0be7da5b7556a01ad43a6daa12ec6722a6bf75691d08cf961d68b87cfa72347bce792807086a547aa687b057b8097b#npm:10.4.20"],\
+          ["browserslist", "npm:4.24.3"],\
+          ["caniuse-lite", "npm:1.0.30001689"],\
+          ["fraction.js", "npm:4.3.7"],\
+          ["normalize-range", "npm:0.1.2"],\
+          ["picocolors", "npm:1.1.1"],\
+          ["postcss", "npm:8.4.31"],\
           ["postcss-value-parser", "npm:4.2.0"]\
         ],\
         "packagePeers": [\
@@ -12353,12 +12353,13 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["axios", [\
-      ["npm:1.16.0", {\
-        "packageLocation": "./.yarn/cache/axios-npm-1.16.0-77f999ccb9-cf8b521ff7.zip/node_modules/axios/",\
+      ["npm:1.18.1", {\
+        "packageLocation": "./.yarn/cache/axios-npm-1.18.1-cfe396e04f-c4cdced3ee.zip/node_modules/axios/",\
         "packageDependencies": [\
-          ["axios", "npm:1.16.0"],\
-          ["follow-redirects", "virtual:77f999ccb93c7a8b1163212330fc2663930702a6310c22e4e44a0943273d572bf2cd007ae086150f8e94e02087a59aa85c3d28f0def8ae1df499b727a5c2330b#npm:1.16.0"],\
+          ["axios", "npm:1.18.1"],\
+          ["follow-redirects", "virtual:cfe396e04f9d811fe025e61204c45b20fa95aeeb72f863d9cf0f07aec679067f9a0d2fe39eb3c317aeb8b92b549644483d65f5e97851fa03255f800f31d04eff#npm:1.16.0"],\
           ["form-data", "npm:4.0.6"],\
+          ["https-proxy-agent", "npm:5.0.1"],\
           ["proxy-from-env", "npm:2.1.0"]\
         ],\
         "linkType": "HARD"\
@@ -13799,13 +13800,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["cookie", [\
-      ["npm:0.4.0", {\
-        "packageLocation": "./.yarn/cache/cookie-npm-0.4.0-4b3d629e45-494314fb0e.zip/node_modules/cookie/",\
-        "packageDependencies": [\
-          ["cookie", "npm:0.4.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:0.4.1", {\
         "packageLocation": "./.yarn/cache/cookie-npm-0.4.1-cc5e2ebb42-0f2defd60a.zip/node_modules/cookie/",\
         "packageDependencies": [\
@@ -13820,6 +13814,13 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
+      ["npm:0.7.2", {\
+        "packageLocation": "./.yarn/cache/cookie-npm-0.7.2-6ea9ee4231-24b286c556.zip/node_modules/cookie/",\
+        "packageDependencies": [\
+          ["cookie", "npm:0.7.2"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:1.0.2", {\
         "packageLocation": "./.yarn/cache/cookie-npm-1.0.2-7a4273d897-f5817cdc84.zip/node_modules/cookie/",\
         "packageDependencies": [\
@@ -13829,20 +13830,20 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["cookie-parser", [\
-      ["npm:1.4.5", {\
-        "packageLocation": "./.yarn/cache/cookie-parser-npm-1.4.5-85a59b20ec-09b41e191a.zip/node_modules/cookie-parser/",\
-        "packageDependencies": [\
-          ["cookie", "npm:0.4.0"],\
-          ["cookie-parser", "npm:1.4.5"],\
-          ["cookie-signature", "npm:1.0.6"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:1.4.6", {\
         "packageLocation": "./.yarn/cache/cookie-parser-npm-1.4.6-a68f84d02a-1e5a63aa82.zip/node_modules/cookie-parser/",\
         "packageDependencies": [\
           ["cookie", "npm:0.4.1"],\
           ["cookie-parser", "npm:1.4.6"],\
+          ["cookie-signature", "npm:1.0.6"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:1.4.7", {\
+        "packageLocation": "./.yarn/cache/cookie-parser-npm-1.4.7-970a70a2fd-243fa13f21.zip/node_modules/cookie-parser/",\
+        "packageDependencies": [\
+          ["cookie", "npm:0.7.2"],\
+          ["cookie-parser", "npm:1.4.7"],\
           ["cookie-signature", "npm:1.0.6"]\
         ],\
         "linkType": "HARD"\
@@ -16263,12 +16264,12 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:77f999ccb93c7a8b1163212330fc2663930702a6310c22e4e44a0943273d572bf2cd007ae086150f8e94e02087a59aa85c3d28f0def8ae1df499b727a5c2330b#npm:1.16.0", {\
-        "packageLocation": "./.yarn/__virtual__/follow-redirects-virtual-c86df41732/0/cache/follow-redirects-npm-1.16.0-816e4f62d9-3fbe3d80b3.zip/node_modules/follow-redirects/",\
+      ["virtual:cfe396e04f9d811fe025e61204c45b20fa95aeeb72f863d9cf0f07aec679067f9a0d2fe39eb3c317aeb8b92b549644483d65f5e97851fa03255f800f31d04eff#npm:1.16.0", {\
+        "packageLocation": "./.yarn/__virtual__/follow-redirects-virtual-5a01cb4fdb/0/cache/follow-redirects-npm-1.16.0-816e4f62d9-3fbe3d80b3.zip/node_modules/follow-redirects/",\
         "packageDependencies": [\
           ["@types/debug", null],\
           ["debug", null],\
-          ["follow-redirects", "virtual:77f999ccb93c7a8b1163212330fc2663930702a6310c22e4e44a0943273d572bf2cd007ae086150f8e94e02087a59aa85c3d28f0def8ae1df499b727a5c2330b#npm:1.16.0"]\
+          ["follow-redirects", "virtual:cfe396e04f9d811fe025e61204c45b20fa95aeeb72f863d9cf0f07aec679067f9a0d2fe39eb3c317aeb8b92b549644483d65f5e97851fa03255f800f31d04eff#npm:1.16.0"]\
         ],\
         "packagePeers": [\
           "@types/debug",\
@@ -17489,7 +17490,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/http-proxy-npm-1.18.1-a313c479c5-2489e98aba.zip/node_modules/http-proxy/",\
         "packageDependencies": [\
           ["eventemitter3", "npm:4.0.7"],\
-          ["follow-redirects", "virtual:77f999ccb93c7a8b1163212330fc2663930702a6310c22e4e44a0943273d572bf2cd007ae086150f8e94e02087a59aa85c3d28f0def8ae1df499b727a5c2330b#npm:1.16.0"],\
+          ["follow-redirects", "virtual:cfe396e04f9d811fe025e61204c45b20fa95aeeb72f863d9cf0f07aec679067f9a0d2fe39eb3c317aeb8b92b549644483d65f5e97851fa03255f800f31d04eff#npm:1.16.0"],\
           ["http-proxy", "npm:1.18.1"],\
           ["requires-port", "npm:1.0.0"]\
         ],\
@@ -20579,25 +20580,25 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["next", [\
-      ["npm:15.5.18", {\
-        "packageLocation": "./.yarn/cache/next-npm-15.5.18-550477cf50-3e4c11beb3.zip/node_modules/next/",\
+      ["npm:15.5.22", {\
+        "packageLocation": "./.yarn/cache/next-npm-15.5.22-cc96ce8e70-92acab567b.zip/node_modules/next/",\
         "packageDependencies": [\
-          ["next", "npm:15.5.18"]\
+          ["next", "npm:15.5.22"]\
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:15.5.18", {\
-        "packageLocation": "./.yarn/__virtual__/next-virtual-2d530d6fbe/0/cache/next-npm-15.5.18-550477cf50-3e4c11beb3.zip/node_modules/next/",\
+      ["virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:15.5.22", {\
+        "packageLocation": "./.yarn/__virtual__/next-virtual-dfef3eaa3d/0/cache/next-npm-15.5.22-cc96ce8e70-92acab567b.zip/node_modules/next/",\
         "packageDependencies": [\
-          ["@next/env", "npm:15.5.18"],\
-          ["@next/swc-darwin-arm64", "npm:15.5.18"],\
-          ["@next/swc-darwin-x64", "npm:15.5.18"],\
-          ["@next/swc-linux-arm64-gnu", "npm:15.5.18"],\
-          ["@next/swc-linux-arm64-musl", "npm:15.5.18"],\
-          ["@next/swc-linux-x64-gnu", "npm:15.5.18"],\
-          ["@next/swc-linux-x64-musl", "npm:15.5.18"],\
-          ["@next/swc-win32-arm64-msvc", "npm:15.5.18"],\
-          ["@next/swc-win32-x64-msvc", "npm:15.5.18"],\
+          ["@next/env", "npm:15.5.22"],\
+          ["@next/swc-darwin-arm64", "npm:15.5.22"],\
+          ["@next/swc-darwin-x64", "npm:15.5.22"],\
+          ["@next/swc-linux-arm64-gnu", "npm:15.5.22"],\
+          ["@next/swc-linux-arm64-musl", "npm:15.5.22"],\
+          ["@next/swc-linux-x64-gnu", "npm:15.5.22"],\
+          ["@next/swc-linux-x64-musl", "npm:15.5.22"],\
+          ["@next/swc-win32-arm64-msvc", "npm:15.5.22"],\
+          ["@next/swc-win32-x64-msvc", "npm:15.5.22"],\
           ["@opentelemetry/api", null],\
           ["@playwright/test", null],\
           ["@swc/helpers", "npm:0.5.15"],\
@@ -20607,16 +20608,16 @@ const RAW_RUNTIME_STATE =
           ["@types/react", "npm:19.2.7"],\
           ["@types/react-dom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:19.0.2"],\
           ["@types/sass", null],\
-          ["autoprefixer", "virtual:2d530d6fbeaaa4c75fa2f21d60fe0cd21d4295fb5d26e8646781c08be8613d27f527d1138522a554ec5d9a7d4a79c2fb545737f95fe746c35f4581d44e33cc34#npm:10.4.20"],\
+          ["autoprefixer", "virtual:dfef3eaa3df1954bba9572fb5d9725776c0be7da5b7556a01ad43a6daa12ec6722a6bf75691d08cf961d68b87cfa72347bce792807086a547aa687b057b8097b#npm:10.4.20"],\
           ["babel-plugin-react-compiler", null],\
           ["caniuse-lite", "npm:1.0.30001690"],\
-          ["next", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:15.5.18"],\
+          ["next", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:15.5.22"],\
           ["postcss", "npm:8.4.31"],\
           ["react", "npm:19.2.3"],\
           ["react-dom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:19.2.3"],\
           ["sass", "npm:1.101.6"],\
           ["sharp", "npm:0.34.3"],\
-          ["styled-jsx", "virtual:2d530d6fbeaaa4c75fa2f21d60fe0cd21d4295fb5d26e8646781c08be8613d27f527d1138522a554ec5d9a7d4a79c2fb545737f95fe746c35f4581d44e33cc34#npm:5.1.6"]\
+          ["styled-jsx", "virtual:dfef3eaa3df1954bba9572fb5d9725776c0be7da5b7556a01ad43a6daa12ec6722a6bf75691d08cf961d68b87cfa72347bce792807086a547aa687b057b8097b#npm:5.1.6"]\
         ],\
         "packagePeers": [\
           "@opentelemetry/api",\
@@ -20634,18 +20635,18 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:b28f6f2dcaa3de9aaf6c7d093d23c4c2c32e9cbea00ed9a5cf21e895c3e09ac7db18108871bf828a77a26ad19ff27d6b02e951ed326d7565e29513f7342ba4d9#npm:15.5.18", {\
-        "packageLocation": "./.yarn/__virtual__/next-virtual-53142f5013/0/cache/next-npm-15.5.18-550477cf50-3e4c11beb3.zip/node_modules/next/",\
+      ["virtual:b28f6f2dcaa3de9aaf6c7d093d23c4c2c32e9cbea00ed9a5cf21e895c3e09ac7db18108871bf828a77a26ad19ff27d6b02e951ed326d7565e29513f7342ba4d9#npm:15.5.22", {\
+        "packageLocation": "./.yarn/__virtual__/next-virtual-f71401ac36/0/cache/next-npm-15.5.22-cc96ce8e70-92acab567b.zip/node_modules/next/",\
         "packageDependencies": [\
-          ["@next/env", "npm:15.5.18"],\
-          ["@next/swc-darwin-arm64", "npm:15.5.18"],\
-          ["@next/swc-darwin-x64", "npm:15.5.18"],\
-          ["@next/swc-linux-arm64-gnu", "npm:15.5.18"],\
-          ["@next/swc-linux-arm64-musl", "npm:15.5.18"],\
-          ["@next/swc-linux-x64-gnu", "npm:15.5.18"],\
-          ["@next/swc-linux-x64-musl", "npm:15.5.18"],\
-          ["@next/swc-win32-arm64-msvc", "npm:15.5.18"],\
-          ["@next/swc-win32-x64-msvc", "npm:15.5.18"],\
+          ["@next/env", "npm:15.5.22"],\
+          ["@next/swc-darwin-arm64", "npm:15.5.22"],\
+          ["@next/swc-darwin-x64", "npm:15.5.22"],\
+          ["@next/swc-linux-arm64-gnu", "npm:15.5.22"],\
+          ["@next/swc-linux-arm64-musl", "npm:15.5.22"],\
+          ["@next/swc-linux-x64-gnu", "npm:15.5.22"],\
+          ["@next/swc-linux-x64-musl", "npm:15.5.22"],\
+          ["@next/swc-win32-arm64-msvc", "npm:15.5.22"],\
+          ["@next/swc-win32-x64-msvc", "npm:15.5.22"],\
           ["@opentelemetry/api", null],\
           ["@playwright/test", null],\
           ["@swc/helpers", "npm:0.5.15"],\
@@ -20655,16 +20656,16 @@ const RAW_RUNTIME_STATE =
           ["@types/react", "npm:19.2.7"],\
           ["@types/react-dom", null],\
           ["@types/sass", null],\
-          ["autoprefixer", "virtual:2d530d6fbeaaa4c75fa2f21d60fe0cd21d4295fb5d26e8646781c08be8613d27f527d1138522a554ec5d9a7d4a79c2fb545737f95fe746c35f4581d44e33cc34#npm:10.4.20"],\
+          ["autoprefixer", "virtual:dfef3eaa3df1954bba9572fb5d9725776c0be7da5b7556a01ad43a6daa12ec6722a6bf75691d08cf961d68b87cfa72347bce792807086a547aa687b057b8097b#npm:10.4.20"],\
           ["babel-plugin-react-compiler", null],\
           ["caniuse-lite", "npm:1.0.30001690"],\
-          ["next", "virtual:b28f6f2dcaa3de9aaf6c7d093d23c4c2c32e9cbea00ed9a5cf21e895c3e09ac7db18108871bf828a77a26ad19ff27d6b02e951ed326d7565e29513f7342ba4d9#npm:15.5.18"],\
+          ["next", "virtual:b28f6f2dcaa3de9aaf6c7d093d23c4c2c32e9cbea00ed9a5cf21e895c3e09ac7db18108871bf828a77a26ad19ff27d6b02e951ed326d7565e29513f7342ba4d9#npm:15.5.22"],\
           ["postcss", "npm:8.4.31"],\
           ["react", "npm:19.2.3"],\
           ["react-dom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:19.2.3"],\
           ["sass", null],\
           ["sharp", "npm:0.34.3"],\
-          ["styled-jsx", "virtual:2d530d6fbeaaa4c75fa2f21d60fe0cd21d4295fb5d26e8646781c08be8613d27f527d1138522a554ec5d9a7d4a79c2fb545737f95fe746c35f4581d44e33cc34#npm:5.1.6"]\
+          ["styled-jsx", "virtual:dfef3eaa3df1954bba9572fb5d9725776c0be7da5b7556a01ad43a6daa12ec6722a6bf75691d08cf961d68b87cfa72347bce792807086a547aa687b057b8097b#npm:5.1.6"]\
         ],\
         "packagePeers": [\
           "@opentelemetry/api",\
@@ -20682,18 +20683,18 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:15.5.18", {\
-        "packageLocation": "./.yarn/__virtual__/next-virtual-a58a7a6e51/0/cache/next-npm-15.5.18-550477cf50-3e4c11beb3.zip/node_modules/next/",\
+      ["virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:15.5.22", {\
+        "packageLocation": "./.yarn/__virtual__/next-virtual-5f3809bfcf/0/cache/next-npm-15.5.22-cc96ce8e70-92acab567b.zip/node_modules/next/",\
         "packageDependencies": [\
-          ["@next/env", "npm:15.5.18"],\
-          ["@next/swc-darwin-arm64", "npm:15.5.18"],\
-          ["@next/swc-darwin-x64", "npm:15.5.18"],\
-          ["@next/swc-linux-arm64-gnu", "npm:15.5.18"],\
-          ["@next/swc-linux-arm64-musl", "npm:15.5.18"],\
-          ["@next/swc-linux-x64-gnu", "npm:15.5.18"],\
-          ["@next/swc-linux-x64-musl", "npm:15.5.18"],\
-          ["@next/swc-win32-arm64-msvc", "npm:15.5.18"],\
-          ["@next/swc-win32-x64-msvc", "npm:15.5.18"],\
+          ["@next/env", "npm:15.5.22"],\
+          ["@next/swc-darwin-arm64", "npm:15.5.22"],\
+          ["@next/swc-darwin-x64", "npm:15.5.22"],\
+          ["@next/swc-linux-arm64-gnu", "npm:15.5.22"],\
+          ["@next/swc-linux-arm64-musl", "npm:15.5.22"],\
+          ["@next/swc-linux-x64-gnu", "npm:15.5.22"],\
+          ["@next/swc-linux-x64-musl", "npm:15.5.22"],\
+          ["@next/swc-win32-arm64-msvc", "npm:15.5.22"],\
+          ["@next/swc-win32-x64-msvc", "npm:15.5.22"],\
           ["@opentelemetry/api", null],\
           ["@playwright/test", null],\
           ["@swc/helpers", "npm:0.5.15"],\
@@ -20703,16 +20704,16 @@ const RAW_RUNTIME_STATE =
           ["@types/react", "npm:19.2.7"],\
           ["@types/react-dom", null],\
           ["@types/sass", null],\
-          ["autoprefixer", "virtual:2d530d6fbeaaa4c75fa2f21d60fe0cd21d4295fb5d26e8646781c08be8613d27f527d1138522a554ec5d9a7d4a79c2fb545737f95fe746c35f4581d44e33cc34#npm:10.4.20"],\
+          ["autoprefixer", "virtual:dfef3eaa3df1954bba9572fb5d9725776c0be7da5b7556a01ad43a6daa12ec6722a6bf75691d08cf961d68b87cfa72347bce792807086a547aa687b057b8097b#npm:10.4.20"],\
           ["babel-plugin-react-compiler", null],\
           ["caniuse-lite", "npm:1.0.30001690"],\
-          ["next", "virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:15.5.18"],\
+          ["next", "virtual:cd295072a2b6c661ee06707d6470a313c9e528e6cc6a584fbe1beace0d006aa53113f0388633d8d909786d1f723ce8023ba37fbb2f0a7746999414b562703366#npm:15.5.22"],\
           ["postcss", "npm:8.4.31"],\
           ["react", "npm:19.2.3"],\
           ["react-dom", "virtual:a831689f0e2c98979300ed8d8bcea2ee029e4083cdca459cee4397964467418e6a4aa3862bb866e9cae0b75b936947401d1c63f81f2eb27e787abdefdb453c2f#npm:19.2.3"],\
           ["sass", "npm:1.101.6"],\
           ["sharp", "npm:0.34.3"],\
-          ["styled-jsx", "virtual:2d530d6fbeaaa4c75fa2f21d60fe0cd21d4295fb5d26e8646781c08be8613d27f527d1138522a554ec5d9a7d4a79c2fb545737f95fe746c35f4581d44e33cc34#npm:5.1.6"]\
+          ["styled-jsx", "virtual:dfef3eaa3df1954bba9572fb5d9725776c0be7da5b7556a01ad43a6daa12ec6722a6bf75691d08cf961d68b87cfa72347bce792807086a547aa687b057b8097b#npm:5.1.6"]\
         ],\
         "packagePeers": [\
           "@opentelemetry/api",\
@@ -24721,8 +24722,8 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:2d530d6fbeaaa4c75fa2f21d60fe0cd21d4295fb5d26e8646781c08be8613d27f527d1138522a554ec5d9a7d4a79c2fb545737f95fe746c35f4581d44e33cc34#npm:5.1.6", {\
-        "packageLocation": "./.yarn/__virtual__/styled-jsx-virtual-dc7f27a533/0/cache/styled-jsx-npm-5.1.6-623e2e7d45-ba01200e82.zip/node_modules/styled-jsx/",\
+      ["virtual:dfef3eaa3df1954bba9572fb5d9725776c0be7da5b7556a01ad43a6daa12ec6722a6bf75691d08cf961d68b87cfa72347bce792807086a547aa687b057b8097b#npm:5.1.6", {\
+        "packageLocation": "./.yarn/__virtual__/styled-jsx-virtual-56b71f85f0/0/cache/styled-jsx-npm-5.1.6-623e2e7d45-ba01200e82.zip/node_modules/styled-jsx/",\
         "packageDependencies": [\
           ["@babel/core", null],\
           ["@types/babel-plugin-macros", null],\
@@ -24731,7 +24732,7 @@ const RAW_RUNTIME_STATE =
           ["babel-plugin-macros", null],\
           ["client-only", "npm:0.0.1"],\
           ["react", "npm:19.2.3"],\
-          ["styled-jsx", "virtual:2d530d6fbeaaa4c75fa2f21d60fe0cd21d4295fb5d26e8646781c08be8613d27f527d1138522a554ec5d9a7d4a79c2fb545737f95fe746c35f4581d44e33cc34#npm:5.1.6"]\
+          ["styled-jsx", "virtual:dfef3eaa3df1954bba9572fb5d9725776c0be7da5b7556a01ad43a6daa12ec6722a6bf75691d08cf961d68b87cfa72347bce792807086a547aa687b057b8097b#npm:5.1.6"]\
         ],\
         "packagePeers": [\
           "@babel/core",\
@@ -26350,10 +26351,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["uuid", [\
-      ["npm:11.0.5", {\
-        "packageLocation": "./.yarn/cache/uuid-npm-11.0.5-685b7c1023-0594ecdff3.zip/node_modules/uuid/",\
+      ["npm:11.1.1", {\
+        "packageLocation": "./.yarn/cache/uuid-npm-11.1.1-311687c807-16411d3dc1.zip/node_modules/uuid/",\
         "packageDependencies": [\
-          ["uuid", "npm:11.0.5"]\
+          ["uuid", "npm:11.1.1"]\
         ],\
         "linkType": "HARD"\
       }],\

--- a/workspaces/apps/packages/goldstack-api/package.json
+++ b/workspaces/apps/packages/goldstack-api/package.json
@@ -51,7 +51,7 @@
     "sort-package-json": "^3.4.0",
     "source-map-support": "^0.5.21",
     "stripe": "^8.114.0",
-    "uuid": "^11.0.5"
+    "uuid": "11"
   },
   "devDependencies": {
     "@goldstack/goldstack-email-send": "0.1.0",

--- a/workspaces/templates-lib/packages/template-email-send/package.json
+++ b/workspaces/templates-lib/packages/template-email-send/package.json
@@ -52,7 +52,7 @@
     "@goldstack/utils-terraform": "0.4.89",
     "@goldstack/utils-terraform-aws": "0.4.94",
     "aws-sdk-client-mock": "^4.1.0",
-    "uuid": "^11.0.5"
+    "uuid": "11"
   },
   "devDependencies": {
     "@goldstack/utils-package-config-generate": "0.3.29",

--- a/workspaces/templates-lib/packages/template-hetzner-vps/package.json
+++ b/workspaces/templates-lib/packages/template-hetzner-vps/package.json
@@ -51,7 +51,7 @@
     "@goldstack/utils-package-config-embedded": "0.5.46",
     "@goldstack/utils-terraform": "0.4.89",
     "@goldstack/utils-terraform-aws": "0.4.94",
-    "uuid": "^11.0.5"
+    "uuid": "11"
   },
   "devDependencies": {
     "@goldstack/utils-package-config-generate": "0.3.29",

--- a/workspaces/templates-lib/packages/template-sqs/package.json
+++ b/workspaces/templates-lib/packages/template-sqs/package.json
@@ -53,7 +53,7 @@
     "@goldstack/utils-terraform": "0.4.89",
     "@goldstack/utils-terraform-aws": "0.4.94",
     "aws-sdk-client-mock": "^4.1.0",
-    "uuid": "^11.0.5"
+    "uuid": "11"
   },
   "devDependencies": {
     "@goldstack/utils-package-config-generate": "0.3.29",

--- a/workspaces/templates-management/packages/auth/package.json
+++ b/workspaces/templates-management/packages/auth/package.json
@@ -29,7 +29,7 @@
     "archiver": "^5.3.1",
     "fs-extra": "^11.2.0",
     "semver": "^7.6.3",
-    "uuid": "^11.0.5"
+    "uuid": "11"
   },
   "devDependencies": {
     "@swc/core": "^1.15.46",

--- a/workspaces/templates-management/packages/project-repository/package.json
+++ b/workspaces/templates-management/packages/project-repository/package.json
@@ -33,7 +33,7 @@
     "@goldstack/utils-template": "0.4.44",
     "fs-extra": "^11.2.0",
     "semver": "^7.6.3",
-    "uuid": "^11.0.5"
+    "uuid": "11"
   },
   "devDependencies": {
     "@goldstack/auth": "0.1.0",

--- a/workspaces/templates-management/packages/session-repository/package.json
+++ b/workspaces/templates-management/packages/session-repository/package.json
@@ -28,7 +28,7 @@
     "@goldstack/utils-sh": "0.5.41",
     "fs-extra": "^11.2.0",
     "stripe": "^8.114.0",
-    "uuid": "^11.0.5"
+    "uuid": "11"
   },
   "devDependencies": {
     "@goldstack/auth": "0.1.0",

--- a/workspaces/templates/packages/user-management/package.json
+++ b/workspaces/templates/packages/user-management/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@goldstack/template-user-management": "0.2.9",
     "source-map-support": "^0.5.21",
-    "uuid": "^11.0.5"
+    "uuid": "11"
   },
   "devDependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.1004.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3000,7 +3000,7 @@ __metadata:
     rimraf: "npm:^6.1.2"
     semver: "npm:^7.6.3"
     typescript: "npm:^5.9.3"
-    uuid: "npm:^11.0.5"
+    uuid: "npm:11"
   languageName: unknown
   linkType: soft
 
@@ -3234,7 +3234,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     ts-node-dev: "npm:^2.0.0"
     typescript: "npm:^5.9.3"
-    uuid: "npm:^11.0.5"
+    uuid: "npm:11"
   languageName: unknown
   linkType: soft
 
@@ -3752,7 +3752,7 @@ __metadata:
     rimraf: "npm:^6.1.2"
     semver: "npm:^7.6.3"
     typescript: "npm:^5.9.3"
-    uuid: "npm:^11.0.5"
+    uuid: "npm:11"
   languageName: unknown
   linkType: soft
 
@@ -3914,7 +3914,7 @@ __metadata:
     rimraf: "npm:^6.1.2"
     stripe: "npm:^8.114.0"
     typescript: "npm:^5.9.3"
-    uuid: "npm:^11.0.5"
+    uuid: "npm:11"
   languageName: unknown
   linkType: soft
 
@@ -4257,7 +4257,7 @@ __metadata:
     rimraf: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
-    uuid: "npm:^11.0.5"
+    uuid: "npm:11"
   languageName: unknown
   linkType: soft
 
@@ -4322,7 +4322,7 @@ __metadata:
     rimraf: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
-    uuid: "npm:^11.0.5"
+    uuid: "npm:11"
   languageName: unknown
   linkType: soft
 
@@ -4736,7 +4736,7 @@ __metadata:
     rimraf: "npm:^6.1.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
-    uuid: "npm:^11.0.5"
+    uuid: "npm:11"
   languageName: unknown
   linkType: soft
 
@@ -5036,7 +5036,7 @@ __metadata:
     source-map-support: "npm:^0.5.21"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
-    uuid: "npm:^11.0.5"
+    uuid: "npm:11"
   languageName: unknown
   linkType: soft
 
@@ -6470,65 +6470,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:15.5.18":
-  version: 15.5.18
-  resolution: "@next/env@npm:15.5.18"
-  checksum: 10/476db1457819d99be69375862bc62b1fcea3470ef6b77f1b80b198bc751d6f8ee135e48ac5c70cb6ea6d6ad93aff38bf8595039986bc3332ce6234d724b5dd50
+"@next/env@npm:15.5.22":
+  version: 15.5.22
+  resolution: "@next/env@npm:15.5.22"
+  checksum: 10/0289b68fe3aeb5783d239637ff50dd483d1609e45b9e98b31ac0d5578fc3228f696fbda1a860b4b0a7ae414c30156ce1d3d889d3a173a5dbd96b362a1a1436f9
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:15.5.18":
-  version: 15.5.18
-  resolution: "@next/swc-darwin-arm64@npm:15.5.18"
+"@next/swc-darwin-arm64@npm:15.5.22":
+  version: 15.5.22
+  resolution: "@next/swc-darwin-arm64@npm:15.5.22"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:15.5.18":
-  version: 15.5.18
-  resolution: "@next/swc-darwin-x64@npm:15.5.18"
+"@next/swc-darwin-x64@npm:15.5.22":
+  version: 15.5.22
+  resolution: "@next/swc-darwin-x64@npm:15.5.22"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:15.5.18":
-  version: 15.5.18
-  resolution: "@next/swc-linux-arm64-gnu@npm:15.5.18"
+"@next/swc-linux-arm64-gnu@npm:15.5.22":
+  version: 15.5.22
+  resolution: "@next/swc-linux-arm64-gnu@npm:15.5.22"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:15.5.18":
-  version: 15.5.18
-  resolution: "@next/swc-linux-arm64-musl@npm:15.5.18"
+"@next/swc-linux-arm64-musl@npm:15.5.22":
+  version: 15.5.22
+  resolution: "@next/swc-linux-arm64-musl@npm:15.5.22"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:15.5.18":
-  version: 15.5.18
-  resolution: "@next/swc-linux-x64-gnu@npm:15.5.18"
+"@next/swc-linux-x64-gnu@npm:15.5.22":
+  version: 15.5.22
+  resolution: "@next/swc-linux-x64-gnu@npm:15.5.22"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:15.5.18":
-  version: 15.5.18
-  resolution: "@next/swc-linux-x64-musl@npm:15.5.18"
+"@next/swc-linux-x64-musl@npm:15.5.22":
+  version: 15.5.22
+  resolution: "@next/swc-linux-x64-musl@npm:15.5.22"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:15.5.18":
-  version: 15.5.18
-  resolution: "@next/swc-win32-arm64-msvc@npm:15.5.18"
+"@next/swc-win32-arm64-msvc@npm:15.5.22":
+  version: 15.5.22
+  resolution: "@next/swc-win32-arm64-msvc@npm:15.5.22"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:15.5.18":
-  version: 15.5.18
-  resolution: "@next/swc-win32-x64-msvc@npm:15.5.18"
+"@next/swc-win32-x64-msvc@npm:15.5.22":
+  version: 15.5.22
+  resolution: "@next/swc-win32-x64-msvc@npm:15.5.22"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -10207,13 +10207,14 @@ __metadata:
   linkType: hard
 
 "axios@npm:^1.15.0":
-  version: 1.16.0
-  resolution: "axios@npm:1.16.0"
+  version: 1.18.1
+  resolution: "axios@npm:1.18.1"
   dependencies:
     follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
+    https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/cf8b521ff732c21550b38c8739aef556ea5e14b268468bb89e4307416ab262b462e582474e810963a3d61c2392ab47ad35c11d05eff027de7c97113bc7411623
+  checksum: 10/c4cdced3ee0a9bf7dcae189fbc74a124aa079d4f04dbd995e602d39c1419476e8d021f87ee39ac8d8398e5a55e6d0b986238b3645f0d9177ac80de87c2a73f18
   languageName: node
   linkType: hard
 
@@ -11411,12 +11412,12 @@ __metadata:
   linkType: hard
 
 "cookie-parser@npm:^1.4.5":
-  version: 1.4.5
-  resolution: "cookie-parser@npm:1.4.5"
+  version: 1.4.7
+  resolution: "cookie-parser@npm:1.4.7"
   dependencies:
-    cookie: "npm:0.4.0"
+    cookie: "npm:0.7.2"
     cookie-signature: "npm:1.0.6"
-  checksum: 10/09b41e191af8e472229b53468b858a53f64a355b438ecb56a38be2a729b862b8233041e5af102115caebae534d399813ec7270b68a949bba3b987b38555c30b6
+  checksum: 10/243fa13f217e793d20a57675e6552beea08c5989fcc68495d543997a31646875335e0e82d687b42dcfd466df57891d22bae7f5ba6ab33b7705ed2dd6eb989105
   languageName: node
   linkType: hard
 
@@ -11444,13 +11445,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.4.0":
-  version: 0.4.0
-  resolution: "cookie@npm:0.4.0"
-  checksum: 10/494314fb0edfc3262e7809ba184829f3dea798800bf81c3e6ca5185083f75ba10fe37ee32a2aa5a4cd79ea1abcc1452ec47d331a4e6beaceaa30b8e6b3ec7636
-  languageName: node
-  linkType: hard
-
 "cookie@npm:0.4.1":
   version: 0.4.1
   resolution: "cookie@npm:0.4.1"
@@ -11462,6 +11456,13 @@ __metadata:
   version: 0.6.0
   resolution: "cookie@npm:0.6.0"
   checksum: 10/c1f8f2ea7d443b9331680598b0ae4e6af18a618c37606d1bbdc75bec8361cce09fe93e727059a673f2ba24467131a9fb5a4eec76bb1b149c1b3e1ccb268dc583
+  languageName: node
+  linkType: hard
+
+"cookie@npm:0.7.2":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 10/24b286c556420d4ba4e9bc09120c9d3db7d28ace2bd0f8ccee82422ce42322f73c8312441271e5eefafbead725980e5996cc02766dbb89a90ac7f5636ede608f
   languageName: node
   linkType: hard
 
@@ -17486,18 +17487,18 @@ __metadata:
   linkType: hard
 
 "next@npm:^15":
-  version: 15.5.18
-  resolution: "next@npm:15.5.18"
+  version: 15.5.22
+  resolution: "next@npm:15.5.22"
   dependencies:
-    "@next/env": "npm:15.5.18"
-    "@next/swc-darwin-arm64": "npm:15.5.18"
-    "@next/swc-darwin-x64": "npm:15.5.18"
-    "@next/swc-linux-arm64-gnu": "npm:15.5.18"
-    "@next/swc-linux-arm64-musl": "npm:15.5.18"
-    "@next/swc-linux-x64-gnu": "npm:15.5.18"
-    "@next/swc-linux-x64-musl": "npm:15.5.18"
-    "@next/swc-win32-arm64-msvc": "npm:15.5.18"
-    "@next/swc-win32-x64-msvc": "npm:15.5.18"
+    "@next/env": "npm:15.5.22"
+    "@next/swc-darwin-arm64": "npm:15.5.22"
+    "@next/swc-darwin-x64": "npm:15.5.22"
+    "@next/swc-linux-arm64-gnu": "npm:15.5.22"
+    "@next/swc-linux-arm64-musl": "npm:15.5.22"
+    "@next/swc-linux-x64-gnu": "npm:15.5.22"
+    "@next/swc-linux-x64-musl": "npm:15.5.22"
+    "@next/swc-win32-arm64-msvc": "npm:15.5.22"
+    "@next/swc-win32-x64-msvc": "npm:15.5.22"
     "@swc/helpers": "npm:0.5.15"
     caniuse-lite: "npm:^1.0.30001579"
     postcss: "npm:8.4.31"
@@ -17540,7 +17541,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10/3e4c11beb34b9c827a49db477429c3e6fc9c38e1e37734014082dd748d401772742705ef0d9752c0a5d1714a577b7937612869a8041069081c9930231017db93
+  checksum: 10/92acab567b9b1436ec024d8d5227949bab5aa747320a7dee1b618a24ae163f2c1fb23bf9b4de7acfba91b7ad8288db23f295d1a0d8449bbf6c7de3f6f13dd146
   languageName: node
   linkType: hard
 
@@ -22475,21 +22476,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"uuid@npm:11":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 10/16411d3dc12a08d6691616c09a75e66a7f900ba1beef6628a76fe0602f82fae2ee537b564d0b7bc95c24f58d059ca9b58c75a1e806118efb50e17822ff00ddd2
+  languageName: node
+  linkType: hard
+
 "uuid@npm:8.0.0":
   version: 8.0.0
   resolution: "uuid@npm:8.0.0"
   bin:
     uuid: dist/bin/uuid
   checksum: 10/5086c43bbe11e2337d9bb9a3b3a156311e5f5ba5da2de8152da9e00cfd5fbbf626d36e6a2838dde06e2105ac563bc298470acc0e4800c96fa2d50565c5782f8a
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^11.0.5":
-  version: 11.0.5
-  resolution: "uuid@npm:11.0.5"
-  bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10/0594ecdff3051e15d4a2c614b4c72e73af373bde0a5d156512353c01156975295d024ae8d7151846d7bd4d22ccd251b16ed51b4318fa71505fb20ad984102dc1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Automated maintenance task: Resolve Easy Non-Critical Security Vulnerabilities

## Changes
- **next**: 15.5.18 → 15.5.22 (resolves 8 high/moderate vulns: GHSA-m99w-x7hq-7vfj, GHSA-89xv-2m56-2m9x, GHSA-68g3-v927-f742, GHSA-4633-3j49-mh5q, GHSA-4c39-4ccg-62r3, GHSA-p9j2-gv94-2wf4, GHSA-q8wf-6r8g-63ch, GHSA-955p-x3mx-jcvp)
- **axios**: 1.16.0 → 1.18.1 (resolves 2 moderate vulns: GHSA-7q8q-rj6j-mhjq, GHSA-mwf2-3pr3-8698)
- **uuid**: 11.0.5 → 11.1.1 (resolves moderate vuln: GHSA-w5hq-g745-h8pq)
- **cookie-parser**: 1.4.5 → 1.4.7 (updates transitive cookie dep)

## Skipped
- **postcss**: Would cause type conflicts with tailwindcss (requires major deduplication effort)
- Remaining transitive vulns (body-parser, brace-expansion, etc.) require updates to upstream deps and are not easy fixes