### PR TITLE
[Maintenance] Add version gating for maintenance tasks

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -110,7 +110,8 @@ jobs:
             You are performing the maintenance task in ${{ matrix.context }}: ${{ matrix.name }}
 
             1. Read instructions/${{ matrix.context }}/maintenance/${{ matrix.name }}.md for specific task instructions.
-            2. Follow instructions/goldstack/patching.md to update dependencies and validate.
-            3. Follow instructions/goldstack/maintenance.md for committing, pushing, PR management, CI monitoring, and time limits.
+            2. For version-bump tasks, check instructions/goldstack/version-gating.md to determine if the update is due (skip if version was bumped < 60 days ago).
+            3. Follow instructions/goldstack/patching.md to update dependencies and validate.
+            4. Follow instructions/goldstack/maintenance.md for committing, pushing, PR management, CI monitoring, and time limits.
 
             Branch name: maintenance/${{ matrix.context }}/${{ matrix.name }}

--- a/instructions/custom/maintenance/next_js_should_be_latest_version.md
+++ b/instructions/custom/maintenance/next_js_should_be_latest_version.md
@@ -1,5 +1,7 @@
 # Next.js Should Be Latest Version
 
+Before proceeding, check the version gating (see `instructions/goldstack/version-gating.md`). If the installed Next.js version was last bumped less than 60 days ago, treat this task as a no-op and do not produce any changes.
+
 The `.syncpackrc.js` configuration in this monorepo has an empty `versionGroups` array, which means packages are not required to use the same version of a dependency. In principle, each package using `next` could be upgraded independently. However, this workspace currently uses only one Next.js version across all packages, which is the typical pattern for Goldstack template users — and the assumption of this task is that the same holds at the time it is run.
 
 1. Identify all packages that depend on `next` and confirm they all use the same version range:

--- a/instructions/goldstack/maintenance/aws_sdk_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/aws_sdk_should_be_latest_version.md
@@ -1,5 +1,7 @@
 # AWS SDK Should Be Latest Version
 
+Before proceeding, check the version gating (see `instructions/goldstack/version-gating.md`). If the installed AWS SDK version was last bumped less than 60 days ago, treat this task as a no-op and do not produce any changes.
+
 1. Identify current versions:
    ```
    grep -r "@aws-sdk\|@smithy" workspaces --include="package.json"

--- a/instructions/goldstack/maintenance/goldstack_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/goldstack_should_be_latest_version.md
@@ -1,5 +1,7 @@
 # Goldstack Should Be Latest Version
 
+Before proceeding, check the version gating (see `instructions/goldstack/version-gating.md`). If the installed Goldstack packages were last bumped less than 60 days ago, treat this task as a no-op and do not produce any changes.
+
 1. Check workflow applicability
 
 DO NOT RUN this task when you are on the github.com/goldstack/goldstack repo.

--- a/instructions/goldstack/maintenance/jest_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/jest_should_be_latest_version.md
@@ -1,5 +1,7 @@
 # Jest Should Be Latest Version
 
+Before proceeding, check the version gating (see `instructions/goldstack/version-gating.md`). If the installed Jest version was last bumped less than 60 days ago, treat this task as a no-op and do not produce any changes.
+
 1. Update Jest and @types/jest:
    ```
    yarn up jest @types/jest

--- a/instructions/goldstack/maintenance/next_js_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/next_js_should_be_latest_version.md
@@ -1,5 +1,7 @@
 # Next.js Should Be Latest Version
 
+Before proceeding, check the version gating (see `instructions/goldstack/version-gating.md`). If the installed Next.js version was last bumped less than 60 days ago, treat this task as a no-op and do not produce any changes.
+
 1. Update Next.js in all packages:
    ```
    yarn up next

--- a/instructions/goldstack/maintenance/swc_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/swc_should_be_latest_version.md
@@ -1,5 +1,7 @@
 # @swc/* Packages Should Be Latest Version
 
+Before proceeding, check the version gating (see `instructions/goldstack/version-gating.md`). If the installed SWC version was last bumped less than 60 days ago, treat this task as a no-op and do not produce any changes.
+
 1. Update SWC packages:
    ```
    yarn up @swc/core @swc/jest

--- a/instructions/goldstack/maintenance/typescript_and_ts_node_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/typescript_and_ts_node_should_be_latest_version.md
@@ -1,10 +1,12 @@
 # TypeScript and ts-node Should Be Latest Version
 
