### PR TITLE
Add --webpack flag to next:watch scripts for Next.js 16 compatibility

### DIFF
--- a/workspaces/apps/packages/goldstack-home/package.json
+++ b/workspaces/apps/packages/goldstack-home/package.json
@@ -21,7 +21,7 @@
     "generate-schema": "ts-node --project tsconfig.local.json src/lib/types/generateSchemas.ts",
     "infra": "yarn template-ts infra",
     "next:tracking:disable": "next telemetry disable",
-    "next:watch": "next",
+    "next:watch": "next --webpack",
     "prepublishOnly": "yarn run build",
     "start:next": "next start",
     "template": "yarn template-ts",

--- a/workspaces/docs/packages/docs-main/package.json
+++ b/workspaces/docs/packages/docs-main/package.json
@@ -18,7 +18,7 @@
     "generate-docs": "ts-node --project tsconfig.local.json ./scripts/generateDocs.ts",
     "infra": "yarn template infra",
     "next:tracking:disable": "next telemetry disable",
-    "next:watch": "next -p 3001",
+    "next:watch": "next -p 3001 --webpack",
     "prepublishOnly": "yarn run build",
     "start:next": "next start",
     "template": "yarn template-ts",

--- a/workspaces/templates/packages/app-nextjs-bootstrap/package.json
+++ b/workspaces/templates/packages/app-nextjs-bootstrap/package.json
@@ -17,7 +17,7 @@
     "deploy-ts": "yarn template-ts set-nextjs-env \"$@\" && yarn build && yarn web:build && yarn template-ts deploy --cf-function \"$@\"",
     "infra": "yarn template infra",
     "next:tracking:disable": "next telemetry disable",
-    "next:watch": "NEXT_TELEMETRY_DISABLED=1 next",
+    "next:watch": "NEXT_TELEMETRY_DISABLED=1 next --webpack",
     "prepublishOnly": "yarn run build",
     "start:next": "NEXT_TELEMETRY_DISABLED=1 next start",
     "template": "yarn template-ts",

--- a/workspaces/templates/packages/app-nextjs-tailwind/package.json
+++ b/workspaces/templates/packages/app-nextjs-tailwind/package.json
@@ -18,7 +18,7 @@
     "deploy-ts": "yarn template-ts set-nextjs-env \"$@\" && yarn build && yarn web:build && yarn template-ts deploy --cf-function \"$@\"",
     "infra": "yarn template infra",
     "next:tracking:disable": "next telemetry disable",
-    "next:watch": "NEXT_TELEMETRY_DISABLED=1 next",
+    "next:watch": "NEXT_TELEMETRY_DISABLED=1 next --webpack",
     "prepublishOnly": "yarn run build",
     "start:next": "NEXT_TELEMETRY_DISABLED=1 next start",
     "template": "yarn template-ts",

--- a/workspaces/templates/packages/app-nextjs/package.json
+++ b/workspaces/templates/packages/app-nextjs/package.json
@@ -16,7 +16,7 @@
     "deploy-ts": "yarn template-ts set-nextjs-env \"$@\" && yarn build && yarn web:build && yarn template-ts deploy --cf-function \"$@\"",
     "infra": "yarn template infra",
     "next:tracking:disable": "next telemetry disable",
-    "next:watch": "NEXT_TELEMETRY_DISABLED=1 next",
+    "next:watch": "NEXT_TELEMETRY_DISABLED=1 next --webpack",
     "prepublishOnly": "yarn run build",
     "start:next": "NEXT_TELEMETRY_DISABLED=1 next start",
     "template": "yarn template-ts",


### PR DESCRIPTION
Next.js 16 uses turbopack by default for dev mode. All 5 Next.js packages already had `--webpack` on `build:next` scripts; this PR adds it to `next:watch` scripts so dev mode also explicitly opts into webpack, maintaining compatibility with custom webpack configs in `next.config.js`.

### Changes
- `workspaces/apps/packages/goldstack-home/package.json` — `next:watch`: `next` → `next --webpack`
- `workspaces/docs/packages/docs-main/package.json` — `next:watch`: `next -p 3001` → `next -p 3001 --webpack`
- `workspaces/templates/packages/app-nextjs-bootstrap/package.json` — `next:watch`: `next` → `next --webpack`
- `workspaces/templates/packages/app-nextjs-tailwind/package.json` — `next:watch`: `next` → `next --webpack`
- `workspaces/templates/packages/app-nextjs/package.json` — `next:watch`: `next` → `next --webpack`