### PR TITLE
Simplify maintenance task instructions

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -79,7 +79,7 @@ jobs:
             You are performing the maintenance task in ${{ matrix.context }}: ${{ matrix.name }}
 
             1. Read instructions/${{ matrix.context }}/maintenance/${{ matrix.name }}.md for specific task instructions.
-            2. Follow instructions/patching.md for how to update dependencies and validate.
-            3. Follow instructions/maintenance.md for workflow (commits, PR management, time limits).
+            2. Follow instructions/patching.md to update dependencies and validate.
+            3. Follow instructions/maintenance.md for committing, pushing, PR management, CI monitoring, and time limits.
 
             Branch name: maintenance/${{ matrix.context }}/${{ matrix.name }}

--- a/instructions/goldstack/maintenance/aws_sdk_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/aws_sdk_should_be_latest_version.md
@@ -10,5 +10,4 @@
    yarn up @aws-sdk/* @smithy/*
    ```
 
-Follow the [patching workflow](../patching.md) to validate and commit.
-Follow the [maintenance workflow](../maintenance.md) for PR management and time limits.
+

--- a/instructions/goldstack/maintenance/easy_non_critical_security_vulnerabilities.md
+++ b/instructions/goldstack/maintenance/easy_non_critical_security_vulnerabilities.md
@@ -12,5 +12,4 @@
 
 3. Re-run the audit to confirm resolved vulnerabilities are gone.
 
-Follow the [patching workflow](../patching.md) to validate.
-Follow the [maintenance workflow](../maintenance.md) for commit, push, PR management, CI monitoring, and time limits.
+

--- a/instructions/goldstack/maintenance/goldstack_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/goldstack_should_be_latest_version.md
@@ -32,5 +32,4 @@ Use `yarn why` to discover which of these are present in the project, then `yarn
    done
    ```
 
-Follow the [patching workflow](../patching.md) to validate.
-Follow the [maintenance workflow](../maintenance.md) for commit, push, PR management, CI monitoring, and time limits.
+

--- a/instructions/goldstack/maintenance/jest_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/jest_should_be_latest_version.md
@@ -5,5 +5,4 @@
    yarn up jest @types/jest
    ```
 
-Follow the [patching workflow](../patching.md) to validate.
-Follow the [maintenance workflow](../maintenance.md) for commit, push, PR management, CI monitoring, and time limits.
+

--- a/instructions/goldstack/maintenance/no_critical_security_vulnerabilities.md
+++ b/instructions/goldstack/maintenance/no_critical_security_vulnerabilities.md
@@ -14,5 +14,4 @@
 
 3. Re-run the audit to confirm vulnerabilities are resolved.
 
-Follow the [patching workflow](../patching.md) to validate and commit.
-Follow the [maintenance workflow](../maintenance.md) for PR management and time limits.
+

--- a/instructions/goldstack/maintenance/swc_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/swc_should_be_latest_version.md
@@ -5,5 +5,4 @@
    yarn up @swc/core @swc/jest
    ```
 
-Follow the [patching workflow](../patching.md) to validate.
-Follow the [maintenance workflow](../maintenance.md) for commit, push, PR management, CI monitoring, and time limits.
+

--- a/instructions/goldstack/maintenance/typescript_and_ts_node_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/typescript_and_ts_node_should_be_latest_version.md
@@ -5,5 +5,4 @@
    yarn up typescript ts-node
    ```
 
-Follow the [patching workflow](../patching.md) to validate.
-Follow the [maintenance workflow](../maintenance.md) for commit, push, PR management, CI monitoring, and time limits.
+

--- a/instructions/goldstack/maintenance/yarn_binary_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/yarn_binary_should_be_latest_version.md
@@ -17,5 +17,4 @@
      yarn plugin import <plugin-name>
      ```
 
-Follow the [patching workflow](../patching.md) to validate.
-Follow the [maintenance workflow](../maintenance.md) for commit, push, PR management, CI monitoring, and time limits.
+


### PR DESCRIPTION
Removes duplicated references to `instructions/patching.md` and `instructions/maintenance.md` from each task file in `instructions/goldstack/maintenance/`, and consolidates them in the workflow prompt in `.github/workflows/maintenance.yml`.

### Changes
- Strengthen the maintenance workflow prompt so the items previously spread across the task files (commit, push, PR management, CI monitoring, time limits) are stated explicitly:
  - `2. Follow instructions/patching.md to update dependencies and validate.`
  - `3. Follow instructions/maintenance.md for committing, pushing, PR management, CI monitoring, and time limits.`
- Remove the trailing `Follow the [patching workflow]…` / `Follow the [maintenance workflow]…` lines from all 8 task files:
  - aws_sdk_should_be_latest_version.md
  - easy_non_critical_security_vulnerabilities.md
  - goldstack_should_be_latest_version.md
  - jest_should_be_latest_version.md
  - no_critical_security_vulnerabilities.md
  - swc_should_be_latest_version.md
  - typescript_and_ts_node_should_be_latest_version.md
  - yarn_binary_should_be_latest_version.md

### Verification
- `yarn format-check`: clean (765 files)
- `yarn lint`: clean (1492 files)

9 files changed, 10 insertions(+), 18 deletions(-)