+Before proceeding, check the version gating (see `instructions/goldstack/version-gating.md`). If the installed TypeScript version was last bumped less than 60 days ago, treat this task as a no-op and do not produce any changes.
+
 1. Update TypeScript and ts-node to the latest **minor/patch** version within the current major:
    ```
-   yarn up typescript@~ ts-node
+   yarn up typescript ts-node
    ```
-   The `~` (tilde) range limits the upgrade to the same major and minor, so a `5.9.x` install will update to the latest `5.9.x` but will not jump to TypeScript 7. A major-version migration is a separate, manual task.
+   A major-version migration (e.g. TypeScript 7) is a separate, manual task.
 
 2. Run the standard checks (see `instructions/goldstack/patching.md`):
    ```
@@ -15,4 +17,3 @@
    - Do **not** modify `tsconfig*.json` files — tsconfig changes are out of scope for this task.
    - Do **not** commit generated files (`*.d.ts`, `*.js`, `*.js.map`, `*.tsbuildinfo`, `dist/`, `build/`).
    - Revert the upgrade, leave a comment on the PR explaining that the latest patch/minor in the current major breaks the codebase, and close the task. A major-version migration can be handled as a dedicated task.
-

--- a/instructions/goldstack/maintenance/yarn_binary_should_be_latest_version.md
+++ b/instructions/goldstack/maintenance/yarn_binary_should_be_latest_version.md
@@ -1,5 +1,7 @@
 # Yarn Binary, SDKs, and Plugins Should Be Latest Version
 
+Before proceeding, check the version gating (see `instructions/goldstack/version-gating.md`). If the Yarn version was last bumped less than 60 days ago, treat this task as a no-op and do not produce any changes.
+
 1. Update Yarn binary to latest:
    ```
    yarn set version latest

--- a/instructions/goldstack/patching.md
+++ b/instructions/goldstack/patching.md
@@ -2,6 +2,10 @@
 
 This workflow applies every time a dependency is changed in the project.
 
+## Semver Ranges
+
+Always use `^` (caret) semver ranges in `package.json`. Never use `~` (tilde). The caret range allows minor and patch updates to flow naturally between version-bump maintenance runs, without locking to an overly narrow range.
+
 ## Steps
 
 ### 1. Run the Audit

--- a/instructions/goldstack/version-gating.md
+++ b/instructions/goldstack/version-gating.md
@@ -1,0 +1,23 @@
+# Version Gating
+
+Some maintenance tasks bump dependencies to their latest versions (TypeScript, Jest, Yarn, Next.js, SWC, AWS SDK, Goldstack). These updates should only run when the currently installed version is **older than 60 days**.
+
+Security vulnerability tasks are exempt from gating and always run.
+
+## Version Ranges
+
+Always use `^` (caret) semver ranges in `package.json`. Never use `~` (tilde). The caret allows minor and patch updates to flow naturally when the 60-day gating permits an update, without locking to an overly narrow range that would block minor version improvements.
+
+## How to Check
+
+Before performing any version bump, determine whether the update is due:
+
+1. Identify the primary package being updated (e.g. `typescript`, `jest`, `@swc/core`, `next`).
+2. Check how long ago the current version entry was last committed:
+   ```bash
+   LAST_UPDATE=$(git log --format="%ct" -1 -S '"<package-name>"' -- "**/package.json" || echo 0)
+   DAYS_AGO=$(( ($(date +%s) - LAST_UPDATE) / 86400 ))
+   echo "$DAYS_AGO days since last version bump"
+   ```
+3. If `DAYS_AGO < 60` → treat this task as a **no-op** (do not commit, do not open a PR).
+4. If `DAYS_AGO >= 60` or the command returns `0` (no matching commit found) → proceed with the update.


### PR DESCRIPTION
Adds version gating to the maintenance workflow:

- **New file **: Defines the 60-day rule — version-bump tasks only run when the current version was last updated > 60 days ago
- **Updated **: Clarifies that caret (`^`) ranges are always preferred, never tilde (`~`)
- **Updated all version-bump task files** (typescript, jest, yarn, next.js, swc, aws-sdk, goldstack): Each now checks version gating as a first step
- **Updated  prompt**: Added step 2 for version gating before dependency updates
- **Security tasks** (critical vulnerabilities, non-critical vulnerabilities) are **not** gated — they always run

Fixes the tilde issue from PR #639 — we keep `^` ranges but update less frequently (60-day minimum).